### PR TITLE
Fix a few instances of spaces in class names starting with the NS prefix

### DIFF
--- a/2013/203.srt
+++ b/2013/203.srt
@@ -3269,7 +3269,7 @@ crisp beautiful text.
 In IOS 6, we introduced all
 
 00:35:34.626 --> 00:35:38.286 A:middle
-of the NS attributed string
+of the NSAttributedString
 components that enable you
 
 00:35:38.286 --> 00:35:40.796 A:middle
@@ -3488,7 +3488,7 @@ One of the things
 that we've noticed is
 
 00:38:12.246 --> 00:38:17.666 A:middle
-that the NS attributed string
+that the NSAttributedString
 system is very powerful.
 
 00:38:17.806 --> 00:38:19.176 A:middle

--- a/2013/205.srt
+++ b/2013/205.srt
@@ -185,7 +185,7 @@ key, NSURL tag names key
 
 00:02:25.586 --> 00:02:28.996 A:middle
 and the value of this is
-an NS array of NS strings.
+an NSArray of NS strings.
 
 00:02:29.636 --> 00:02:32.806 A:middle
 You would use this API on
@@ -369,7 +369,7 @@ light content controls?
 
 00:04:31.036 --> 00:04:34.646 A:middle
 Well, they're available through
-a new API called NS Appearance.
+a new API called NSAppearance.
 
 00:04:35.546 --> 00:04:39.116 A:middle
 This is a class that lets you
@@ -501,17 +501,17 @@ using this appearance.
 
 00:05:55.926 --> 00:05:57.826 A:middle
 Next thing I want to talk
-about is NS StackView.
+about is NSStackView.
 
 00:05:58.376 --> 00:06:00.226 A:middle
-NS StackView is a
+NSStackView is a
 new class we've added
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:05:58.376 --> 00:06:00.226 A:middle
-NS StackView is a
+NSStackView is a
 new class we've added
 
 00:06:00.226 --> 00:06:02.136 A:middle
@@ -550,7 +550,7 @@ little example.
 
 00:06:23.476 --> 00:06:27.316 A:middle
 This is the kind of view you
-might build with NS StackView.
+might build with NSStackView.
 
 00:06:27.676 --> 00:06:30.406 A:middle
 Here you have a group of
@@ -656,7 +656,7 @@ of thing that's fairly simple
 to build with a StackView.
 
 00:07:36.186 --> 00:07:38.766 A:middle
-The API of NS StackView
+The API of NSStackView
 is purely straightforward,
 
 00:07:39.076 --> 00:07:42.586 A:middle
@@ -699,7 +699,7 @@ are and so on.
 
 00:08:04.066 --> 00:08:07.566 A:middle
 There will be a more in-depth
-coverage of NS StackView
+coverage of NSStackView
 
 00:08:07.566 --> 00:08:09.856 A:middle
 in this talk which is tomorrow,
@@ -1384,7 +1384,7 @@ ways to customize this.
 
 00:15:30.836 --> 00:15:33.766 A:middle
 One new class, one other
-new class is NS PDF panel,
+new class is NSPDFPanel,
 
 00:15:34.036 --> 00:15:36.786 A:middle
 this gives you more panel over
@@ -1415,7 +1415,7 @@ to save the PDF files too.
 
 00:15:51.796 --> 00:15:55.076 A:middle
 And then there's this other
-class NS PDF info that sets
+class NSPDFInfo that sets
 
 00:15:55.076 --> 00:15:57.316 A:middle
 and gets that basically
@@ -1683,7 +1683,7 @@ in your application, here's
 the code you would write.
 
 00:18:50.696 --> 00:18:53.936 A:middle
-You tell NS app to begin
+You tell NSApp to begin
 a sheet you provide
 
 00:18:53.966 --> 00:18:56.346 A:middle
@@ -3225,7 +3225,7 @@ of that download is finished.
 
 00:35:14.566 --> 00:35:17.146 A:middle
 And in fact that those
-facilities do use NS Progress
+facilities do use NSProgress
 
 00:35:17.586 --> 00:35:18.236 A:middle
 in the system.
@@ -3235,7 +3235,7 @@ So let me give you
 a quick example
 
 00:35:19.796 --> 00:35:21.286 A:middle
-of how you use NS Progress.
+of how you use NSProgress.
 
 00:35:21.556 --> 00:35:24.096 A:middle
 Here's a simple method
@@ -3262,7 +3262,7 @@ two lines of code.
 
 00:35:35.316 --> 00:35:37.616 A:middle
 One of them goes and
-creates an NS Progress object
+creates an NSProgress object
 
 00:35:38.026 --> 00:35:41.636 A:middle
 and you specify a total unit
@@ -4854,7 +4854,7 @@ Textkit by saying when you look
 
 00:52:17.786 --> 00:52:21.136 A:middle
 at Cocoa Text on OS X,
-you see NS Text View.
+you see NSTextView.
 
 00:52:21.886 --> 00:52:24.066 A:middle
 However, if you make

--- a/2013/209.srt
+++ b/2013/209.srt
@@ -1678,7 +1678,7 @@ And here what we do is you
 grab the current mouse location
 
 00:18:05.106 --> 00:18:07.966 A:middle
-from NS Event and
+from NSEvent and
 we set up that --
 
 00:18:07.966 --> 00:18:11.256 A:middle
@@ -2465,12 +2465,12 @@ Here's what the API looks like.
 We have two forms.
 
 00:26:39.886 --> 00:26:43.326 A:middle
-On NS Application Delegate
+On NSApplicationDelegate
 there's application did change
 
 00:26:43.326 --> 00:26:46.556 A:middle
 occlusion state and there's also
-an NS notification if you prefer
+an NSNotification if you prefer
 
 00:26:46.556 --> 00:26:47.466 A:middle
 to listen to it that way.
@@ -2523,7 +2523,7 @@ The window API is almost
 exactly the same except it's
 
 00:27:17.586 --> 00:27:18.346 A:middle
-on NS Window.
+on NSWindow.
 
 00:27:18.466 --> 00:27:20.276 A:middle
 So Window Did Change
@@ -2694,7 +2694,7 @@ to save the most energy.
 Here's the API.
 
 00:29:03.766 --> 00:29:06.096 A:middle
-It's on NS Timer and
+It's on NSTimer and
 hopefully it should --
 
 00:29:06.176 --> 00:29:07.016 A:middle
@@ -3307,7 +3307,7 @@ bit different
 
 00:35:21.166 --> 00:35:24.806 A:middle
 than the existing count API on
-NS Process Info and Foundation.
+NSProcessInfo and Foundation.
 
 00:35:25.156 --> 00:35:26.836 A:middle
 So you can use either
@@ -3349,7 +3349,7 @@ how you might use this.
 
 00:35:49.066 --> 00:35:52.006 A:middle
 I'm going to have an
-NS Operation Queue
+NSOperationQueue
 
 00:35:52.006 --> 00:35:54.136 A:middle
 that has long running

--- a/2013/213.srt
+++ b/2013/213.srt
@@ -799,7 +799,7 @@ So our string for object
 value method looks like this,
 
 00:08:10.356 --> 00:08:13.556 A:middle
-we take in an NS number and we
+we take in an NSNumber and we
 just ask for its double value.
 
 00:08:13.556 --> 00:08:16.276 A:middle
@@ -2147,14 +2147,14 @@ property actually just happens
 
 00:23:23.266 --> 00:23:25.616 A:middle
 as a side effect of the
-regular NS view drawing cycle.
+regular NSView drawing cycle.
 
 00:23:25.616 --> 00:23:26.776 A:middle
 And when we change a property
 
 00:23:26.776 --> 00:23:29.156 A:middle
 that effects the visual
-appearance of NS view,
+appearance of NSView,
 
 00:23:29.386 --> 00:23:31.546 A:middle
 the view gets marked as

--- a/2013/219.srt
+++ b/2013/219.srt
@@ -2336,7 +2336,7 @@ be going over the first five
 
 00:27:43.746 --> 00:27:45.556 A:middle
 in this table, and Doug
-will cover NS string
+will cover NSString
 
 00:27:45.556 --> 00:27:46.786 A:middle
 in more detail in the next.
@@ -2376,14 +2376,14 @@ In a concrete sense, it
 is represented in Cocoa
 
 00:28:05.836 --> 00:28:09.106 A:middle
-with the NS locale API.
+with the NSLocale API.
 
 00:28:10.156 --> 00:28:12.156 A:middle
 Usually as a programmer,
 you will not be dealing
 
 00:28:12.156 --> 00:28:14.096 A:middle
-with the NS locale
+with the NSLocale
 object directly.
 
 00:28:14.186 --> 00:28:17.246 A:middle
@@ -2442,7 +2442,7 @@ at formatting dates.
 
 00:28:49.756 --> 00:28:52.746 A:middle
 So, for this, we've provided
-the NS date formatter.
+the NSDateFormatter.
 
 00:28:53.096 --> 00:28:56.906 A:middle
 This converts between NS
@@ -2472,7 +2472,7 @@ you can call localized
 string from date;
 
 00:29:10.456 --> 00:29:12.236 A:middle
-passing in your NS date, as well
+passing in your NSDate, as well
 
 00:29:12.236 --> 00:29:14.086 A:middle
 as a date style and
@@ -2490,7 +2490,7 @@ of information they're
 presenting to the user
 
 00:29:20.826 --> 00:29:22.136 A:middle
-about your NS date object.
+about your NSDate object.
 
 00:29:22.796 --> 00:29:25.006 A:middle
 Here, they can vary
@@ -2557,7 +2557,7 @@ Here we have the out of
 the box representation
 
 00:30:04.106 --> 00:30:06.166 A:middle
-of a single NS date object.
+of a single NSDate object.
 
 00:30:06.866 --> 00:30:09.526 A:middle
 Here we have June 6, 2013,
@@ -2616,7 +2616,7 @@ time object.
 
 00:30:46.326 --> 00:30:48.706 A:middle
 So, this is the preferred
-way to work with NS date.
+way to work with NSDate.
 
 00:30:49.016 --> 00:30:51.476 A:middle
 Out of the box, calling a
@@ -2634,13 +2634,13 @@ If on the other hand, you
 want to present a custom view
 
 00:30:59.276 --> 00:31:00.706 A:middle
-of this same NS date object,
+of this same NSDate object,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:30:59.276 --> 00:31:00.706 A:middle
-of this same NS date object,
+of this same NSDate object,
 
 00:31:00.706 --> 00:31:04.886 A:middle
 you have to go beyond the
@@ -2667,7 +2667,7 @@ don't meet your needs,
 
 00:31:17.966 --> 00:31:20.576 A:middle
 you create an instance of
-the NS day formatter class.
+the NSDateFormatter class.
 
 00:31:21.476 --> 00:31:24.166 A:middle
 From there, you create
@@ -2726,7 +2726,7 @@ Also critically, we
 pass here the locale,
 
 00:31:55.326 --> 00:31:56.666 A:middle
-NS locale, current locale.
+NSLocale, current locale.
 
 00:31:57.966 --> 00:32:01.596 A:middle
 So, this is the correct to do
@@ -2858,7 +2858,7 @@ of variation around the world.
 
 00:33:18.166 --> 00:33:21.146 A:middle
 To help you with this, we
-have NS number formatter,
+have NSNumberFormatter,
 
 00:33:21.426 --> 00:33:23.426 A:middle
 which is meant to mirror
@@ -2935,7 +2935,7 @@ C format strings.
 
 00:34:05.076 --> 00:34:07.946 A:middle
 Here we call string from
-format on NS String,
+format on NSString,
 
 00:34:08.386 --> 00:34:11.755 A:middle
 saying that we want a floating
@@ -2961,7 +2961,7 @@ is to instead called
 localized string
 
 00:34:25.186 --> 00:34:26.676 A:middle
-of format on your NS String.
+of format on your NSString.
 
 00:34:27.065 --> 00:34:28.826 A:middle
 This is only for a code
@@ -2976,14 +2976,14 @@ that will be used going forward,
 
 00:34:34.255 --> 00:34:36.226 A:middle
 we prefer using the
-NS number formatter.
+NSNumberFormatter.
 
 00:34:36.735 --> 00:34:38.476 A:middle
 Here you call localized
 string with number,
 
 00:34:38.636 --> 00:34:41.246 A:middle
-pass in your NS number,
+pass in your NSNumber,
 and pass in again,
 
 00:34:41.246 --> 00:34:43.036 A:middle
@@ -3001,21 +3001,21 @@ in a locale appropriate
 manner for a given user.
 
 00:34:52.016 --> 00:34:55.766 A:middle
-So, like NS day formatter, we
+So, like NSDateFormatter, we
 have explicit preset styles.
 
 00:34:56.136 --> 00:34:57.246 A:middle
 Here's what these look like.
 
 00:34:57.526 --> 00:35:00.186 A:middle
-Let's start with an NS number
+Let's start with an NSNumber
 literal, denoted by the at sign,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:34:57.526 --> 00:35:00.186 A:middle
-Let's start with an NS number
+Let's start with an NSNumber
 literal, denoted by the at sign,
 
 00:35:00.186 --> 00:35:03.846 A:middle
@@ -3070,7 +3070,7 @@ different between both locales.
 So, let's go into more detail
 
 00:35:37.226 --> 00:35:39.106 A:middle
-about the NS locale
+about the NSLocale
 object itself.
 
 00:35:40.036 --> 00:35:43.156 A:middle
@@ -3086,8 +3086,8 @@ To give it as an information,
 sorry, to give it as an argument
 
 00:35:49.526 --> 00:35:51.656 A:middle
-to an NS number formatter
-and NS date formatter,
+to an NSNumberFormatter
+and NSDateFormatter,
 
 00:35:51.966 --> 00:35:54.966 A:middle
 you can call current
@@ -3117,7 +3117,7 @@ want even more detail,
 
 00:36:06.836 --> 00:36:09.176 A:middle
 you can create an instance
-of the NS locale class.
+of the NSLocale class.
 
 00:36:09.596 --> 00:36:13.566 A:middle
 From there, you can call object
@@ -3136,7 +3136,7 @@ the metric system.
 
 00:36:19.576 --> 00:36:22.586 A:middle
 This information is stored in an
-instance of the NS locale class.
+instance of the NSLocale class.
 
 00:36:22.996 --> 00:36:25.656 A:middle
 You call object for key
@@ -3159,7 +3159,7 @@ for a given locale.
 
 00:36:33.936 --> 00:36:36.856 A:middle
 All this is available from an
-instance of NS locale class.
+instance of NSLocale class.
 
 00:36:38.006 --> 00:36:41.736 A:middle
 So, here, let's see what this
@@ -3222,7 +3222,7 @@ you call preferred
 localizations on an instance
 
 00:37:13.416 --> 00:37:14.616 A:middle
-of the NS bundle class.
+of the NSBundle class.
 
 00:37:15.036 --> 00:37:17.946 A:middle
 On the other hand, to get the
@@ -3298,7 +3298,7 @@ recently as 1989.
 
 00:38:03.886 --> 00:38:08.746 A:middle
 So, to interact with calendars,
-we use the NS calendar object.
+we use the NSCalendar object.
 
 00:38:09.096 --> 00:38:10.576 A:middle
 This allows us to
@@ -3324,7 +3324,7 @@ from the date, that
 then we can add
 
 00:38:20.766 --> 00:38:24.236 A:middle
-on to additional NS date objects
+on to additional NSDate objects
 to get dates in the future.
 
 00:38:25.516 --> 00:38:28.206 A:middle
@@ -3332,7 +3332,7 @@ Likewise, as I said, you
 can do delta computations
 
 00:38:28.206 --> 00:38:30.016 A:middle
-between two NS date objects.
+between two NSDate objects.
 
 00:38:31.036 --> 00:38:34.936 A:middle
 So, keep in mind though that NS
@@ -3346,7 +3346,7 @@ You must interpret this NS
 date object through the lens
 
 00:38:39.236 --> 00:38:41.796 A:middle
-of an NS calendar if you're
+of an NSCalendar if you're
 presenting it to the user.
 
 00:38:42.476 --> 00:38:43.766 A:middle
@@ -3355,7 +3355,7 @@ code internally,
 
 00:38:43.766 --> 00:38:45.946 A:middle
 of course it's still fine
-to use the NS date object.
+to use the NSDate object.
 
 00:38:46.016 --> 00:38:51.066 A:middle
 So, let's see an example of
@@ -3369,7 +3369,7 @@ We here, call components
 from date,
 
 00:38:55.476 --> 00:38:57.106 A:middle
-passing in our NS date object,
+passing in our NSDate object,
 
 00:38:57.526 --> 00:39:00.106 A:middle
 and passing in the individual
@@ -3391,7 +3391,7 @@ that you explicitly specify
 that are returned in the form
 
 00:39:06.496 --> 00:39:08.236 A:middle
-of an NS date components object.
+of an NSDateComponents object.
 
 00:39:09.326 --> 00:39:11.746 A:middle
 From there, you can
@@ -3409,11 +3409,11 @@ You can then this NS
 date components object
 
 00:39:17.616 --> 00:39:23.216 A:middle
-onto an additional NS calendar
+onto an additional NSCalendar
 method to add these components
 
 00:39:23.246 --> 00:39:25.966 A:middle
-to an existing NS date, and
+to an existing NSDate, and
 obtain a date in the future.
 
 00:39:26.836 --> 00:39:30.526 A:middle
@@ -3537,7 +3537,7 @@ So, I'm just creating
 using string with format
 
 00:40:51.576 --> 00:40:55.426 A:middle
-from the NS number and NS date
+from the NSNumber and NSDate
 attached to my note object.
 
 00:40:55.876 --> 00:40:57.866 A:middle
@@ -3578,8 +3578,8 @@ So, what I've chosen
 to do here is
 
 00:41:19.006 --> 00:41:22.436 A:middle
-to create an NS date formatter
-and an NS number formatter
+to create an NSDateFormatter
+and an NSNumberFormatter
 
 00:41:22.436 --> 00:41:23.876 A:middle
 to format these two objects.
@@ -3896,7 +3896,7 @@ The first one is, use
 Unicode and in particular,
 
 00:46:01.626 --> 00:46:04.676 A:middle
-the NS string class, which is
+the NSString class, which is
 our standard representation
 
 00:46:04.736 --> 00:46:07.576 A:middle
@@ -3917,7 +3917,7 @@ sort it, etc.,
 
 00:46:17.846 --> 00:46:20.026 A:middle
 use some of the standard
-NS string API's,
+NSString API's,
 
 00:46:20.836 --> 00:46:24.216 A:middle
 which are all Unicode savvy,
@@ -3952,7 +3952,7 @@ most of its date blocks
 in a single strength,
 
 00:46:46.926 --> 00:46:52.136 A:middle
-we use NS string as our standard
+we use NSString as our standard
 Unicode containing object,
 
 00:46:53.166 --> 00:46:57.506 A:middle
@@ -4118,7 +4118,7 @@ by user visible characters,
 character clusters,
 
 00:48:52.496 --> 00:48:54.016 A:middle
-you use the NS string
+you use the NSString
 enumeration
 
 00:48:54.016 --> 00:48:56.046 A:middle
@@ -4149,7 +4149,7 @@ Likewise, if you're going
 through it by words,
 
 00:49:10.016 --> 00:49:11.776 A:middle
-use NS string enumeration
+use NSString enumeration
 by words,
 
 00:49:11.826 --> 00:49:15.566 A:middle
@@ -4270,7 +4270,7 @@ Now, there are a couple of API's
 that you might look at for this.
 
 00:50:42.246 --> 00:50:43.916 A:middle
-NS string has a standard
+NSString has a standard
 compare method
 
 00:50:43.916 --> 00:50:46.656 A:middle
@@ -4795,14 +4795,14 @@ will detect these things,
 and even make them into links.
 
 00:56:58.756 --> 00:57:01.206 A:middle
-There is also NS data detector
+There is also NSDataDetector
 at the foundation level
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:56:58.756 --> 00:57:01.206 A:middle
-There is also NS data detector
+There is also NSDataDetector
 at the foundation level
 
 00:57:01.206 --> 00:57:02.286 A:middle
@@ -4879,7 +4879,7 @@ X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:58:00.776 --> 00:58:04.446 A:middle
 For text, use Unicode and NS
-string, and the NS string API's
+string, and the NSString API's
 
 00:58:04.886 --> 00:58:07.026 A:middle
 for iteration, searching,

--- a/2013/304.srt
+++ b/2013/304.srt
@@ -163,7 +163,7 @@ Here it is.
 
 00:02:07.226 --> 00:02:10.295 A:middle
 We have an NP Map view
-and an NS Window running
+and an NSWindow running
 
 00:02:10.295 --> 00:02:11.216 A:middle
 on Mac OS X there.
@@ -3042,7 +3042,7 @@ in which case you probably
 want to show like a UI alert
 
 00:33:27.656 --> 00:33:29.946 A:middle
-or NS alert or do
+or NSAlert or do
 something with that.
 
 00:33:30.506 --> 00:33:33.376 A:middle
@@ -3288,7 +3288,7 @@ also in Mavericks that's
 a distance formatter.
 
 00:35:44.096 --> 00:35:46.136 A:middle
-This is an NS formatter
+This is an NSFormatter
 subclass that allows you
 
 00:35:46.136 --> 00:35:47.336 A:middle

--- a/2013/305.srt
+++ b/2013/305.srt
@@ -1378,7 +1378,7 @@ And we have this class
 
 00:15:32.296 --> 00:15:33.966 A:middle
 in the system called
-NS Number Formatter.
+NSNumberFormatter.
 
 00:15:33.966 --> 00:15:37.296 A:middle
 And if you create one of
@@ -1931,7 +1931,7 @@ and then you can load it
 
 00:21:48.136 --> 00:21:50.776 A:middle
 with your favorite
-NS data methods.
+NSData methods.
 
 00:21:51.286 --> 00:21:53.936 A:middle
 So that's the only

--- a/2013/404.srt
+++ b/2013/404.srt
@@ -2881,7 +2881,7 @@ X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 that exposed this feature.
 
 00:33:00.996 --> 00:33:04.056 A:middle
-We have NS Enum for a
+We have NS_ENUM for a
 traditional enumerations,
 
 00:33:04.056 --> 00:33:05.326 A:middle
@@ -2892,7 +2892,7 @@ You know, ABC, JKL, XYZ.
 
 00:33:07.696 --> 00:33:11.826 A:middle
 And they also have a
-convenient macro for NS Options.
+convenient macro for NS_OPTIONS.
 
 00:33:12.686 --> 00:33:16.756 A:middle
 So, a bit wise operations,
@@ -2911,13 +2911,13 @@ with just warnings.
 
 00:33:27.166 --> 00:33:30.816 A:middle
 We also improved code
-completion with NS Enum
+completion with NS_ENUM
 
 00:33:30.816 --> 00:33:32.146 A:middle
 and explicitly-typed enums.
 
 00:33:33.236 --> 00:33:37.186 A:middle
-So before NS Enum, if you tried
+So before NS_ENUM, if you tried
 
 00:33:37.186 --> 00:33:40.806 A:middle
 to code complete our
@@ -2935,7 +2935,7 @@ That's not fun.
 
 00:33:49.356 --> 00:33:52.756 A:middle
 Well, if we just switch to
-the NS Enum macro and then get
+the NS_ENUM macro and then get
 
 00:33:52.756 --> 00:33:53.886 A:middle
 up the compiler feature,
@@ -3059,7 +3059,7 @@ write it as intended.
 
 00:35:16.776 --> 00:35:19.526 A:middle
 Digging deeper on what
-NS Enum can do for you,
+NS_ENUM can do for you,
 
 00:35:20.046 --> 00:35:21.666 A:middle
 let's consider the fact
@@ -3087,7 +3087,7 @@ And this manifested as a
 silent bug in your code.
 
 00:35:40.296 --> 00:35:42.966 A:middle
-Now with NS Enum, you get
+Now with NS_ENUM, you get
 the warning that you want
 
 00:35:43.106 --> 00:35:46.266 A:middle

--- a/2013/407.srt
+++ b/2013/407.srt
@@ -2510,7 +2510,7 @@ complex types like images,
 
 00:32:16.016 --> 00:32:19.026 A:middle
 we support UI image in
-iOS, NS image on Mac OS.
+iOS, NSImage on Mac OS.
 
 00:32:19.576 --> 00:32:21.486 A:middle
 But also CGImageRef and CIImage.

--- a/2013/409.srt
+++ b/2013/409.srt
@@ -2018,7 +2018,7 @@ NSRect and the boards--
 
 00:28:02.766 --> 00:28:05.226 A:middle
 the location we were going to--
-in the form of an NS point,
+in the form of an NSPoint,
 
 00:28:05.916 --> 00:28:08.026 A:middle
 I think there's a foundation

--- a/2013/410.srt
+++ b/2013/410.srt
@@ -2145,8 +2145,8 @@ behind the scenes.
 There are the obvious ones.
 
 00:23:28.276 --> 00:23:31.056 A:middle
-If I look for an NS set or
-an NS dictionary I'll see
+If I look for an NSSet or
+an NSDictionary I'll see
 
 00:23:31.056 --> 00:23:32.436 A:middle
 that there's a relatively
@@ -2169,7 +2169,7 @@ obvious containers, again,
 
 00:23:42.196 --> 00:23:44.836 A:middle
 UI view, view controllers
-or NS image
+or NSImage
 
 00:23:45.176 --> 00:23:47.126 A:middle
 that represent a
@@ -3700,7 +3700,7 @@ a little bit later,
 
 00:41:00.746 --> 00:41:04.526 A:middle
 but what we really needed to
-do is was use a local NS error
+do is was use a local NSError
 
 00:41:04.526 --> 00:41:08.336 A:middle
 and get that assignment
@@ -3871,7 +3871,7 @@ is a root leak,
 
 00:43:15.306 --> 00:43:21.386 A:middle
 and that this actually leaks
-an NS array which leaks a list.
+an NSArray which leaks a list.
 
 00:43:21.956 --> 00:43:24.466 A:middle
 So that's kind of nice.

--- a/2013/416.srt
+++ b/2013/416.srt
@@ -321,7 +321,7 @@ AppleScript objective C exposes
 the Cocoa classes to AppleScript
 
 00:04:41.146 --> 00:04:45.176 A:middle
-so things like NS String
+so things like NSString
 become available to you
 
 00:04:45.176 --> 00:04:48.886 A:middle
@@ -1582,14 +1582,14 @@ and ability because it taps
 
 00:22:57.146 --> 00:23:00.536 A:middle
 into the power of the
-Cocoa class NS String
+Cocoa class NSString
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:22:57.146 --> 00:23:00.536 A:middle
 into the power of the
-Cocoa class NS String
+Cocoa class NSString
 
 00:23:00.536 --> 00:23:01.906 A:middle
 to do all the heavy lifting.
@@ -2047,14 +2047,14 @@ the implementation,
 
 00:29:45.316 --> 00:29:49.086 A:middle
 like Sal mentioned earlier
-we construct an NS String
+we construct an NSString
 
 00:29:49.386 --> 00:29:53.836 A:middle
 from our AppleScript string,
 we call the appropriate method
 
 00:29:54.516 --> 00:29:56.486 A:middle
-of NS String to do the
+of NSString to do the
 capitalization we want
 
 00:29:56.486 --> 00:29:59.056 A:middle
@@ -2099,7 +2099,7 @@ Furthermore we now
 have a third options
 
 00:30:40.036 --> 00:30:41.956 A:middle
-because the NS String
+because the NSString
 class has a method
 
 00:30:42.006 --> 00:30:46.026 A:middle
@@ -3174,14 +3174,14 @@ works again it takes the source
 
 00:45:59.926 --> 00:46:04.046 A:middle
 string, converts it to a Cocoa
-string using NS String's string
+string using NSString's string
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:45:59.926 --> 00:46:04.046 A:middle
 string, converts it to a Cocoa
-string using NS String's string
+string using NSString's string
 
 00:46:04.516 --> 00:46:09.736 A:middle
 method, string with string and

--- a/2013/417.srt
+++ b/2013/417.srt
@@ -1201,7 +1201,7 @@ You can use some AppleScript
 Objective-C and talk
 
 00:15:29.576 --> 00:15:34.546 A:middle
-to the NS string class and use
+to the NSString class and use
 some of its methods as well.
 
 00:15:35.656 --> 00:15:40.876 A:middle

--- a/2013/504.srt
+++ b/2013/504.srt
@@ -1300,7 +1300,7 @@ when you're using sets
 within your game.
 
 00:14:30.316 --> 00:14:32.536 A:middle
-The first is an NS string title.
+The first is an NSString title.
 
 00:14:32.906 --> 00:14:34.936 A:middle
 Now this is really just the
@@ -1328,7 +1328,7 @@ titles work today as well.
 
 00:14:49.136 --> 00:14:51.136 A:middle
 Then you're going to have
-your NS string identifier.
+your NSString identifier.
 
 00:14:51.136 --> 00:14:55.486 A:middle
 This is just the set ID that
@@ -1414,7 +1414,7 @@ Now, when your completion
 handler is called, you're going
 
 00:15:42.646 --> 00:15:46.286 A:middle
-to be passed back an NS array
+to be passed back an NSArray
 of GK Leaderboard set instances.
 
 00:15:47.046 --> 00:15:48.816 A:middle
@@ -1471,7 +1471,7 @@ And when that completion
 handler is called back,
 
 00:16:14.376 --> 00:16:17.316 A:middle
-you'll be provided an NS array
+you'll be provided an NSArray
 of GK Leaderboard instances.
 
 00:16:18.246 --> 00:16:20.796 A:middle
@@ -1529,7 +1529,7 @@ then that's going to point
 
 00:16:54.576 --> 00:16:58.476 A:middle
 to UI image, if you're running
-on OS X, they'll be an NS image.
+on OS X, they'll be an NSImage.
 
 00:16:58.906 --> 00:17:00.926 A:middle
 And once this completion
@@ -2055,7 +2055,7 @@ Category property.
 
 00:22:55.706 --> 00:22:59.596 A:middle
 That was a pointer for basically
-the NS string identifier
+the NSString identifier
 
 00:22:59.596 --> 00:23:00.846 A:middle
 that you set up on
@@ -2364,7 +2364,7 @@ and how our completion handler,
 
 00:26:22.756 --> 00:26:26.306 A:middle
 as a signature, such that it can
-pass back an NS error object.
+pass back an NSError object.
 
 00:26:27.326 --> 00:26:28.776 A:middle
 This is largely vestigial.
@@ -2508,7 +2508,7 @@ are three different scores,
 
 00:27:54.946 --> 00:27:57.686 A:middle
 you should batch those into
-a single NS array and pass
+a single NSArray and pass
 
 00:27:57.686 --> 00:27:59.686 A:middle
 that in via report
@@ -3706,7 +3706,7 @@ you wish to be preselected.
 
 00:41:24.316 --> 00:41:26.956 A:middle
 Then a message which is
-an optional NS string
+an optional NSString
 
 00:41:26.956 --> 00:41:29.796 A:middle
 that you can pass that will pop

--- a/2013/606.srt
+++ b/2013/606.srt
@@ -1201,7 +1201,7 @@ Finally, we switch the
 row from editor to viewer.
 
 00:15:46.546 --> 00:15:49.276 A:middle
-So that's-- NS Application
+So that's-- NSApplication
 doesn't create a document
 
 00:15:49.276 --> 00:15:50.386 A:middle

--- a/2013/703.srt
+++ b/2013/703.srt
@@ -4118,7 +4118,7 @@ conform to NSCopying.
 
 00:44:51.616 --> 00:44:55.206 A:middle
 And actually most CB objects can
-be used as NS dictionary keys.
+be used as NSDictionary keys.
 
 00:44:55.546 --> 00:44:58.156 A:middle
 We've seen a lot of you

--- a/2013/710.srt
+++ b/2013/710.srt
@@ -3309,7 +3309,7 @@ or if you're including
 helper tools that you run
 
 00:38:20.166 --> 00:38:23.606 A:middle
-through things like NS Task, all
+through things like NSTask, all
 of those must also be Sandboxed.
 
 00:38:24.066 --> 00:38:27.426 A:middle

--- a/2013/711.srt
+++ b/2013/711.srt
@@ -1879,14 +1879,14 @@ NSURL's, file URL on disk
 
 00:21:59.746 --> 00:22:03.646 A:middle
 or elsewhere, it could be in
-memory in the form of NS data
+memory in the form of NSData
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:21:59.746 --> 00:22:03.646 A:middle
 or elsewhere, it could be in
-memory in the form of NS data
+memory in the form of NSData
 
 00:22:04.146 --> 00:22:08.166 A:middle
 or a UI image or CI image


### PR DESCRIPTION
Didn't fix the ones spanning across multiple lines yet since they will require a bit more effort in determining optimal placement.
