### PR TITLE
Remove duplicate lines from srt files

### DIFF
--- a/2013/100.srt
+++ b/2013/100.srt
@@ -10,9 +10,6 @@ X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:11.016 --> 00:01:37.000 A:middle
-[ Music ]
-
 00:01:37.516 --> 00:01:51.226 A:middle
 [ Applause ]
 
@@ -30,9 +27,6 @@ Thank you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.816 --> 00:02:01.576 A:middle
-Thank you.
 
 00:02:01.576 --> 00:02:01.836 A:middle
 Thank you.
@@ -181,10 +175,6 @@ per day did that last year.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.896 --> 00:04:03.306 A:middle
-and over a million people
-per day did that last year.
-
 00:04:03.686 --> 00:04:04.626 A:middle
 It's phenomenal.
 
@@ -255,10 +245,6 @@ the history of the building
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.966 --> 00:05:01.176 A:middle
-We've painstakingly honored
-the history of the building
-
 00:05:01.706 --> 00:05:05.216 A:middle
 by restoring the facade
 and the original theater,
@@ -297,17 +283,11 @@ for you this morning.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:34.516 --> 00:06:56.516 A:middle
-[ Music ]
-
 00:06:57.016 --> 00:07:04.000 A:middle
 [ Applause ]
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.016 --> 00:07:04.000 A:middle
-[ Applause ]
 
 00:07:04.896 --> 00:07:05.666 A:middle
 That's Berlin.
@@ -495,10 +475,6 @@ and the iOS platform
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.566 --> 00:10:01.266 A:middle
-They are using iOS devices
-and the iOS platform
-
 00:10:01.526 --> 00:10:03.396 A:middle
 to bring artificial intelligence
 
@@ -574,9 +550,6 @@ Anki Drive.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:55.516 --> 00:11:03.446 A:middle
-[ Pause ]
 
 00:11:03.946 --> 00:11:05.286 A:middle
 [Background Music] Assisting me
@@ -843,10 +816,6 @@ and get a deeper look.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.066 --> 00:14:01.156 A:middle
-so you can download it
-and get a deeper look.
-
 00:14:01.846 --> 00:14:04.206 A:middle
 We are a robotics and
 artificial intelligence company
@@ -917,10 +886,6 @@ incredibly strong at 72 million.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:56.646 --> 00:15:00.996 A:middle
-The Mac install base now is
-incredibly strong at 72 million.
-
 00:15:01.346 --> 00:15:04.096 A:middle
 This is double what it
 was just five years ago.
@@ -987,10 +952,6 @@ to take my word for it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.826 --> 00:16:03.076 A:middle
-And you don't just have
-to take my word for it.
 
 00:16:03.426 --> 00:16:05.236 A:middle
 All of these guys agree.
@@ -1061,10 +1022,6 @@ Craig Federighi up to the stage.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.566 --> 00:17:03.136 A:middle
-To do that, I'd like to invite
-Craig Federighi up to the stage.
-
 00:17:03.566 --> 00:17:03.916 A:middle
 Craig.
 
@@ -1128,9 +1085,6 @@ What do you think?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.966 --> 00:18:00.086 A:middle
-What do you think?
-
 00:18:03.516 --> 00:18:08.776 A:middle
 [ Applause ]
 
@@ -1191,9 +1145,6 @@ OS X Mavericks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:54.516 --> 00:19:03.726 A:middle
-[ Applause ]
 
 00:19:04.226 --> 00:19:07.926 A:middle
 Now, Mavericks is a release
@@ -1344,10 +1295,6 @@ you can get at your menus
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.186 --> 00:21:01.146 A:middle
-But now, in Mavericks,
-you can get at your menus
-
 00:21:01.426 --> 00:21:02.956 A:middle
 across multiple displays.
 
@@ -1419,9 +1366,6 @@ and let's merge all my windows.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.856 --> 00:22:00.316 A:middle
-and let's merge all my windows.
 
 00:22:00.316 --> 00:22:03.966 A:middle
 Just like that, they
@@ -1507,9 +1451,6 @@ Looks pretty important to me.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.136 --> 00:23:00.296 A:middle
-Looks pretty important to me.
 
 00:23:00.706 --> 00:23:04.196 A:middle
 And we'll go here into
@@ -1604,9 +1545,6 @@ and they're tagged like that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.526 --> 00:24:00.076 A:middle
-and they're tagged like that.
 
 00:24:00.686 --> 00:24:02.806 A:middle
 And tags are great
@@ -1775,10 +1713,6 @@ an Apple TV around here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.056 --> 00:26:02.366 A:middle
-Finally, I actually have
-an Apple TV around here.
-
 00:26:02.366 --> 00:26:03.486 A:middle
 Let's bring that into place.
 
@@ -1851,9 +1785,6 @@ They want great responsiveness
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.326 --> 00:27:00.726 A:middle
-They want great responsiveness
 
 00:27:00.976 --> 00:27:03.226 A:middle
 but they also want
@@ -1944,9 +1875,6 @@ of high power use and back down.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.366 --> 00:28:01.446 A:middle
-of high power use and back down.
-
 00:28:01.446 --> 00:28:05.326 A:middle
 And all of those transitions
 actually consume a lot of power.
@@ -2021,10 +1949,6 @@ and it does that in the past
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.956 --> 00:29:00.926 A:middle
-to need to get free memory
-and it does that in the past
 
 00:29:01.126 --> 00:29:03.866 A:middle
 by writing those inactive
@@ -2109,10 +2033,6 @@ cookies for privacy,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.556 --> 00:30:00.896 A:middle
-blocking of third party
-cookies for privacy,
-
 00:30:01.256 --> 00:30:03.656 A:middle
 making the web easier to read
 with features like Reading List,
@@ -2192,10 +2112,6 @@ process-per-tab architecture,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.776 --> 00:31:03.286 A:middle
-to JavaScript, a full
-process-per-tab architecture,
-
 00:31:03.286 --> 00:31:05.066 A:middle
 and memory efficiency
 improvements
@@ -2274,10 +2190,6 @@ energy than Chrome.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.826 --> 00:32:03.026 A:middle
-Safari uses way less
-energy than Chrome.
-
 00:32:03.076 --> 00:32:05.986 A:middle
 And when you compare to
 Firefox, it's just kind of sad.
@@ -2351,10 +2263,6 @@ improved scrolling
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.096 --> 00:33:00.466 A:middle
-In Safari, we've
-improved scrolling
 
 00:33:00.506 --> 00:33:04.086 A:middle
 for more popular websites and
@@ -2518,10 +2426,6 @@ here on Twitter and LinkedIn
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.796 --> 00:35:01.216 A:middle
-You see sites that I'm following
-here on Twitter and LinkedIn
-
 00:35:01.476 --> 00:35:03.996 A:middle
 and click on a site-- a
 link that's been shared.
@@ -2608,9 +2512,6 @@ I think you're going to like it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.516 --> 00:36:03.826 A:middle
-[ Applause ]
 
 00:36:04.326 --> 00:36:05.916 A:middle
 So, we have some
@@ -2759,10 +2660,6 @@ Notification and you can do this
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.016 --> 00:38:01.456 A:middle
-You can reply right inside the
-Notification and you can do this
-
 00:38:01.456 --> 00:38:02.626 A:middle
 for things like email
 
@@ -2836,10 +2733,6 @@ for you right in the background
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:55.056 --> 00:39:00.316 A:middle
-And it will now update apps
-for you right in the background
-
 00:39:00.316 --> 00:39:01.976 A:middle
 so you don't have
 to do it yourself.
@@ -2901,9 +2794,6 @@ Next, Maps.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:55.516 --> 00:40:00.136 A:middle
-[ Applause ]
 
 00:40:00.636 --> 00:40:03.596 A:middle
 The Maps team has been making
@@ -2978,10 +2868,6 @@ iBooks to the Mac.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:51.906 --> 00:41:01.496 A:middle
-Finally, we're bringing
-iBooks to the Mac.
-
 00:41:01.666 --> 00:41:10.446 A:middle
 So now, you have access
 to the full library
@@ -3047,10 +2933,6 @@ Tower right here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.146 --> 00:42:00.826 A:middle
-maybe the Eiffel
-Tower right here.
 
 00:42:01.486 --> 00:42:04.366 A:middle
 Let's go in to look
@@ -3118,10 +3000,6 @@ to me, of course, on my phone.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.756 --> 00:43:00.236 A:middle
-so this location is available
-to me, of course, on my phone.
 
 00:43:00.626 --> 00:43:03.086 A:middle
 And because this is a
@@ -3206,10 +3084,6 @@ Tony's Pizza
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.176 --> 00:44:00.446 A:middle
-so I'm going to select
-Tony's Pizza
-
 00:44:01.336 --> 00:44:02.466 A:middle
 and you notice I get a map.
 
@@ -3286,10 +3160,6 @@ reading so you can get in here
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:57.636 --> 00:45:00.816 A:middle
-Books of course ultimately about
-reading so you can get in here
-
 00:45:00.816 --> 00:45:04.316 A:middle
 and read, move easily
 between the pages.
@@ -3361,9 +3231,6 @@ really great way to learn.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:57.516 --> 00:46:02.076 A:middle
-[ Applause ]
-
 00:46:02.576 --> 00:46:05.096 A:middle
 It's also a great
 environment for taking notes,
@@ -3429,10 +3296,6 @@ on whatever device you choose
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.006 --> 00:47:01.556 A:middle
-So now, your books are available
-on whatever device you choose
 
 00:47:01.556 --> 00:47:04.636 A:middle
 to read them on and it remembers
@@ -3503,9 +3366,6 @@ Thank you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:52.516 --> 00:48:01.226 A:middle
-[ Applause ]
 
 00:48:01.726 --> 00:48:03.056 A:middle
 &gt;&gt; Well, good morning everyone.
@@ -3580,9 +3440,6 @@ for incredible power savings.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.416 --> 00:49:01.506 A:middle
-for incredible power savings.
 
 00:49:01.736 --> 00:49:03.996 A:middle
 There's more energy-efficient
@@ -3661,10 +3518,6 @@ almost the entire Trilogy
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.716 --> 00:50:01.976 A:middle
-up to 10 hours, you can watch
-almost the entire Trilogy
 
 00:50:01.976 --> 00:50:03.966 A:middle
 of Lord of the Rings,
@@ -3745,10 +3598,6 @@ cool features.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.746 --> 00:51:00.266 A:middle
-they have a lot of
-cool features.
-
 00:51:00.266 --> 00:51:01.116 A:middle
 I'll just point out one,
 
@@ -3827,10 +3676,6 @@ arsenic-free display glass,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:56.696 --> 00:52:00.286 A:middle
-EPEAT Gold, most on
-arsenic-free display glass,
-
 00:52:00.556 --> 00:52:05.766 A:middle
 mercury-free displays, BFR-free,
 PVC-free, and highly recyclable.
@@ -3898,10 +3743,6 @@ on the fastest,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.706 --> 00:53:00.496 A:middle
-to get their hands
-on the fastest,
 
 00:53:00.496 --> 00:53:01.946 A:middle
 most expandable Mac we make.
@@ -3976,9 +3817,6 @@ next generation of Mac Pro.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:57.516 --> 00:54:17.516 A:middle
-[ Pause ]
-
 00:54:18.016 --> 00:54:49.000 A:middle
 [ Music ]
 
@@ -3987,9 +3825,6 @@ X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:49.516 --> 00:55:04.186 A:middle
-[ Applause ]
 
 00:55:04.686 --> 00:55:05.956 A:middle
 Can't innovate anymore, my ass.
@@ -4045,9 +3880,6 @@ of the previous generation.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:59.076 --> 00:56:00.246 A:middle
-of the previous generation.
 
 00:56:00.956 --> 00:56:04.396 A:middle
 The fastest memory we've ever
@@ -4121,10 +3953,6 @@ Thunderbolt 1.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:56:59.466 --> 00:57:01.516 A:middle
-and industry of leading
-Thunderbolt 1.
-
 00:57:02.256 --> 00:57:05.736 A:middle
 But the place where the team has
 probably gone, the most crazy
@@ -4192,10 +4020,6 @@ hard at work in a version
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:57:59.586 --> 00:58:01.836 A:middle
-The Final Cut Pro team is
-hard at work in a version
 
 00:58:01.836 --> 00:58:04.416 A:middle
 of Final Cut Pro X that will
@@ -4270,10 +4094,6 @@ six FireWire 2 being driven
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:58:55.646 --> 00:59:01.106 A:middle
-There is audio, four USB 3,
-six FireWire 2 being driven
-
 00:59:01.106 --> 00:59:04.326 A:middle
 by three FireWire 2
 controllers and you guys
@@ -4341,9 +4161,6 @@ from The Foundry are going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:59:59.106 --> 01:00:00.366 A:middle
-from The Foundry are going
-
 01:00:00.366 --> 01:00:02.536 A:middle
 to show you some amazing
 character animation
@@ -4408,10 +4225,6 @@ out of their content
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:00:58.676 --> 01:01:02.946 A:middle
-out of their content
-35 billion times.
-
 01:01:04.026 --> 01:01:08.216 A:middle
 Now, the back-end infrastructure
 of iCloud allows us
@@ -4466,10 +4279,6 @@ you how we're deeply integrating
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:01:56.316 --> 01:02:01.636 A:middle
-Today, we want to share with
-you how we're deeply integrating
 
 01:02:01.636 --> 01:02:05.256 A:middle
 iCloud into the next
@@ -4541,10 +4350,6 @@ introduce the newest member
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:02:57.236 --> 01:03:00.996 A:middle
-But today, I want to
-introduce the newest member
 
 01:03:00.996 --> 01:03:06.006 A:middle
 of the iWork family,
@@ -4875,10 +4680,6 @@ fire up Chrome.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:07:58.926 --> 01:08:00.186 A:middle
-I'm just going to
-fire up Chrome.
-
 01:08:01.516 --> 01:08:06.606 A:middle
 [ Laughter ]
 
@@ -5089,10 +4890,6 @@ a variety of ways.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:10:59.466 --> 01:11:01.626 A:middle
-Now this shows up in
-a variety of ways.
-
 01:11:01.626 --> 01:11:06.556 A:middle
 As an example, just like
 iOS customers buy more
@@ -5153,9 +4950,6 @@ has ever been done.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:11:55.516 --> 01:12:00.996 A:middle
-[ Applause ]
 
 01:12:01.496 --> 01:12:04.986 A:middle
 And iOS satisfaction is
@@ -5219,10 +5013,6 @@ using the latest version of iOS.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:12:57.386 --> 01:13:03.326 A:middle
-Over 90 percent of iOS users are
-using the latest version of iOS.
-
 01:13:03.326 --> 01:13:08.256 A:middle
 Now, that's in stark contrast
 to the world of Android.
@@ -5281,10 +5071,6 @@ math, you would find
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:13:57.836 --> 01:14:00.606 A:middle
-In fact, if you do the
-math, you would find
-
 01:14:00.606 --> 01:14:05.736 A:middle
 that iOS 6 is the world's most
 popular mobile operating system
@@ -5336,10 +5122,6 @@ change to iOS
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:14:59.776 --> 01:15:03.346 A:middle
-iOS 7 is the biggest
-change to iOS
 
 01:15:03.346 --> 01:15:05.286 A:middle
 since the introduction
@@ -5395,9 +5177,6 @@ so much about experience.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:15:59.516 --> 01:16:08.546 A:middle
-[ Music ]
-
 01:16:09.046 --> 01:16:16.876 A:middle
 I think there is a profound and
 enduring beauty in simplicity,
@@ -5437,9 +5216,6 @@ across the entire system.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:16:55.516 --> 01:17:04.846 A:middle
-[ Music ]
 
 01:17:05.346 --> 01:17:08.606 A:middle
 We've considered
@@ -5495,10 +5271,6 @@ of depth and vitality.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:17:56.856 --> 01:18:00.316 A:middle
-and motion, create a sense
-of depth and vitality.
-
 01:18:01.516 --> 01:18:08.986 A:middle
 [ Music &amp; Applause ]
 
@@ -5553,9 +5325,6 @@ to make it instantly familiar.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:18:59.186 --> 01:19:00.736 A:middle
-to make it instantly familiar.
-
 01:19:01.516 --> 01:19:05.926 A:middle
 [ Music ]
 
@@ -5597,9 +5366,6 @@ and in many ways, a beginning.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:19:41.016 --> 01:20:14.000 A:middle
-[ Applause ]
 
 01:20:15.506 --> 01:20:18.556 A:middle
 &gt;&gt; You are going to
@@ -5649,9 +5415,6 @@ Craig.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:20:54.516 --> 01:21:04.016 A:middle
-[ Applause ]
 
 01:21:04.516 --> 01:21:08.606 A:middle
 &gt;&gt; Well, on behalf of all of
@@ -5721,10 +5484,6 @@ this liveliness.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:21:59.776 --> 01:22:02.006 A:middle
-over across the system,
-this liveliness.
-
 01:22:02.006 --> 01:22:04.366 A:middle
 I mean just take a look
 at something like weather,
@@ -5789,10 +5548,6 @@ iOS 7 is to see it live.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:22:57.396 --> 01:23:00.676 A:middle
-The best way to appreciate
-iOS 7 is to see it live.
 
 01:23:01.096 --> 01:23:02.746 A:middle
 I'd like to give you
@@ -5938,10 +5693,6 @@ up the keyboard,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:24:57.646 --> 01:25:01.626 A:middle
-The bubbles, spring
-up the keyboard,
-
 01:25:02.046 --> 01:25:03.906 A:middle
 lets you slide contents
 of the keyboard.
@@ -6016,9 +5767,6 @@ And that gesture from moving in
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:25:59.466 --> 01:26:00.886 A:middle
-And that gesture from moving in
 
 01:26:00.886 --> 01:26:02.136 A:middle
 and out works here
@@ -6100,10 +5848,6 @@ redesign of the user experience.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:26:56.146 --> 01:27:01.026 A:middle
-It's a comprehensive end-to-end
-redesign of the user experience.
-
 01:27:01.846 --> 01:27:04.416 A:middle
 Installing iOS 7
 on your phone is
@@ -6179,10 +5923,6 @@ of the night and you need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:27:58.306 --> 01:28:00.286 A:middle
-So if you wake up in the middle
-of the night and you need
-
 01:28:00.286 --> 01:28:02.876 A:middle
 to find something, your
 flashlight's right there.
@@ -6252,10 +5992,6 @@ constantly throughout the day,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:28:59.136 --> 01:29:01.436 A:middle
-that you're using
-constantly throughout the day,
 
 01:29:01.436 --> 01:29:03.986 A:middle
 a social networking app or
@@ -6349,10 +6085,6 @@ push notifications as a trigger
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:29:58.806 --> 01:30:03.206 A:middle
-And, finally, iOS 7 response to
-push notifications as a trigger
 
 01:30:03.206 --> 01:30:05.956 A:middle
 to give that application
@@ -6491,10 +6223,6 @@ earlier for going back well
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:31:59.446 --> 01:32:02.456 A:middle
-And that same gesture you saw
-earlier for going back well
-
 01:32:02.456 --> 01:32:04.166 A:middle
 of course that works
 in Safari as well.
@@ -6588,10 +6316,6 @@ bottom into tabs, unbelievable,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:32:59.626 --> 01:33:05.436 A:middle
-I'm going to click here at the
-bottom into tabs, unbelievable,
-
 01:33:05.886 --> 01:33:07.566 A:middle
 and you're no longer
 limited to just eight.
@@ -6654,9 +6378,6 @@ and up comes Control Center.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:33:59.036 --> 01:34:00.456 A:middle
-and up comes Control Center.
 
 01:34:00.926 --> 01:34:03.906 A:middle
 See how these great switches
@@ -6734,10 +6455,6 @@ out, just like this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:34:58.346 --> 01:35:03.356 A:middle
-Move into Mail, back
-out, just like this.
 
 01:35:04.216 --> 01:35:05.176 A:middle
 It's really, really nice.
@@ -6882,10 +6599,6 @@ way to manage your photos
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:36:59.686 --> 01:37:02.256 A:middle
-to give you a great new
-way to manage your photos
-
 01:37:02.256 --> 01:37:03.876 A:middle
 and it's the new Photos app.
 
@@ -6964,10 +6677,6 @@ natural organization
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:37:59.716 --> 01:38:01.556 A:middle
-It provides this
-natural organization
 
 01:38:01.556 --> 01:38:02.916 A:middle
 for appreciating the photos.
@@ -7050,9 +6759,6 @@ photo collection.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:38:54.516 --> 01:39:00.776 A:middle
-[ Applause ]
 
 01:39:01.276 --> 01:39:04.196 A:middle
 And look how we pull out the
@@ -7147,10 +6853,6 @@ any of you were running iOS 7,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:39:58.436 --> 01:40:01.626 A:middle
-We have AirDrop right here if
-any of you were running iOS 7,
 
 01:40:01.626 --> 01:40:03.076 A:middle
 I'd see you, it looks
@@ -7249,10 +6951,6 @@ they've shared.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:40:58.606 --> 01:41:00.226 A:middle
-and the photos that
-they've shared.
-
 01:41:00.666 --> 01:41:06.086 A:middle
 And now, we even support sharing
 video via iCloud photo sharing.
@@ -7321,10 +7019,6 @@ a gorgeous new interface.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:41:56.636 --> 01:42:00.706 A:middle
-The first thing is Siri has
-a gorgeous new interface.
 
 01:42:01.236 --> 01:42:04.706 A:middle
 Now as I speak, you'll see a
@@ -7406,10 +7100,6 @@ lot more questions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:42:59.406 --> 01:43:01.956 A:middle
-And it can answer a
-lot more questions
-
 01:43:02.396 --> 01:43:05.816 A:middle
 because we've integrated some
 new services like Twitter,
@@ -7475,10 +7165,6 @@ make phone calls, play music,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:43:57.736 --> 01:44:02.086 A:middle
-into your car so that you can
-make phone calls, play music,
-
 01:44:02.506 --> 01:44:06.856 A:middle
 go to maps, get your iMessages
 right on the screen in your car
@@ -7533,10 +7219,6 @@ Apps than ever before.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:44:59.556 --> 01:45:02.416 A:middle
-It's way easier to find
-Apps than ever before.
 
 01:45:02.576 --> 01:45:06.166 A:middle
 We've added a new feature where
@@ -7600,9 +7282,6 @@ Next, let's talk about music.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:45:58.556 --> 01:46:00.176 A:middle
-Next, let's talk about music.
 
 01:46:00.746 --> 01:46:03.886 A:middle
 The music app in iOS
@@ -7678,10 +7357,6 @@ way to listen to your music.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:46:57.816 --> 01:47:01.336 A:middle
-Now, the music app is the best
-way to listen to your music.
-
 01:47:01.876 --> 01:47:04.606 A:middle
 But today, we're
 introducing an amazing way
@@ -7744,9 +7419,6 @@ So you just tap.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:47:59.016 --> 01:48:05.000 A:middle
-[ Music ]
 
 01:48:05.096 --> 01:48:08.096 A:middle
 [Background Music] And once
@@ -7873,9 +7545,6 @@ And that's iTunes Radio.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:49:58.516 --> 01:50:06.576 A:middle
-[ Applause ]
-
 01:50:07.076 --> 01:50:11.226 A:middle
 So iTunes Radio is built into
 iOS 7, it works on your iPhone,
@@ -7930,9 +7599,6 @@ Thank you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:50:58.666 --> 01:51:00.626 A:middle
-&gt;&gt; Thank you Eddy.
 
 01:51:02.236 --> 01:51:05.126 A:middle
 So 10 amazing features in iOS 7
@@ -8062,9 +7728,6 @@ for developers as well.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:52:59.676 --> 01:53:00.916 A:middle
-for developers as well.
-
 01:53:01.286 --> 01:53:04.176 A:middle
 The SDK includes
 over 1500 new APIs.
@@ -8126,10 +7789,6 @@ for iPhone 4 and later iPad 2
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:53:59.086 --> 01:54:04.156 A:middle
-So iOS 7 will be available
-for iPhone 4 and later iPad 2
-
 01:54:04.156 --> 01:54:08.906 A:middle
 and later the iPad mini and the
 fifth generation iPod touch.
@@ -8190,10 +7849,6 @@ a Mac or a PC.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:54:59.866 --> 01:55:03.146 A:middle
-in your browser on
-a Mac or a PC.
-
 01:55:03.816 --> 01:55:11.576 A:middle
 iOS 7, amazing new features and
 a stunning new user interface,
@@ -8244,10 +7899,6 @@ with the reminder, that our goal
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:55:58.826 --> 01:56:03.396 A:middle
-I'd like to close this morning
-with the reminder, that our goal
 
 01:56:03.396 --> 01:56:06.596 A:middle
 at Apple is to make
@@ -8306,9 +7957,6 @@ This is what matters.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:56:55.296 --> 01:57:02.836 A:middle
-This is what matters.
-
 01:57:02.836 --> 01:57:08.976 A:middle
 The experience of a product.
 
@@ -8344,9 +7992,6 @@ And it means everything.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:57:53.516 --> 01:58:01.886 A:middle
-[ Applause ]
 
 01:58:02.386 --> 01:58:02.766 A:middle
 &gt;&gt; Thank you.

--- a/2013/101.srt
+++ b/2013/101.srt
@@ -10,9 +10,6 @@ X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:09.016 --> 00:01:38.000 A:middle
-[ Music &amp; Background Noise ]
-
 00:01:38.516 --> 00:01:44.536 A:middle
 [ Applause ]
 
@@ -37,9 +34,6 @@ Welcome to WWDC 2013.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.236 --> 00:02:00.936 A:middle
-Welcome to WWDC 2013.
 
 00:02:03.416 --> 00:02:07.576 A:middle
 The epic ecosystem continues to
@@ -211,10 +205,6 @@ app downloads.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.946 --> 00:04:01.016 A:middle
-of over 50 billion
-app downloads.
-
 00:04:01.836 --> 00:04:03.976 A:middle
 And the rate of downloads
 start accelerating
@@ -303,9 +293,6 @@ from a paid app to be a premium.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.526 --> 00:05:00.666 A:middle
-from a paid app to be a premium.
-
 00:05:01.126 --> 00:05:03.106 A:middle
 In which case, you can
 validate with the receipts
@@ -391,10 +378,6 @@ these services with your apps.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.896 --> 00:06:01.346 A:middle
-that users can use to integrate
-these services with your apps.
-
 00:06:02.396 --> 00:06:04.916 A:middle
 Now, we understand that there
 is one specific area that many
@@ -467,10 +450,6 @@ brief update on iCloud.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.146 --> 00:07:00.226 A:middle
-So, that's just a
-brief update on iCloud.
 
 00:07:00.796 --> 00:07:02.906 A:middle
 We're working very hard to
@@ -549,10 +528,6 @@ classes, 679 new methods
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:54.916 --> 00:08:00.936 A:middle
-We've got 114 new
-classes, 679 new methods
 
 00:08:01.016 --> 00:08:04.076 A:middle
 and 917 new properties.
@@ -713,10 +688,6 @@ defining your content areas.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.866 --> 00:10:02.946 A:middle
-and shadows and cut-lines in
-defining your content areas.
-
 00:10:03.486 --> 00:10:06.296 A:middle
 And sophisticated animations
 make this perhaps the most
@@ -787,10 +758,6 @@ see some differences.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.726 --> 00:11:02.936 A:middle
-And right away, you can
-see some differences.
 
 00:11:04.026 --> 00:11:11.316 A:middle
 Let's try this one
@@ -865,9 +832,6 @@ They too have no boarders.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.696 --> 00:12:01.266 A:middle
-They too have no boarders.
 
 00:12:01.406 --> 00:12:03.826 A:middle
 And in fact, you'll notice
@@ -966,9 +930,6 @@ because the action sheet is up.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.876 --> 00:13:01.116 A:middle
-because the action sheet is up.
-
 00:13:01.796 --> 00:13:04.526 A:middle
 If I just missed the action
 sheet, the color goes away.
@@ -1055,10 +1016,6 @@ make text smaller or drag it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:56.736 --> 00:14:00.466 A:middle
-I can drag it to the left to
-make text smaller or drag it
 
 00:14:00.506 --> 00:14:03.006 A:middle
 to the right to make text
@@ -1152,10 +1109,6 @@ Time to accept my action
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.746 --> 00:15:01.736 A:middle
-I'm going to tap the Start
-Time to accept my action
 
 00:15:01.736 --> 00:15:04.466 A:middle
 and the Table View slides
@@ -1389,10 +1342,6 @@ one-type-fits-all system font,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.706 --> 00:18:00.846 A:middle
-Instead of a single
-one-type-fits-all system font,
-
 00:18:01.176 --> 00:18:03.866 A:middle
 we've introduced a family of
 fonts that are being chosen
@@ -1476,10 +1425,6 @@ this available to you
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.496 --> 00:19:01.636 A:middle
-And WebKit makes
-this available to you
-
 00:19:01.636 --> 00:19:03.746 A:middle
 through the use of
 CSS font values.
@@ -1555,10 +1500,6 @@ animations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.536 --> 00:20:00.376 A:middle
-Transitions are canned
-animations
 
 00:20:00.376 --> 00:20:02.376 A:middle
 between your view
@@ -1638,10 +1579,6 @@ changes in your UI.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:56.936 --> 00:21:00.086 A:middle
-of the device to
-changes in your UI.
 
 00:21:00.266 --> 00:21:01.726 A:middle
 You're familiar with
@@ -1726,10 +1663,6 @@ with using your hierarchy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.586 --> 00:22:00.886 A:middle
-You associate a set of behaviors
-with using your hierarchy.
-
 00:22:01.216 --> 00:22:04.216 A:middle
 And as the physics engine
 runs, it updates properties
@@ -1807,10 +1740,6 @@ high-res art from your 1x art.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:56.886 --> 00:23:01.246 A:middle
-of differentiating your iPhone
-high-res art from your 1x art.
-
 00:23:01.246 --> 00:23:04.126 A:middle
 And then we added
 Retina iPad, so frankly,
@@ -1887,9 +1816,6 @@ and does a really good job
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.506 --> 00:24:00.826 A:middle
-and does a really good job
 
 00:24:00.826 --> 00:24:02.806 A:middle
 of keeping your content
@@ -1971,10 +1897,6 @@ already saying to yourselves,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.756 --> 00:25:02.136 A:middle
-Now, I know what most of you are
-already saying to yourselves,
-
 00:25:02.136 --> 00:25:03.476 A:middle
 I know how to fix that problem.
 
@@ -2042,10 +1964,6 @@ are the days of the -427K
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.756 --> 00:26:02.856 A:middle
-As Toby told you, gone
-are the days of the -427K
-
 00:26:02.856 --> 00:26:06.206 A:middle
 at 1x twiddle i something.
 
@@ -2111,10 +2029,6 @@ a little more.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.846 --> 00:27:00.536 A:middle
-I can even zoom in
-a little more.
 
 00:27:01.286 --> 00:27:04.376 A:middle
 Now, all I need to do is
@@ -2188,10 +2102,6 @@ so I'm going to slice the 1x
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.746 --> 00:28:03.976 A:middle
-But I like what Xcode gave me,
-so I'm going to slice the 1x
 
 00:28:03.976 --> 00:28:05.226 A:middle
 in exactly the same way.
@@ -2340,10 +2250,6 @@ stop there though.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.846 --> 00:30:05.186 A:middle
-Yeah. Now, we didn't
-stop there though.
-
 00:30:05.186 --> 00:30:07.296 A:middle
 We've also added a lot
 
@@ -2488,10 +2394,6 @@ three and a half and four inch.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.516 --> 00:32:00.166 A:middle
-here I'm switching between the
-three and a half and four inch.
-
 00:32:01.096 --> 00:32:05.736 A:middle
 I can even go back and
 look at iOS 6.1 style UI.
@@ -2552,10 +2454,6 @@ up to date as you can make it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:57.336 --> 00:33:00.796 A:middle
-that your app's content is as
-up to date as you can make it.
 
 00:33:01.536 --> 00:33:04.656 A:middle
 To help you out, we're
@@ -2634,10 +2532,6 @@ not actually allowed
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.906 --> 00:34:06.066 A:middle
-Now, I've been told I'm
-not actually allowed
 
 00:34:06.066 --> 00:34:08.846 A:middle
 to push back the start time
@@ -2783,10 +2677,6 @@ continue to enhance it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.886 --> 00:36:02.816 A:middle
-And we're going to
-continue to enhance it.
-
 00:36:03.416 --> 00:36:05.776 A:middle
 Now leaderboards, you can
 have over 500 leaderboards,
@@ -2864,10 +2754,6 @@ created Sprite Kit.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.096 --> 00:37:00.426 A:middle
-So that's why we
-created Sprite Kit.
-
 00:37:00.426 --> 00:37:02.646 A:middle
 It has everything you
 expect in a game engine.
@@ -2937,10 +2823,6 @@ the things you would expect --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.466 --> 00:38:01.826 A:middle
-The animation system has all
-the things you would expect --
 
 00:38:02.166 --> 00:38:06.256 A:middle
 translation, rotation,
@@ -3099,10 +2981,6 @@ on top of the system.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.696 --> 00:40:02.046 A:middle
-We have a pixelate filter
-on top of the system.
-
 00:40:02.046 --> 00:40:05.016 A:middle
 And these filters can be applied
 to all or part Sprite tree
@@ -3183,10 +3061,6 @@ sample code for you guys.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.326 --> 00:41:00.266 A:middle
-production quality game
-sample code for you guys.
 
 00:41:00.766 --> 00:41:03.966 A:middle
 So let me jump in here
@@ -3343,10 +3217,6 @@ experience to a new level
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.236 --> 00:43:01.936 A:middle
-We're taking the gaming
-experience to a new level
-
 00:43:01.936 --> 00:43:03.716 A:middle
 by defining the standard --
 
@@ -3437,9 +3307,6 @@ and some shoulder buttons.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.516 --> 00:44:00.546 A:middle
-and some shoulder buttons.
 
 00:44:01.666 --> 00:44:04.976 A:middle
 The hands configuration adds two
@@ -3688,10 +3555,6 @@ Xcode, particle editor,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.826 --> 00:47:01.346 A:middle
-Tools built in the
-Xcode, particle editor,
-
 00:47:01.386 --> 00:47:02.966 A:middle
 and a text [inaudible]
 generator.
@@ -3782,10 +3645,6 @@ used to optimizing our apps
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:57.246 --> 00:48:00.656 A:middle
-All of us here are already
-used to optimizing our apps
-
 00:48:00.656 --> 00:48:03.446 A:middle
 for low memory use and
 low CPU utilization.
@@ -3869,9 +3728,6 @@ of animations and switching
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.686 --> 00:49:00.936 A:middle
-of animations and switching
 
 00:49:00.936 --> 00:49:02.356 A:middle
 between different
@@ -3957,10 +3813,6 @@ some extra memory.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.686 --> 00:50:01.416 A:middle
-that we needed to free
-some extra memory.
 
 00:50:02.366 --> 00:50:05.176 A:middle
 But they only notified once we
@@ -4054,10 +3906,6 @@ to take down first.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.116 --> 00:51:01.256 A:middle
-which regions are best
-to take down first.
-
 00:51:02.516 --> 00:51:05.816 A:middle
 Unlike low memory notifications,
 purgeable memory is designed
@@ -4142,10 +3990,6 @@ techniques now work together
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:57.816 --> 00:52:00.796 A:middle
-So all this memory management
-techniques now work together
 
 00:52:00.796 --> 00:52:04.326 A:middle
 in Mavericks to give us the
@@ -4237,10 +4081,6 @@ that content quickly enough
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:59.646 --> 00:53:02.056 A:middle
-as your application can render
-that content quickly enough
-
 00:53:02.506 --> 00:53:04.786 A:middle
 if we never block them in main
 thread for long and interfere
@@ -4328,10 +4168,6 @@ takes effect automatically
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:58.716 --> 00:54:01.286 A:middle
-Responsive scrolling
-takes effect automatically
-
 00:54:01.666 --> 00:54:04.456 A:middle
 for most applications linked
 against our latest tested case.
@@ -4415,10 +4251,6 @@ two frequent timers and one
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.176 --> 00:55:01.866 A:middle
-We found that unnecessary, in
-two frequent timers and one
 
 00:55:01.866 --> 00:55:03.006 A:middle
 of the largest sources
@@ -4517,10 +4349,6 @@ being backgrounded.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:59.746 --> 00:56:01.466 A:middle
-if the application is
-being backgrounded.
-
 00:56:01.826 --> 00:56:03.576 A:middle
 For example, a long
 running file export.
@@ -4601,10 +4429,6 @@ so we get a good look.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:56:58.176 --> 00:57:01.496 A:middle
-I'm going to zoom in
-so we get a good look.
-
 00:57:01.696 --> 00:57:03.626 A:middle
 Now, in the debug navigator,
 
@@ -4678,10 +4502,6 @@ players is provided by a server.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:57:56.606 --> 00:58:02.206 A:middle
-Now, the position of the other
-players is provided by a server.
-
 00:58:02.776 --> 00:58:04.426 A:middle
 There are obviously
 aren't any players yet,
@@ -4751,10 +4571,6 @@ of power usage.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:58:57.856 --> 00:59:01.996 A:middle
-and various aspects
-of power usage.
-
 00:59:02.456 --> 00:59:05.996 A:middle
 Each of which has a button
 that allows you to analyze
@@ -4822,9 +4638,6 @@ There, problem solved.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:59:59.506 --> 01:00:01.416 A:middle
-There, problem solved.
-
 01:00:02.091 --> 01:00:04.091 A:middle
 [ Laughter ]
 
@@ -4889,10 +4702,6 @@ my app is pulling the server
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:00:57.436 --> 01:01:01.596 A:middle
-I've gone with here is that
-my app is pulling the server
 
 01:01:02.046 --> 01:01:06.846 A:middle
 for user updates instead of
@@ -4962,10 +4771,6 @@ our new margin monitor support
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:01:57.176 --> 01:02:00.756 A:middle
-like to cover starting with
-our new margin monitor support
 
 01:02:01.226 --> 01:02:04.486 A:middle
 which makes using [inaudible]
@@ -5066,10 +4871,6 @@ Mavericks is the TVs can now act
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:02:57.246 --> 01:03:01.866 A:middle
-Another exciting change in
-Mavericks is the TVs can now act
-
 01:03:01.866 --> 01:03:04.066 A:middle
 as fully independent
 displays via AirPlay.
@@ -5160,10 +4961,6 @@ through the Mac App Store
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:03:58.386 --> 01:04:00.826 A:middle
-it's available to apps shipping
-through the Mac App Store
-
 01:04:00.936 --> 01:04:03.206 A:middle
 that declare the use of
 Map Kit as a capability.
@@ -5245,10 +5042,6 @@ and really put the focus
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:04:58.706 --> 01:05:01.716 A:middle
-It works to minimize clatter
-and really put the focus
-
 01:05:01.756 --> 01:05:04.606 A:middle
 on the controls and
 your content.
@@ -5329,10 +5122,6 @@ previous release seen here
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:05:57.486 --> 01:06:00.576 A:middle
-Comparing a new UI to the
-previous release seen here
-
 01:06:00.576 --> 01:06:02.686 A:middle
 on the left, you can
 see that we were able
@@ -5409,10 +5198,6 @@ separate window using all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:06:58.076 --> 01:07:01.406 A:middle
-Documentation is now its own
-separate window using all
 
 01:07:01.406 --> 01:07:02.396 A:middle
 of the new design elements.
@@ -5494,9 +5279,6 @@ And as part of this transition,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:07:59.796 --> 01:08:01.036 A:middle
-And as part of this transition,
 
 01:08:01.316 --> 01:08:03.786 A:middle
 we have some awesome performance
@@ -5655,10 +5437,6 @@ you'll get all the information
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:09:58.616 --> 01:10:01.406 A:middle
-to your application and
-you'll get all the information
-
 01:10:01.596 --> 01:10:02.606 A:middle
 you need.
 
@@ -5734,10 +5512,6 @@ with your application
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:10:58.926 --> 01:11:00.526 A:middle
-to be interactive
-with your application
 
 01:11:00.946 --> 01:11:04.976 A:middle
 and see things you might
@@ -6068,9 +5842,6 @@ to run just this one test.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:14:59.516 --> 01:15:05.646 A:middle
-[ Applause ]
-
 01:15:06.146 --> 01:15:07.466 A:middle
 Actually, this feature
 is even cooler.
@@ -6162,10 +5933,6 @@ clarify a second.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:15:59.226 --> 01:16:00.416 A:middle
-Actually, I want to
-clarify a second.
 
 01:16:00.496 --> 01:16:01.856 A:middle
 I said that's a picture
@@ -6360,10 +6127,6 @@ new categories.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:17:59.286 --> 01:18:00.636 A:middle
-that there are two
-new categories.
-
 01:18:01.066 --> 01:18:03.446 A:middle
 Test classes and test colors.
 
@@ -6462,10 +6225,6 @@ features in Xcode 5.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:18:59.356 --> 01:19:01.526 A:middle
-of the great new testing
-features in Xcode 5.
-
 01:19:02.246 --> 01:19:02.946 A:middle
 Let's go back to slides.
 
@@ -6538,10 +6297,6 @@ you've had in the area
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:19:59.716 --> 01:20:02.486 A:middle
-the number one request
-you've had in the area
 
 01:20:02.486 --> 01:20:05.066 A:middle
 of testing is better
@@ -6623,9 +6378,6 @@ for all of your workflows.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:20:59.436 --> 01:21:02.826 A:middle
-for all of your workflows.
-
 01:21:02.826 --> 01:21:03.106 A:middle
 Apple IDs.
 
@@ -6700,9 +6452,6 @@ So, with each platform release,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:21:59.616 --> 01:22:02.126 A:middle
-So, with each platform release,
 
 01:22:02.806 --> 01:22:05.486 A:middle
 we give you guys amazing new
@@ -6782,10 +6531,6 @@ all of this work for you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:22:59.866 --> 01:23:03.136 A:middle
-and frankly let Xcode do
-all of this work for you.
 
 01:23:03.696 --> 01:23:08.246 A:middle
 We wanted to provide also some
@@ -6870,10 +6615,6 @@ inside the project workflow.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:23:59.586 --> 01:24:02.106 A:middle
-and merging right from
-inside the project workflow.
 
 01:24:03.436 --> 01:24:06.166 A:middle
 And when you want more detailed
@@ -7024,10 +6765,6 @@ And to get to what the final
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:25:58.526 --> 01:26:00.666 A:middle
-And to get to what the final
--- the slide finally says here,
 
 01:26:00.666 --> 01:26:02.976 A:middle
 I'm going to show you a
@@ -7189,10 +6926,6 @@ tests that passed.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:27:58.956 --> 01:28:00.986 A:middle
-The green are all the
-tests that passed.
-
 01:28:00.986 --> 01:28:03.106 A:middle
 But it looks like we had some
 failures introduced recently.
@@ -7286,10 +7019,6 @@ that shows me my test history.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:28:56.796 --> 01:29:00.106 A:middle
-Across the top is a timeline
-that shows me my test history.
 
 01:29:00.666 --> 01:29:03.026 A:middle
 You can see my tests have
@@ -7386,10 +7115,6 @@ be to look at the integration
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:29:59.116 --> 01:30:02.286 A:middle
-Another option though would
-be to look at the integration
-
 01:30:02.316 --> 01:30:05.006 A:middle
 and see who made the changes
 and get them to fix it.
@@ -7474,10 +7199,6 @@ and up it was Max
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:30:59.856 --> 01:31:02.126 A:middle
-who made the change
-and up it was Max
 
 01:31:02.126 --> 01:31:05.036 A:middle
 who made this change,
@@ -7653,10 +7374,6 @@ box enabled
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:32:59.536 --> 01:33:00.866 A:middle
-so I leave this check
-box enabled
-
 01:33:01.996 --> 01:33:04.426 A:middle
 and we'll click Create Bot.
 
@@ -7747,10 +7464,6 @@ and fun display and we've done
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:33:59.536 --> 01:34:02.986 A:middle
-to provide a really interactive
-and fun display and we've done
-
 01:34:02.986 --> 01:34:05.076 A:middle
 that in the form of Scoreboard.
 
@@ -7834,10 +7547,6 @@ Integration with Xcode 5.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-01:34:57.836 --> 01:35:00.136 A:middle
-And that's Continuous
-Integration with Xcode 5.
-
 01:35:01.516 --> 01:35:10.256 A:middle
 [ Applause ]
 
@@ -7902,10 +7611,6 @@ features is a continuous
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:35:59.046 --> 01:36:01.136 A:middle
-The combination of these
-features is a continuous
 
 01:36:01.136 --> 01:36:03.896 A:middle
 integration system
@@ -7975,10 +7680,6 @@ going to make developer previews
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:36:57.846 --> 01:37:00.406 A:middle
-To get you started, you're
-going to make developer previews
 
 01:37:00.406 --> 01:37:02.696 A:middle
 of all these products
@@ -8073,9 +7774,6 @@ I'd see you around this week.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:37:58.016 --> 01:38:00.016 A:middle
-[ Applause ]
 
 01:38:00.016 --> 01:38:09.716 A:middle
 [ Silence ]

--- a/2013/102.srt
+++ b/2013/102.srt
@@ -60,10 +60,6 @@ here to celebrate excellence
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.736 --> 00:01:02.476 A:middle
-&gt;&gt; You know, today we are
-here to celebrate excellence
-
 00:01:02.476 --> 00:01:05.766 A:middle
 in design and innovation
 on iOS and OS X.
@@ -134,10 +130,6 @@ thirteenth year doing the Design
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.266 --> 00:02:00.246 A:middle
-&gt;&gt; You know, this is my
-thirteenth year doing the Design
 
 00:02:00.246 --> 00:02:03.866 A:middle
 Awards and we have changed
@@ -219,10 +211,6 @@ to great apps.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.446 --> 00:03:01.166 A:middle
-and again and again
-to great apps.
-
 00:03:02.896 --> 00:03:05.596 A:middle
 &gt;&gt; Each winner today will
 receive an amazing set
@@ -292,9 +280,6 @@ So that is very cool.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:59.556 --> 00:04:01.176 A:middle
-So that is very cool.
 
 00:04:01.176 --> 00:04:04.646 A:middle
 &gt;&gt; So let's get on
@@ -380,10 +365,6 @@ don't to help you focus
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.966 --> 00:05:01.776 A:middle
-out of your way when you
-don't to help you focus
 
 00:05:01.776 --> 00:05:03.256 A:middle
 on completing important tasks.
@@ -497,10 +478,6 @@ mosaic.io by Ishaan Gulrajani,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.466 --> 00:06:01.416 A:middle
-Our other student winner is
-mosaic.io by Ishaan Gulrajani,
-
 00:06:01.416 --> 00:06:02.796 A:middle
 Alex List, and Zain Shah.
 
@@ -582,10 +559,6 @@ part of the image it draws.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.756 --> 00:07:01.986 A:middle
-and which determine which
-part of the image it draws.
 
 00:07:02.306 --> 00:07:03.026 A:middle
 So watch this.
@@ -671,9 +644,6 @@ to almost every aspect
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.876 --> 00:08:00.046 A:middle
-to almost every aspect
-
 00:08:00.046 --> 00:08:02.866 A:middle
 of the product including some
 really compelling integration
@@ -753,10 +723,6 @@ so they can add on a lot
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.556 --> 00:09:02.356 A:middle
-extensive support for plug-ins
-so they can add on a lot
 
 00:09:02.356 --> 00:09:05.936 A:middle
 of extra functionality; and they
@@ -971,9 +937,6 @@ by the World Wildlife Fund.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:57.016 --> 00:12:01.000 A:middle
-[ Music ]
-
 00:12:01.636 --> 00:12:02.136 A:middle
 &gt;&gt; Congratulations.
 
@@ -1054,10 +1017,6 @@ OpenGL ES, and so much more.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.836 --> 00:13:01.986 A:middle
-Core Location support,
-OpenGL ES, and so much more.
-
 00:13:02.056 --> 00:13:05.536 A:middle
 This is a fantastic app,
 and it's tailored for
@@ -1126,9 +1085,6 @@ iPhone, iPad, and the web.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.036 --> 00:14:00.146 A:middle
-iPhone, iPad, and the web.
 
 00:14:01.676 --> 00:14:04.976 A:middle
 &gt;&gt; The folks at Evernote
@@ -1210,10 +1166,6 @@ Mac iPad and iPhone versions
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.266 --> 00:15:01.036 A:middle
-this is on the Mac -- and with
-Mac iPad and iPhone versions
 
 00:15:01.036 --> 00:15:04.436 A:middle
 of the app, and even
@@ -1452,9 +1404,6 @@ Thank you.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.516 --> 00:18:00.466 A:middle
-[ Music ]
-
 00:18:00.966 --> 00:18:01.726 A:middle
 And that's Yahoo!
 
@@ -1614,9 +1563,6 @@ Yeah.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.626 --> 00:20:00.216 A:middle
-&gt;&gt; Artists love this app.
-
 00:20:00.376 --> 00:20:02.716 A:middle
 It comes packed with 48
 brushes with everything
@@ -1694,10 +1640,6 @@ through In App Purchase.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.686 --> 00:21:02.196 A:middle
-or pencils or tools
-through In App Purchase.
-
 00:21:02.366 --> 00:21:04.866 A:middle
 And the App does this
 really innovative preview
@@ -1770,9 +1712,6 @@ Raiders by Atypical Games.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:55.016 --> 00:22:03.000 A:middle
-[ Music ]
 
 00:22:03.786 --> 00:22:06.136 A:middle
 &gt;&gt; You're first,
@@ -2032,9 +1971,6 @@ Keller, and Puck Meerburg.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:52.516 --> 00:25:00.516 A:middle
-[ Applause ]
-
 00:25:01.016 --> 00:25:11.000 A:middle
 [ Music ]
 
@@ -2122,10 +2058,6 @@ his friends, his family,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.496 --> 00:26:01.936 A:middle
-his education, his experiences,
-his friends, his family,
-
 00:26:01.936 --> 00:26:04.966 A:middle
 and etc. You tap on each
 one of these, they expand
@@ -2210,10 +2142,6 @@ and his interests.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.166 --> 00:27:01.006 A:middle
-his school, his sports,
-and his interests.
-
 00:27:01.006 --> 00:27:03.966 A:middle
 And we picked it because it
 had hockey I think is one
@@ -2292,10 +2220,6 @@ seeing behind me is his WWDC
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.416 --> 00:28:02.426 A:middle
-I mean, the app that you're
-seeing behind me is his WWDC
 
 00:28:02.426 --> 00:28:06.316 A:middle
 submission called WWDC, and
@@ -2394,10 +2318,6 @@ and just help them out.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:56.006 --> 00:29:01.056 A:middle
-learn from them or something,
-and just help them out.
-
 00:29:01.056 --> 00:29:03.766 A:middle
 And also there's the
 other ADA winners as well.
@@ -2469,7 +2389,4 @@ We'll see you next year.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:48.516 --> 00:30:03.900 A:middle
-[ Applause ]
 

--- a/2013/109.srt
+++ b/2013/109.srt
@@ -7,15 +7,6 @@ X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:17.516 --> 00:02:19.516 A:middle
-[ Music ]
-
-WEBVTT
-X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:00:17.516 --> 00:02:19.516 A:middle
-[ Music ]
-
 00:02:20.016 --> 00:02:24.000 A:middle
 [ Applause ]
 
@@ -61,10 +52,6 @@ visual effects companies,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:56.066 --> 00:03:00.176 A:middle
-and technologies out of
-visual effects companies,
 
 00:03:00.686 --> 00:03:03.916 A:middle
 out of animation companies,
@@ -141,10 +128,6 @@ off as a model, as a mesh.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:56.666 --> 00:04:01.716 A:middle
-like Gollum here, he starts
-off as a model, as a mesh.
-
 00:04:01.966 --> 00:04:04.766 A:middle
 And that model gives
 you the overall shape.
@@ -218,9 +201,6 @@ and have it full screen?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.336 --> 00:05:00.006 A:middle
-and have it full screen?
 
 00:05:00.996 --> 00:05:05.286 A:middle
 In a game, you might put,
@@ -304,10 +284,6 @@ the artists down.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.296 --> 00:06:00.606 A:middle
-This was slowing
-the artists down.
-
 00:06:00.896 --> 00:06:03.656 A:middle
 The one thing that artists
 love to do is paint.
@@ -384,10 +360,6 @@ a day wasn't, you know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.236 --> 00:07:00.186 A:middle
-And if releasing three times
-a day wasn't, you know,
 
 00:07:00.256 --> 00:07:02.636 A:middle
 enough work, my brand
@@ -471,9 +443,6 @@ this guy, again, for The Hobbit.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.596 --> 00:08:03.126 A:middle
-this guy, again, for The Hobbit.
 
 00:08:03.316 --> 00:08:08.336 A:middle
 In 2010, Weta Digital and The
@@ -634,10 +603,6 @@ Scott went out one weekend
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.176 --> 00:10:01.656 A:middle
-So what this really means is
-Scott went out one weekend
-
 00:10:01.656 --> 00:10:04.116 A:middle
 and rented an industrial
 laser scanner
@@ -716,10 +681,6 @@ is you build a set,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.226 --> 00:11:01.756 A:middle
-what you normally do
-is you build a set,
 
 00:11:02.446 --> 00:11:05.566 A:middle
 you put some cameras on the set,
@@ -894,9 +855,6 @@ to do for a while anyway.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.876 --> 00:13:00.866 A:middle
-to do for a while anyway.
-
 00:13:01.106 --> 00:13:03.476 A:middle
 It really gives us a
 lot of benefits in terms
@@ -975,10 +933,6 @@ with multiple GPUs in mind.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:56.496 --> 00:14:00.886 A:middle
-We originally designed MARI
-with multiple GPUs in mind.
 
 00:14:01.686 --> 00:14:05.486 A:middle
 For me it makes so much sense
@@ -1060,10 +1014,6 @@ customers to help them design
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:56.786 --> 00:15:00.356 A:middle
-with our most demanding
-customers to help them design
-
 00:15:00.356 --> 00:15:04.246 A:middle
 and build systems that
 will meet their, you know,
@@ -1144,9 +1094,6 @@ to put together new techniques
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.576 --> 00:16:00.196 A:middle
-to put together new techniques
 
 00:16:00.196 --> 00:16:02.836 A:middle
 for creating incredibly
@@ -1300,10 +1247,6 @@ there are a lot
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.296 --> 00:18:00.466 A:middle
-You saw on the trailer,
-there are a lot
-
 00:18:00.466 --> 00:18:02.946 A:middle
 of different characters
 in this upcoming film
@@ -1392,10 +1335,6 @@ by our production designer,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.416 --> 00:19:02.376 A:middle
-With Mike Wazowski, this image
-by our production designer,
 
 00:19:02.376 --> 00:19:05.296 A:middle
 Ricky, is this great
@@ -1494,10 +1433,6 @@ your horns get longer.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.836 --> 00:20:00.946 A:middle
-obviously as you get older,
-your horns get longer.
-
 00:20:01.826 --> 00:20:04.756 A:middle
 And with Mike, you know,
 you've got this great detail
@@ -1591,9 +1526,6 @@ I doubt that very much.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.076 --> 00:21:01.096 A:middle
-I doubt that very much.
-
 00:21:03.236 --> 00:21:05.846 A:middle
 &gt;&gt; All right, so that
 is Dean Hardscrabble
@@ -1682,10 +1614,6 @@ that is scary.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.386 --> 00:22:01.316 A:middle
-that you see is "Wow,
-that is scary.
-
 00:22:01.316 --> 00:22:03.966 A:middle
 I'm going to"-- you know, if you
 see that you want to run away.
@@ -1767,10 +1695,6 @@ wanted to stay true to that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.736 --> 00:23:02.696 A:middle
-And with the next film, we
-wanted to stay true to that.
 
 00:23:03.266 --> 00:23:06.476 A:middle
 But with Hardscrabble, we needed
@@ -1862,10 +1786,6 @@ needs to look
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.006 --> 00:24:00.726 A:middle
-This is how the character
-needs to look
 
 00:24:00.726 --> 00:24:03.016 A:middle
 in color and with specularity.
@@ -1964,10 +1884,6 @@ were thought about.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.696 --> 00:25:00.836 A:middle
-All these things
-were thought about.
-
 00:25:01.606 --> 00:25:05.756 A:middle
 But with this photography-- with
 these images, I wasn't supposed
@@ -2050,10 +1966,6 @@ Mac for about six weeks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.756 --> 00:26:01.446 A:middle
-has only been on the
-Mac for about six weeks.
 
 00:26:01.446 --> 00:26:03.736 A:middle
 So, what could possibly
@@ -2155,9 +2067,6 @@ of that variation first.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.216 --> 00:27:00.486 A:middle
-of that variation first.
 
 00:27:00.856 --> 00:27:03.376 A:middle
 And I'm going to be a little
@@ -2333,10 +2242,6 @@ this feels very liquid.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.496 --> 00:29:02.466 A:middle
-Now, you'll notice that
-this feels very liquid.
-
 00:29:02.466 --> 00:29:03.896 A:middle
 It feels very smooth, right?
 
@@ -2439,10 +2344,6 @@ has variety to it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.946 --> 00:30:01.966 A:middle
-Every-- all skin
-has variety to it.
-
 00:30:01.966 --> 00:30:03.596 A:middle
 It has mottling and
 freckles and--
@@ -2515,10 +2416,6 @@ little bit of darkening.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.326 --> 00:31:00.356 A:middle
-Add some freckles, a
-little bit of darkening.
 
 00:31:00.666 --> 00:31:01.966 A:middle
 And I can put some stuff on
@@ -2615,10 +2512,6 @@ offended too many people.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.676 --> 00:32:00.276 A:middle
-I hope I haven't
-offended too many people.
 
 00:32:01.916 --> 00:32:04.956 A:middle
 Anyway, so I'm OK with
@@ -2810,10 +2703,6 @@ painted makeup before, you know.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.666 --> 00:34:00.496 A:middle
-But I told her, "Honey, I
-painted makeup before, you know.
 
 00:34:00.496 --> 00:34:02.226 A:middle
 I do it for work.
@@ -3017,10 +2906,6 @@ how I would do that over here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.776 --> 00:36:01.686 A:middle
-And so, I'm going to show you
-how I would do that over here.
-
 00:36:04.676 --> 00:36:06.986 A:middle
 So, here we're starting with a
 color and I'm going to switch
@@ -3095,10 +2980,6 @@ where the skin would fold
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.376 --> 00:37:01.216 A:middle
-All of them flow exactly
-where the skin would fold
 
 00:37:01.216 --> 00:37:02.366 A:middle
 and compress over time.
@@ -3291,10 +3172,6 @@ and it's starting to feel good
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.196 --> 00:39:02.706 A:middle
-Now, so we've got these shapes
-and it's starting to feel good
-
 00:39:02.706 --> 00:39:04.466 A:middle
 but it's still in the realm
 
@@ -3369,10 +3246,6 @@ great crow's feet
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.366 --> 00:40:02.936 A:middle
-I'm going to get some
-great crow's feet
 
 00:40:02.936 --> 00:40:03.556 A:middle
 on the side of her face.
@@ -3457,10 +3330,6 @@ it will affect the final look
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:58.106 --> 00:41:00.276 A:middle
-And we can start to see how
-it will affect the final look
 
 00:41:00.276 --> 00:41:00.836 A:middle
 of the character.
@@ -3562,10 +3431,6 @@ anywhere from two minutes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.996 --> 00:42:01.856 A:middle
-and that render would take
-anywhere from two minutes
-
 00:42:01.856 --> 00:42:05.016 A:middle
 for a really kind of
 inexpensive render
@@ -3663,10 +3528,6 @@ anywhere from 2 minutes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.366 --> 00:43:02.276 A:middle
-And instead of waiting for
-anywhere from 2 minutes
-
 00:43:02.306 --> 00:43:06.356 A:middle
 to 12 hours, we can see that
 at 60 frames per second.
@@ -3749,10 +3610,6 @@ pixels, all right?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:56.586 --> 00:44:00.106 A:middle
-about 2.4 billion
-pixels, all right?
 
 00:44:00.666 --> 00:44:02.146 A:middle
 That is a vast amount of data.
@@ -3852,10 +3709,6 @@ real advantage comes in.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:57.866 --> 00:45:00.516 A:middle
-here's where the actual
-real advantage comes in.
-
 00:45:01.696 --> 00:45:04.486 A:middle
 Working at an animation studio,
 you paint all these details
@@ -3954,10 +3807,6 @@ elephant texture again.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.636 --> 00:46:01.876 A:middle
-I'm going to pull in my
-elephant texture again.
-
 00:46:02.776 --> 00:46:05.836 A:middle
 And I'm going to
 grab these wrinkles.
@@ -4034,10 +3883,6 @@ about 10 gigabytes worth
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:57.346 --> 00:47:00.636 A:middle
-So, this character represents
-about 10 gigabytes worth
 
 00:47:00.636 --> 00:47:02.606 A:middle
 of image data but we
@@ -4132,10 +3977,6 @@ such a privilege to work
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.096 --> 00:48:01.266 A:middle
-And I've been so-- it's been
-such a privilege to work
 
 00:48:01.266 --> 00:48:02.176 A:middle
 on Monsters University.
@@ -4333,9 +4174,6 @@ My Aunt Phyllis.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.146 --> 00:50:01.406 A:middle
-My Aunt Phyllis.
 
 00:50:01.496 --> 00:50:01.816 A:middle
 In the morning.

--- a/2013/200.srt
+++ b/2013/200.srt
@@ -163,10 +163,6 @@ all of the features
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.806 --> 00:02:00.836 A:middle
-and deaf can use
-all of the features
-
 00:02:00.836 --> 00:02:03.716 A:middle
 and all the functionality of
 OS X to its fullest potential.
@@ -253,10 +249,6 @@ disabilities and developers
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.916 --> 00:03:00.336 A:middle
-for both users with
-disabilities and developers
 
 00:03:00.336 --> 00:03:03.166 A:middle
 who are developing to help
@@ -544,10 +536,6 @@ time today to go into the nuts
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.346 --> 00:06:02.126 A:middle
-Now, we're not going to have
-time today to go into the nuts
-
 00:06:02.126 --> 00:06:04.146 A:middle
 and bolts specifically
 of closed captioning.
@@ -735,9 +723,6 @@ and scrolling capabilities.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.726 --> 00:08:00.136 A:middle
-and scrolling capabilities.
-
 00:08:00.136 --> 00:08:03.656 A:middle
 The case with the Trackpad, you
 also have Multi-Touch gestures.
@@ -821,9 +806,6 @@ You need to press your Switch
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.936 --> 00:09:01.376 A:middle
-You need to press your Switch
 
 00:09:01.376 --> 00:09:02.816 A:middle
 when the appropriate
@@ -927,10 +909,6 @@ full functionality of the mouse.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.146 --> 00:10:00.806 A:middle
-But going beyond that, we have
-full functionality of the mouse.
-
 00:10:01.476 --> 00:10:03.636 A:middle
 And this problem
 alone is really hard.
@@ -1019,10 +997,6 @@ even do click and hold
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.566 --> 00:11:00.526 A:middle
-a right click, they can
-even do click and hold
 
 00:11:00.526 --> 00:11:02.046 A:middle
 to do Drag and Drop operations.
@@ -1116,10 +1090,6 @@ insert a Fade to Black,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.596 --> 00:12:01.276 A:middle
-things like insert a Crossfade,
-insert a Fade to Black,
 
 00:12:01.376 --> 00:12:03.226 A:middle
 or trim this Clip
@@ -1215,10 +1185,6 @@ of the extended functionality
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.716 --> 00:13:02.496 A:middle
-Users buy our products because
-of the extended functionality
-
 00:13:02.496 --> 00:13:05.036 A:middle
 and integration that
 your apps provide.
@@ -1301,10 +1267,6 @@ that presents lots of pretty UIs
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.616 --> 00:14:03.526 A:middle
-First, there is your application
-that presents lots of pretty UIs
-
 00:14:03.866 --> 00:14:06.466 A:middle
 and fancy cool features.
 
@@ -1369,10 +1331,6 @@ every UI, like this Play button,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.776 --> 00:15:03.476 A:middle
-And the way it works is that
-every UI, like this Play button,
 
 00:15:04.046 --> 00:15:08.576 A:middle
 is conveying its accessibility
@@ -1441,10 +1399,6 @@ to get attributes in such.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.996 --> 00:16:02.616 A:middle
-And then there's methods
-to get attributes in such.
-
 00:16:03.306 --> 00:16:08.186 A:middle
 And there are methods to
 perform actions [inaudible] UIs
@@ -1504,10 +1458,6 @@ Accessibility Inspector
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.076 --> 00:17:03.406 A:middle
-So this tool is called
-Accessibility Inspector
 
 00:17:03.406 --> 00:17:06.526 A:middle
 and the good thing is, now,
@@ -1571,10 +1521,6 @@ more examples for you here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:56.716 --> 00:18:01.036 A:middle
-So this year, we added four
-more examples for you here.
-
 00:18:03.346 --> 00:18:07.746 A:middle
 Now, what I want to do is use
 Inspector, take my mouse over,
@@ -1629,9 +1575,6 @@ to support for your app.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:55.516 --> 00:19:05.296 A:middle
-[ Background Noise ]
 
 00:19:05.796 --> 00:19:07.276 A:middle
 So now, I'm going to tell you
@@ -1700,10 +1643,6 @@ have altered the behavior
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.826 --> 00:20:02.826 A:middle
-But we noticed that developer
-have altered the behavior
 
 00:20:03.106 --> 00:20:07.326 A:middle
 so that you could select
@@ -1894,10 +1833,6 @@ was user info.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.586 --> 00:23:01.436 A:middle
-This post notification
-was user info.
-
 00:23:01.756 --> 00:23:04.166 A:middle
 API takes in additional
 parameter
@@ -1954,10 +1889,6 @@ those API support to solve that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.666 --> 00:24:05.566 A:middle
-So let's see how you can add
-those API support to solve that.
-
 00:24:09.416 --> 00:24:12.576 A:middle
 I have the Accessibility
 UI example project.
@@ -2009,10 +1940,6 @@ No for Accessibility is Ignored.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:54.706 --> 00:25:00.536 A:middle
-So I have to explicitly return
-No for Accessibility is Ignored.
 
 00:25:02.136 --> 00:25:06.546 A:middle
 So once this element is
@@ -2076,10 +2003,6 @@ to perform those actions,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:57.306 --> 00:26:02.726 A:middle
-Then when you're asked
-to perform those actions,
 
 00:26:03.726 --> 00:26:07.826 A:middle
 you could go ahead and
@@ -2228,10 +2151,6 @@ and select that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.136 --> 00:28:01.546 A:middle
-&gt;&gt; I'll go ahead
-and select that.
-
 00:28:01.776 --> 00:28:03.456 A:middle
 &gt;&gt; Two items available
 in the Update Items Menu.
@@ -2312,10 +2231,6 @@ Announcement.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.136 --> 00:29:01.736 A:middle
-about is Accessibility
-Announcement.
-
 00:29:02.666 --> 00:29:04.956 A:middle
 In your app, there may
 be times where you want
@@ -2383,10 +2298,6 @@ determine to speak it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:57.766 --> 00:30:01.356 A:middle
-VoiceOver can then either
-determine to speak it,
-
 00:30:01.356 --> 00:30:03.586 A:middle
 output to Braille, or
 do something about it.
@@ -2453,10 +2364,6 @@ sensitive patient informations,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:57.146 --> 00:31:00.786 A:middle
-that display valuable
-sensitive patient informations,
-
 00:31:01.576 --> 00:31:03.436 A:middle
 what I'm going to
 say next is for you.
@@ -2522,10 +2429,6 @@ Contents Protected Content API.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:56.416 --> 00:32:00.186 A:middle
-This is called the Set Make
-Contents Protected Content API.
 
 00:32:01.406 --> 00:32:03.126 A:middle
 So to see how these works,
@@ -2649,10 +2552,6 @@ subclass of the NSTextField,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.626 --> 00:34:03.496 A:middle
-In there, I just have a
-subclass of the NSTextField,
-
 00:34:03.746 --> 00:34:06.576 A:middle
 so that displayed the content.
 
@@ -2714,10 +2613,6 @@ for the text field cell,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.176 --> 00:35:02.196 A:middle
-that app already supports
-for the text field cell,
-
 00:35:03.416 --> 00:35:06.256 A:middle
 we're also going to add
 this new Contents Protected
@@ -2775,10 +2670,6 @@ application that wants
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:54.486 --> 00:36:00.136 A:middle
-So in OS X, if any
-application that wants
 
 00:36:00.406 --> 00:36:03.376 A:middle
 to use the end-user's
@@ -2842,10 +2733,6 @@ for you to do just that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.306 --> 00:37:01.896 A:middle
-So we created an API
-for you to do just that.
-
 00:37:02.446 --> 00:37:06.526 A:middle
 It's called the AX is Trusted,
 Process Trusted with Options
@@ -2908,9 +2795,6 @@ you can listen to that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.876 --> 00:38:00.766 A:middle
-you can listen to that.
 
 00:38:01.016 --> 00:38:05.926 A:middle
 So to recap, Apple is
@@ -2976,10 +2860,6 @@ online for documentations.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.106 --> 00:39:03.086 A:middle
-previous WWDC videos, or look
-online for documentations.
 
 00:39:03.596 --> 00:39:07.886 A:middle
 Today, I have also

--- a/2013/201.srt
+++ b/2013/201.srt
@@ -73,9 +73,6 @@ And the design
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.916 --> 00:01:00.446 A:middle
-And the design
-
 00:01:00.446 --> 00:01:04.626 A:middle
 of the application should make
 it clear how user uses it.
@@ -152,9 +149,6 @@ that are really engaging.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.886 --> 00:02:00.996 A:middle
-that are really engaging.
-
 00:02:01.606 --> 00:02:07.196 A:middle
 So let's move on and talk about
 the changes we've made in UIKit
@@ -217,10 +211,6 @@ changes in the fonts
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.046 --> 00:03:02.676 A:middle
-and we've made extensive
-changes in the fonts
 
 00:03:03.206 --> 00:03:04.786 A:middle
 to make them beautiful
@@ -380,10 +370,6 @@ see the message list
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.796 --> 00:05:01.336 A:middle
-and on the left you
-see the message list
-
 00:05:01.486 --> 00:05:02.876 A:middle
 and on the right you
 see the message body.
@@ -529,10 +515,6 @@ to variance that have looser
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:56.306 --> 00:07:00.606 A:middle
-From Bold and Italic variance,
-to variance that have looser
-
 00:07:00.606 --> 00:07:03.336 A:middle
 or tighter line letting as well
 as the wide variety of others.
@@ -597,10 +579,6 @@ Letterpress for a second.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:56.776 --> 00:08:02.666 A:middle
-So let's talk about
-Letterpress for a second.
 
 00:08:04.126 --> 00:08:06.796 A:middle
 Letterpress is a form of
@@ -681,10 +659,6 @@ in the OS and iOS 7.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.396 --> 00:09:01.776 A:middle
-and ligatures everywhere
-in the OS and iOS 7.
-
 00:09:03.046 --> 00:09:06.096 A:middle
 And so text which rendered like
 this in prior version of iOS,
@@ -758,10 +732,6 @@ built on top of Core Text.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.146 --> 00:10:03.276 A:middle
-high level text API that's
-built on top of Core Text.
-
 00:10:03.686 --> 00:10:08.816 A:middle
 And we've rewritten all of our
 text related controls in UIKit
@@ -827,10 +797,6 @@ it to these sessions and find
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:56.836 --> 00:11:00.506 A:middle
-I encourage you all to make
-it to these sessions and find
 
 00:11:00.506 --> 00:11:01.696 A:middle
 out about Textkit and find
@@ -916,10 +882,6 @@ scrolling text view vertically
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.726 --> 00:12:02.026 A:middle
-we've also expanded the main
-scrolling text view vertically
 
 00:12:02.296 --> 00:12:05.466 A:middle
 underneath the bars at the top
@@ -1078,10 +1040,6 @@ that the header
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.946 --> 00:14:01.706 A:middle
-we want to make sure
-that the header
-
 00:14:01.706 --> 00:14:05.196 A:middle
 of the Mail Message still
 appears below the navigation
@@ -1147,10 +1105,6 @@ the edges of the screen along
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:55.626 --> 00:15:00.226 A:middle
-for Layout, which describes
-the edges of the screen along
 
 00:15:00.226 --> 00:15:01.796 A:middle
 which we're going
@@ -1234,10 +1188,6 @@ describe where those features
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:57.446 --> 00:16:01.466 A:middle
-and a bottom layout guide that
-describe where those features
-
 00:16:01.466 --> 00:16:02.806 A:middle
 at the top and bottom
 of the screen
@@ -1319,10 +1269,6 @@ style and visibility
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.736 --> 00:17:02.266 A:middle
-to specify the correct
-style and visibility
 
 00:17:02.266 --> 00:17:04.036 A:middle
 for the status bar
@@ -1481,10 +1427,6 @@ should recognize simultaneously
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.896 --> 00:19:02.886 A:middle
-of your gesture recognizers
-should recognize simultaneously
-
 00:19:03.306 --> 00:19:06.756 A:middle
 with this interactive pop, you
 can do that using this API.
@@ -1549,10 +1491,6 @@ to provide it to all of you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.946 --> 00:20:00.896 A:middle
-And we're actually going
-to provide it to all of you
 
 00:20:01.306 --> 00:20:03.826 A:middle
 in the form of a new
@@ -1629,10 +1567,6 @@ the collection's user interface.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.856 --> 00:21:03.146 A:middle
-the year's user interface, and
-the collection's user interface.
 
 00:21:04.386 --> 00:21:06.526 A:middle
 And I just want to run
@@ -1713,10 +1647,6 @@ for both View Controllers.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.456 --> 00:22:02.806 A:middle
-that same Collection View
-for both View Controllers.
 
 00:22:03.796 --> 00:22:05.676 A:middle
 And it's going to
@@ -1801,10 +1731,6 @@ that things are still clear,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.886 --> 00:23:03.136 A:middle
-But in order to make sure
-that things are still clear,
-
 00:23:04.636 --> 00:23:09.166 A:middle
 we're using color to signify
 interactivity and selection.
@@ -1879,10 +1805,6 @@ all the way up to UIView.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.826 --> 00:24:01.356 A:middle
-from certain UIControls
-all the way up to UIView.
-
 00:24:01.356 --> 00:24:03.726 A:middle
 You can set it on any UIView.
 
@@ -1952,10 +1874,6 @@ that Notes Back button.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:58.256 --> 00:25:01.326 A:middle
-a gray overlay over
-that Notes Back button.
 
 00:25:01.966 --> 00:25:04.416 A:middle
 Take a look at that Back
@@ -2031,10 +1949,6 @@ scratched the surface
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.866 --> 00:26:01.156 A:middle
-that I've barely
-scratched the surface
 
 00:26:01.206 --> 00:26:03.056 A:middle
 of in this brief discussion.
@@ -2177,9 +2091,6 @@ content into Alert Views.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:54.526 --> 00:28:01.156 A:middle
-[ Applause ]
-
 00:28:01.656 --> 00:28:03.276 A:middle
 We know a lot of you guys
 have been doing this,
@@ -2259,10 +2170,6 @@ in iOS 7 also look
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:55.956 --> 00:29:01.936 A:middle
-A segmented controls
-in iOS 7 also look
 
 00:29:01.936 --> 00:29:02.876 A:middle
 significantly different.
@@ -2422,10 +2329,6 @@ the search bar inside the
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:56.826 --> 00:31:00.146 A:middle
-we're not typically displaying
-the search bar inside the
-
 00:31:00.146 --> 00:31:01.046 A:middle
 navigation bar.
 
@@ -2510,9 +2413,6 @@ along and is always up-to-date.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.806 --> 00:32:00.026 A:middle
-along and is always up-to-date.
 
 00:32:02.016 --> 00:32:04.316 A:middle
 We have a session
@@ -2749,10 +2649,6 @@ amazing year after year.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.576 --> 00:35:01.046 A:middle
-talk which is always
-amazing year after year.
-
 00:35:01.666 --> 00:35:05.226 A:middle
 But this year in particular,
 it's going to have a demo
@@ -2824,10 +2720,6 @@ moving in a way that suggests
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.816 --> 00:36:00.816 A:middle
-of the Messages icon, it's
-moving in a way that suggests
 
 00:36:00.816 --> 00:36:01.976 A:middle
 that it's really floating there.
@@ -2911,10 +2803,6 @@ all day [laughter].
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:56.636 --> 00:37:01.476 A:middle
-I could watch this
-all day [laughter].
-
 00:37:03.596 --> 00:37:05.886 A:middle
 The best news I have is not
 just that we've done this thing,
@@ -2982,9 +2870,6 @@ and hand it to my friend.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.446 --> 00:38:01.966 A:middle
-and hand it to my friend.
 
 00:38:01.966 --> 00:38:04.426 A:middle
 And once you know
@@ -3065,10 +2950,6 @@ nice shading effect.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.306 --> 00:39:00.856 A:middle
-in order to create a
-nice shading effect.
-
 00:39:00.856 --> 00:39:04.736 A:middle
 And then we're doing this
 perspective skew distortion
@@ -3143,10 +3024,6 @@ without really getting
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.206 --> 00:40:01.536 A:middle
-and that helps communicate
-without really getting
 
 00:40:01.536 --> 00:40:04.156 A:middle
 in the way or taking
@@ -3231,10 +3108,6 @@ of advance image processing fast
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.106 --> 00:41:03.806 A:middle
-So, in order to make this kind
-of advance image processing fast
-
 00:41:04.526 --> 00:41:07.016 A:middle
 and easy for you and
 your applications,
@@ -3315,10 +3188,6 @@ in your applications.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.606 --> 00:42:00.586 A:middle
-for communicating depth
-in your applications.
 
 00:42:01.526 --> 00:42:07.106 A:middle
 So I think this one is
@@ -3458,10 +3327,6 @@ to you, UIKit dynamics.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.316 --> 00:44:01.386 A:middle
-that I've been describing
-to you, UIKit dynamics.
-
 00:44:02.286 --> 00:44:03.716 A:middle
 We did it with the
 motion effects.
@@ -3531,10 +3396,6 @@ abstract and we've gone
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.586 --> 00:45:05.126 A:middle
-That is all very
-abstract and we've gone
 
 00:45:05.126 --> 00:45:06.366 A:middle
 over a lot of API today.
@@ -3618,10 +3479,6 @@ going full screen,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.916 --> 00:46:01.216 A:middle
-your controllers are
-going full screen,
-
 00:46:01.926 --> 00:46:04.056 A:middle
 that's the default behavior,
 you don't have to turn that on.
@@ -3701,10 +3558,6 @@ that, for instance,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.406 --> 00:47:00.756 A:middle
-or the convenience
-that, for instance,
 
 00:47:01.146 --> 00:47:03.216 A:middle
 your users will have their
@@ -3791,10 +3644,6 @@ pleased about that
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.396 --> 00:48:00.286 A:middle
-and we're really
-pleased about that
 
 00:48:00.366 --> 00:48:03.926 A:middle
 because it gives the
@@ -3884,10 +3733,6 @@ be tasteful with these effects
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.826 --> 00:49:01.966 A:middle
-Obviously, it's important to
-be tasteful with these effects
-
 00:49:02.036 --> 00:49:02.816 A:middle
 because they're dramatic.
 
@@ -3956,10 +3801,6 @@ consider focusing your efforts
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:56.796 --> 00:50:01.056 A:middle
-And so we would suggest that you
-consider focusing your efforts
 
 00:50:01.056 --> 00:50:02.336 A:middle
 on iOS 7 first.
@@ -4049,10 +3890,6 @@ time to start.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:57.446 --> 00:51:01.186 A:middle
-now might be a good
-time to start.
 
 00:51:01.386 --> 00:51:07.206 A:middle
 Finally, as you're considering

--- a/2013/202.srt
+++ b/2013/202.srt
@@ -93,9 +93,6 @@ And more specifically,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.966 --> 00:01:01.206 A:middle
-And more specifically,
-
 00:01:01.556 --> 00:01:04.775 A:middle
 no two users have the exact
 same abilities so this is
@@ -197,10 +194,6 @@ to do some really cool stuff
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.886 --> 00:02:02.536 A:middle
-that we've added in this release
-to do some really cool stuff
-
 00:02:02.536 --> 00:02:04.056 A:middle
 that was never before
 possible and it's going
@@ -288,10 +281,6 @@ Access to deal
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.226 --> 00:03:00.316 A:middle
-So we introduce Guided
-Access to deal
 
 00:03:00.316 --> 00:03:01.996 A:middle
 with the problem
@@ -394,10 +383,6 @@ and on your device.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.926 --> 00:04:01.816 A:middle
-in your hearing aid
-and on your device.
-
 00:04:02.116 --> 00:04:04.716 A:middle
 So, if you walk into say a noisy
 environment like a restaurant,
@@ -491,10 +476,6 @@ to this idea
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.636 --> 00:05:03.106 A:middle
-So, I want to return
-to this idea
-
 00:05:03.106 --> 00:05:04.776 A:middle
 of supporting different
 abilities
@@ -585,10 +566,6 @@ hard, you know, day and night
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.096 --> 00:06:01.086 A:middle
-that we've worked really
-hard, you know, day and night
 
 00:06:01.576 --> 00:06:03.956 A:middle
 and we've gone ahead and baked
@@ -683,10 +660,6 @@ can really set it up in a way
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.876 --> 00:07:01.266 A:middle
-of customization here so users
-can really set it up in a way
-
 00:07:01.266 --> 00:07:02.116 A:middle
 that works well for them.
 
@@ -779,10 +752,6 @@ number of external switches
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:56.336 --> 00:08:00.176 A:middle
-we're supporting a large
-number of external switches
 
 00:08:00.176 --> 00:08:01.056 A:middle
 that will work for you.
@@ -962,10 +931,6 @@ UIAccessibility API
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.626 --> 00:10:00.206 A:middle
-we're going to use the
-UIAccessibility API
-
 00:10:00.676 --> 00:10:03.116 A:middle
 to fix them again, you know,
 starting with the most basic
@@ -1061,10 +1026,6 @@ VoiceOver then internally,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:55.796 --> 00:11:01.076 A:middle
-in the center of the screen,
-VoiceOver then internally,
-
 00:11:01.076 --> 00:11:02.296 A:middle
 you know, computes
 this question,
@@ -1156,10 +1117,6 @@ you're on the device,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.666 --> 00:12:00.236 A:middle
-But even better, if
-you're on the device,
 
 00:12:00.236 --> 00:12:01.766 A:middle
 we can just use the
@@ -1262,9 +1219,6 @@ with my Accessibility Shortcut
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.026 --> 00:13:00.256 A:middle
-with my Accessibility Shortcut
 
 00:13:00.656 --> 00:13:02.416 A:middle
 and I really recommend
@@ -1373,10 +1327,6 @@ let us increment
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.026 --> 00:14:01.616 A:middle
-that as expected,
-let us increment
-
 00:14:01.616 --> 00:14:02.856 A:middle
 or decrement the
 floor we're seeing.
@@ -1482,10 +1432,6 @@ accessibility experience.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.786 --> 00:15:01.036 A:middle
-application and make a great
-accessibility experience.
-
 00:15:05.596 --> 00:15:09.796 A:middle
 Okay, so we have an idea of the
 bugs we need to start tackling,
@@ -1577,10 +1523,6 @@ the case of VoiceOver,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.226 --> 00:16:01.396 A:middle
-of the element and in
-the case of VoiceOver,
 
 00:16:01.396 --> 00:16:02.826 A:middle
 this is the first thing
@@ -1678,10 +1620,6 @@ we also had a floor value.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:57.266 --> 00:17:00.566 A:middle
-that said Moscone West but
-we also had a floor value.
-
 00:17:00.766 --> 00:17:03.486 A:middle
 And so again, this is a great
 place to use accessibilityValue.
@@ -1777,10 +1715,6 @@ would be appropriate here
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.306 --> 00:18:00.806 A:middle
-so the static text trait
-would be appropriate here
 
 00:18:00.946 --> 00:18:02.376 A:middle
 and it would give
@@ -1885,10 +1819,6 @@ basically just an increment
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.396 --> 00:19:00.706 A:middle
-of the screen because it is
-basically just an increment
-
 00:19:00.706 --> 00:19:02.476 A:middle
 or decrement or up and down
 the change of the floor.
@@ -1974,10 +1904,6 @@ an appropriate place to do
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:57.746 --> 00:20:00.426 A:middle
-And so, you know, we find
-an appropriate place to do
 
 00:20:00.426 --> 00:20:03.726 A:middle
 that like awakeFromNib
@@ -2086,10 +2012,6 @@ know that is my titleView,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.086 --> 00:21:02.476 A:middle
-So, if I find the class, I
-know that is my titleView,
-
 00:21:03.156 --> 00:21:08.296 A:middle
 I'm going to go ahead and just
 grab the basic accessibility
@@ -2162,9 +2084,6 @@ titleLabel, text, great.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.646 --> 00:22:01.376 A:middle
-titleLabel, text, great.
 
 00:22:02.036 --> 00:22:05.586 A:middle
 So, this is a pretty
@@ -2304,9 +2223,6 @@ So, what should our value be?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.726 --> 00:24:00.626 A:middle
-So, what should our value be?
-
 00:24:00.626 --> 00:24:02.866 A:middle
 Well, we do have a value
 associated with this control,
@@ -2444,10 +2360,6 @@ so, this is one of those times
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.496 --> 00:26:00.296 A:middle
-incrementor/decrementor and
-so, this is one of those times
-
 00:26:00.296 --> 00:26:02.086 A:middle
 when you as the implementer,
 you know,
@@ -2521,10 +2433,6 @@ over to our application,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.726 --> 00:27:01.956 A:middle
-Okay, so if we switch back
-over to our application,
 
 00:27:02.176 --> 00:27:03.346 A:middle
 let's turn VoiceOver back on.
@@ -2632,10 +2540,6 @@ button trait to this control.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.636 --> 00:28:01.466 A:middle
-because we applied the
-button trait to this control.
-
 00:28:01.466 --> 00:28:03.046 A:middle
 And so now, let's
 go ahead and try
@@ -2719,10 +2623,6 @@ want to convey to the user
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.126 --> 00:29:01.006 A:middle
-that represent everything we
-want to convey to the user
 
 00:29:01.246 --> 00:29:05.156 A:middle
 and return them using the
@@ -2819,10 +2719,6 @@ don't have a frame,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.536 --> 00:30:01.056 A:middle
-out of thin air so they
-don't have a frame,
-
 00:30:01.286 --> 00:30:03.426 A:middle
 so we need to figure out what
 we want this frame to be.
@@ -2915,10 +2811,6 @@ API in iOS 7 that's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.866 --> 00:31:01.826 A:middle
-we've added some brand new
-API in iOS 7 that's going
-
 00:31:01.826 --> 00:31:03.886 A:middle
 to allow you to, you know, get
 yourself out of this corner.
@@ -3009,10 +2901,6 @@ is going to allow us to do.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:56.606 --> 00:32:00.066 A:middle
-on the screen, what this
-is going to allow us to do.
-
 00:32:00.506 --> 00:32:02.766 A:middle
 Great. So, let's now go
 back to the application
@@ -3065,10 +2953,6 @@ accessibilityElementAtIndex,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.006 --> 00:33:00.356 A:middle
-So, for
-accessibilityElementAtIndex,
 
 00:33:00.836 --> 00:33:05.126 A:middle
 we're just going to use the
@@ -3148,10 +3032,6 @@ are enumerating this backwards
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.326 --> 00:34:00.836 A:middle
-And so, you might notice that we
-are enumerating this backwards
 
 00:34:00.836 --> 00:34:02.586 A:middle
 and there is a reason
@@ -3257,10 +3137,6 @@ have one more thing to do.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.056 --> 00:35:01.846 A:middle
-So, that's not it, we
-have one more thing to do.
-
 00:35:02.156 --> 00:35:05.146 A:middle
 What happens when we change
 floors or show or hide Coffee?
@@ -3327,10 +3203,6 @@ accessibilityActivate.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.276 --> 00:36:01.586 A:middle
-for here is
-accessibilityActivate.
 
 00:36:02.766 --> 00:36:05.576 A:middle
 And so if we jump to the header,
@@ -3399,10 +3271,6 @@ accessibilityIncrement.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:56.356 --> 00:37:00.186 A:middle
-and similarly,
-accessibilityIncrement.
 
 00:37:00.776 --> 00:37:06.276 A:middle
 And so, it just so happens,
@@ -3600,10 +3468,6 @@ stairs eventually.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.876 --> 00:39:01.286 A:middle
-&gt;&gt; And I get to the
-stairs eventually.
-
 00:39:01.286 --> 00:39:04.256 A:middle
 So you can see that this allows
 VoiceOver users to, you know,
@@ -3695,10 +3559,6 @@ you know, it turns out a lot
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.676 --> 00:40:02.196 A:middle
-But we got some feedback and,
-you know, it turns out a lot
 
 00:40:02.196 --> 00:40:03.746 A:middle
 of really powerful
@@ -3864,10 +3724,6 @@ in these places
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.356 --> 00:42:00.866 A:middle
-touch from happening
-in these places
-
 00:42:01.066 --> 00:42:02.766 A:middle
 and so users won't be able
 to change these things.
@@ -3960,10 +3816,6 @@ these changes, you know,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:56.886 --> 00:43:00.486 A:middle
-the user wants to make
-these changes, you know,
-
 00:43:00.626 --> 00:43:03.086 A:middle
 act appropriately, and
 then it's your job--
@@ -4050,10 +3902,6 @@ state persistence comes free.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.876 --> 00:44:01.226 A:middle
-And so for that reason,
-state persistence comes free.
 
 00:44:01.526 --> 00:44:03.836 A:middle
 You don't have to maintain
@@ -4338,10 +4186,6 @@ utterance out of a string
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.366 --> 00:47:00.666 A:middle
-Second, you make an
-utterance out of a string
-
 00:47:00.736 --> 00:47:01.766 A:middle
 that you'd like to speak.
 
@@ -4424,10 +4268,6 @@ accessories for iOS and OS X.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:57.276 --> 00:48:02.206 A:middle
-over to the designing
-accessories for iOS and OS X.
 
 00:48:02.526 --> 00:48:06.536 A:middle
 I mean, that is also directly

--- a/2013/203.srt
+++ b/2013/203.srt
@@ -83,10 +83,6 @@ bit different look.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.566 --> 00:01:02.846 A:middle
-But now, it has a little
-bit different look.
-
 00:01:02.846 --> 00:01:05.476 A:middle
 And again, they spent a lot of
 time talking about how this--
@@ -172,10 +168,6 @@ your application.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.076 --> 00:02:00.196 A:middle
-for how they use
-your application.
-
 00:02:00.966 --> 00:02:02.746 A:middle
 And if we notice that, for
 instance, they're firing
@@ -247,9 +239,6 @@ don't call me at all.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.476 --> 00:03:00.256 A:middle
-don't call me at all.
 
 00:03:00.606 --> 00:03:03.346 A:middle
 You'll have to call
@@ -533,10 +522,6 @@ and images a little bit.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.436 --> 00:06:01.966 A:middle
-so let's talk about views
-and images a little bit.
-
 00:06:04.676 --> 00:06:09.796 A:middle
 We have some new image
 rendering modes in UIKit to deal
@@ -620,10 +605,6 @@ you'll be able to use this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.976 --> 00:07:00.606 A:middle
-into a different context,
-you'll be able to use this.
 
 00:07:01.296 --> 00:07:04.476 A:middle
 Template means go
@@ -712,10 +693,6 @@ a top level UIView.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.066 --> 00:08:02.826 A:middle
-What I've got here is
-a top level UIView.
-
 00:08:03.196 --> 00:08:05.796 A:middle
 There's a UIImage view there
 which has the little chevron
@@ -800,10 +777,6 @@ desaturation.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:57.036 --> 00:09:01.336 A:middle
-this is a gray automatically
-desaturation.
 
 00:09:01.566 --> 00:09:02.996 A:middle
 If you don't want that behavior,
@@ -1000,10 +973,6 @@ API you already have.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.946 --> 00:11:01.156 A:middle
-to the UIViewAnimation
-API you already have.
-
 00:11:01.936 --> 00:11:03.926 A:middle
 Once you've got that
 you can also put
@@ -1179,10 +1148,6 @@ one of these two things.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.136 --> 00:13:00.826 A:middle
-to effect, and the type is
-one of these two things.
-
 00:13:00.826 --> 00:13:04.856 A:middle
 It's either along the horizontal
 axis or along the vertical axis.
@@ -1271,10 +1236,6 @@ and vertical offset.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.336 --> 00:14:01.146 A:middle
-that's a horizontal
-and vertical offset.
-
 00:14:01.146 --> 00:14:03.726 A:middle
 So horizontal is obviously
 that the axis that we're using
@@ -1354,10 +1315,6 @@ ways to be able to combine them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.336 --> 00:15:01.016 A:middle
-There are really interesting
-ways to be able to combine them.
 
 00:15:01.016 --> 00:15:05.046 A:middle
 And you're really able to do a
@@ -1445,10 +1402,6 @@ values in there yourself
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.556 --> 00:16:01.856 A:middle
-So if you're needing to update
-values in there yourself
 
 00:16:01.856 --> 00:16:03.906 A:middle
 for a custom subclass,
@@ -1539,9 +1492,6 @@ of composition for UIKit.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.836 --> 00:17:03.846 A:middle
-of composition for UIKit.
-
 00:17:03.846 --> 00:17:06.296 A:middle
 We've made a lot of
 changes to view controllers
@@ -1623,10 +1573,6 @@ content here to make sure
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.866 --> 00:18:00.876 A:middle
-I'm not stretching out the
-content here to make sure
 
 00:18:00.876 --> 00:18:02.356 A:middle
 that it fits the
@@ -1716,10 +1662,6 @@ only the left and right edges
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.876 --> 00:19:01.226 A:middle
-But if you want to specify
-only the left and right edges
 
 00:19:01.226 --> 00:19:02.926 A:middle
 and leave the top and
@@ -1811,10 +1753,6 @@ shorter, so.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:57.106 --> 00:20:00.446 A:middle
-the Nav bar's a little
-shorter, so.
 
 00:20:01.186 --> 00:20:04.096 A:middle
 We also we have new
@@ -1909,10 +1847,6 @@ is the navigation bar getting
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.116 --> 00:21:01.126 A:middle
-What's you're seeing in iOS 7
-is the navigation bar getting
-
 00:21:01.126 --> 00:21:04.076 A:middle
 taller and the status bar
 being over laid on it.
@@ -1990,10 +1924,6 @@ pop in navigation controllers
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.796 --> 00:22:00.386 A:middle
-where you slide, you do a push
-pop in navigation controllers
 
 00:22:00.426 --> 00:22:01.836 A:middle
 or for a modal transition,
@@ -2086,10 +2016,6 @@ do this transition.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.156 --> 00:23:00.866 A:middle
-to find out how to
-do this transition.
-
 00:23:00.866 --> 00:23:02.996 A:middle
 So, let's say you've got
 an UINavigationController,
@@ -2178,10 +2104,6 @@ controller for a presentation
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.116 --> 00:24:00.256 A:middle
-for an interaction
-controller for a presentation
-
 00:24:00.856 --> 00:24:02.466 A:middle
 or an interaction
 controller for dismissal
@@ -2268,10 +2190,6 @@ this is for the parts
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:56.126 --> 00:25:00.716 A:middle
-So, the animated bits,
-this is for the parts
 
 00:25:00.716 --> 00:25:02.446 A:middle
 where things are
@@ -2368,10 +2286,6 @@ your objects conform to.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.806 --> 00:26:00.036 A:middle
-this is a protocol that
-your objects conform to.
-
 00:26:00.396 --> 00:26:03.706 A:middle
 This is where you put all of
 the information that you need
@@ -2465,9 +2379,6 @@ where your content or the state
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.606 --> 00:27:02.716 A:middle
-where your content or the state
-
 00:27:02.716 --> 00:27:06.126 A:middle
 that you're restoring doesn't
 really match the snapshot we
@@ -2552,10 +2463,6 @@ that, that are all going to need
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.676 --> 00:28:00.126 A:middle
-or created models, things like
-that, that are all going to need
 
 00:28:00.126 --> 00:28:01.856 A:middle
 to participate in
@@ -2643,10 +2550,6 @@ those things for you as well.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.566 --> 00:29:00.626 A:middle
-we can now state restore
-those things for you as well.
 
 00:29:01.486 --> 00:29:03.966 A:middle
 So UIApplicationLaunchOptions
@@ -2744,10 +2647,6 @@ the things that you're going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.956 --> 00:30:00.136 A:middle
-or register the UTIs for
-the things that you're going
 
 00:30:00.136 --> 00:30:01.966 A:middle
 to be able to accept
@@ -2848,10 +2747,6 @@ this stuff up if you discover
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.626 --> 00:31:00.476 A:middle
-So you might want to queue
-this stuff up if you discover
-
 00:31:00.476 --> 00:31:05.216 A:middle
 that there are 12 or 15
 things in the Inbox directory.
@@ -2941,10 +2836,6 @@ these UIDynamicAnimator objects.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.256 --> 00:32:02.786 A:middle
-What you'll do is create one of
-these UIDynamicAnimator objects.
 
 00:32:04.006 --> 00:32:05.556 A:middle
 And a Dynamic Animator
@@ -3036,10 +2927,6 @@ just a tree of all kinds
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:55.976 --> 00:33:01.526 A:middle
-Dynamic behaviors are
-just a tree of all kinds
 
 00:33:01.526 --> 00:33:03.586 A:middle
 of supported things for gravity
@@ -3137,10 +3024,6 @@ bringing the camera up.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.396 --> 00:34:00.636 A:middle
-down when you're
-bringing the camera up.
-
 00:34:01.366 --> 00:34:04.946 A:middle
 A PushBehavior is if you
 give it a view an impulse
@@ -3225,10 +3108,6 @@ fantastic job talking
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.626 --> 00:35:02.616 A:middle
-And Olivia will an absolutely
-fantastic job talking
-
 00:35:02.616 --> 00:35:03.396 A:middle
 about this.
 
@@ -3305,10 +3184,6 @@ dynamic types sizing mechanism.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.696 --> 00:36:00.966 A:middle
-We've introduced a new
-dynamic types sizing mechanism.
-
 00:36:00.966 --> 00:36:05.236 A:middle
 So, dynamic type, this is the
 text size view controller that's
@@ -3384,10 +3259,6 @@ to be able to go back,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.566 --> 00:37:01.366 A:middle
-and this is your opportunity
-to be able to go back,
 
 00:37:01.696 --> 00:37:04.526 A:middle
 find out what changed,
@@ -3472,10 +3343,6 @@ and fonts for your application
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:57.466 --> 00:38:02.916 A:middle
-to get relative text styles
-and fonts for your application
-
 00:38:02.916 --> 00:38:03.946 A:middle
 and they'll scale relative
 
@@ -3547,9 +3414,6 @@ It's got a UITextView in it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.726 --> 00:39:01.036 A:middle
-It's got a UITextView in it.
 
 00:39:01.336 --> 00:39:04.046 A:middle
 That UITextView has
@@ -3630,10 +3494,6 @@ TextView and TextContainer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.436 --> 00:40:01.716 A:middle
-Let's talk a little bit about
-TextView and TextContainer.
 
 00:40:02.046 --> 00:40:04.306 A:middle
 An initWithFrame textContainer
@@ -3729,10 +3589,6 @@ really had a lot of control
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.116 --> 00:41:00.216 A:middle
-So things that you've never
-really had a lot of control
-
 00:41:00.216 --> 00:41:02.956 A:middle
 over before, where things
 break, how they break
@@ -3821,10 +3677,6 @@ where are the places
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.506 --> 00:42:01.946 A:middle
-out where is the bitmap,
-where are the places
 
 00:42:01.946 --> 00:42:02.946 A:middle
 that it's overlapping.
@@ -3999,10 +3851,6 @@ well as what gets drawn.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.536 --> 00:44:01.496 A:middle
-in the LayoutManager as
-well as what gets drawn.
 
 00:44:02.466 --> 00:44:07.906 A:middle
 So speaking of drawing, you'll
@@ -4182,9 +4030,6 @@ This is fantastic stuff.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.076 --> 00:46:00.826 A:middle
-This is fantastic stuff.
-
 00:46:01.456 --> 00:46:04.826 A:middle
 We're not the only people
 working on this stuff.
@@ -4274,9 +4119,6 @@ Mac OS X-- OS X-based games.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.226 --> 00:47:01.306 A:middle
-Mac OS X-- OS X-based games.
 
 00:47:01.696 --> 00:47:04.406 A:middle
 It has image atlas support
@@ -4373,10 +4215,6 @@ Bluetooth LE beacons bits,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:57.736 --> 00:48:00.476 A:middle
-CoreLocations adopted the new
-Bluetooth LE beacons bits,
-
 00:48:00.476 --> 00:48:02.526 A:middle
 so you'll be able to take your
 device and actually turn it
@@ -4469,10 +4307,6 @@ some system integrity features
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.776 --> 00:49:00.556 A:middle
-New leaderboard improvements and
-some system integrity features
 
 00:49:00.556 --> 00:49:02.046 A:middle
 to make sure that

--- a/2013/204.srt
+++ b/2013/204.srt
@@ -72,10 +72,6 @@ that you should be considering
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.366 --> 00:01:01.216 A:middle
-these are a few tips and things
-that you should be considering
-
 00:01:01.216 --> 00:01:02.786 A:middle
 as you're implementing it.
 
@@ -145,10 +141,6 @@ your application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.296 --> 00:02:00.256 A:middle
-after users have left
-your application.
 
 00:02:00.696 --> 00:02:03.876 A:middle
 And a number of applications
@@ -222,10 +214,6 @@ device is awake to, for example,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.406 --> 00:03:02.416 A:middle
-And that anytime that the
-device is awake to, for example,
 
 00:03:02.886 --> 00:03:07.196 A:middle
 check mail, your application
@@ -380,10 +368,6 @@ it flies in, it goes right back
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.726 --> 00:05:01.056 A:middle
-that user taps that snapshot and
-it flies in, it goes right back
-
 00:05:01.056 --> 00:05:02.506 A:middle
 into the same place
 that they left it.
@@ -461,10 +445,6 @@ Newsstand, we've only updated it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.766 --> 00:06:01.246 A:middle
-So quick note about
-Newsstand, we've only updated it
-
 00:06:01.926 --> 00:06:03.286 A:middle
 to support these two things,
 
@@ -531,10 +511,6 @@ can get an understanding of how
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.626 --> 00:07:01.026 A:middle
-that works so that you guys
-can get an understanding of how
 
 00:07:01.026 --> 00:07:01.896 A:middle
 to build your features.
@@ -620,9 +596,6 @@ about background app refresh.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.246 --> 00:08:01.196 A:middle
-about background app refresh.
-
 00:08:01.296 --> 00:08:03.606 A:middle
 So, let's say you've got
 the next great social
@@ -707,10 +680,6 @@ attention to how this works.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.086 --> 00:09:01.956 A:middle
-So, I want you to pay
-attention to how this works.
-
 00:09:03.916 --> 00:09:07.036 A:middle
 The first thing you do is
 either in the Info.plist
@@ -791,10 +760,6 @@ and from that point on,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.396 --> 00:10:00.846 A:middle
-in a completion handler
-and from that point on,
 
 00:10:01.366 --> 00:10:03.986 A:middle
 you're allowed a certain
@@ -881,10 +846,6 @@ installs it, it starts signed
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.346 --> 00:11:02.886 A:middle
-And so when the user first
-installs it, it starts signed
-
 00:11:02.886 --> 00:11:05.226 A:middle
 out which means that
 there's no content available.
@@ -965,10 +926,6 @@ say an hour, for the next hour,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.646 --> 00:12:02.966 A:middle
-So if you set this to let's
-say an hour, for the next hour,
 
 00:12:03.356 --> 00:12:05.356 A:middle
 the system will not
@@ -1064,10 +1021,6 @@ a really great experience
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.306 --> 00:13:01.376 A:middle
-We think that will give you
-a really great experience
 
 00:13:01.376 --> 00:13:04.316 A:middle
 and give your users
@@ -1232,10 +1185,6 @@ apps minimum fetch interval.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.156 --> 00:15:01.326 A:middle
-to do is I need to set my
-apps minimum fetch interval.
-
 00:15:02.056 --> 00:15:05.426 A:middle
 This is super important because
 the default interval is never,
@@ -1310,10 +1259,6 @@ method takes in a block
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.246 --> 00:16:00.186 A:middle
-It looks like this
-method takes in a block
 
 00:16:00.186 --> 00:16:01.606 A:middle
 than when the refresh
@@ -1395,10 +1340,6 @@ code path that was coming
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.476 --> 00:17:00.066 A:middle
-when there was only one
-code path that was coming
 
 00:17:00.066 --> 00:17:01.406 A:middle
 through here, but now
@@ -1489,10 +1430,6 @@ to update the signature
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.396 --> 00:18:03.346 A:middle
-And then that means I need
-to update the signature
-
 00:18:04.066 --> 00:18:07.036 A:middle
 to fetch new posts with
 completion handler.
@@ -1558,10 +1495,6 @@ having your app resumed
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.236 --> 00:19:01.456 A:middle
-The second scenario is
-having your app resumed
 
 00:19:01.456 --> 00:19:02.956 A:middle
 in the background to
@@ -1638,10 +1571,6 @@ to fetch new content.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.436 --> 00:20:01.556 A:middle
-into the background
-to fetch new content.
-
 00:20:02.596 --> 00:20:04.636 A:middle
 If I look down here in
 the Syslog for my app,
@@ -1712,10 +1641,6 @@ see what it looks like now.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:55.786 --> 00:21:00.016 A:middle
-So let me resume my app and
-see what it looks like now.
 
 00:21:00.256 --> 00:21:02.346 A:middle
 OK great, we have one
@@ -1804,10 +1729,6 @@ completion handler
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.946 --> 00:22:00.316 A:middle
-with calling the
-completion handler
-
 00:22:01.166 --> 00:22:03.656 A:middle
 and calling the completion
 handler with the proper status
@@ -1883,10 +1804,6 @@ things at the same time and--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.886 --> 00:23:00.796 A:middle
-but you do too many of these
-things at the same time and--
 
 00:23:00.796 --> 00:23:03.256 A:middle
 or you do too many of these
@@ -1969,10 +1886,6 @@ small example about--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.936 --> 00:24:02.376 A:middle
-So let me give you a
-small example about--
-
 00:24:03.026 --> 00:24:06.576 A:middle
 of what I mean by-- when I
 say adapts to user activity.
@@ -2045,10 +1958,6 @@ based on actual device usage.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.536 --> 00:25:02.486 A:middle
-It learns these patterns
-based on actual device usage.
 
 00:25:03.516 --> 00:25:07.306 A:middle
 It coalesces, fetches across the
@@ -2125,10 +2034,6 @@ up in your application
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.816 --> 00:26:00.706 A:middle
-where the user can pop
-up in your application
-
 00:26:01.056 --> 00:26:02.936 A:middle
 and instantly start
 viewing, you know,
@@ -2193,10 +2098,6 @@ message or an old transcript
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:57.836 --> 00:27:02.236 A:middle
-where they see either the old
-message or an old transcript
 
 00:27:02.236 --> 00:27:03.546 A:middle
 that they were looking
@@ -2274,10 +2175,6 @@ powerful.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.846 --> 00:28:02.656 A:middle
-Now, this is incredibly
-powerful.
 
 00:28:02.736 --> 00:28:05.776 A:middle
 We think there's a lot of
@@ -2361,10 +2258,6 @@ feature capabilities menu
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.056 --> 00:29:01.866 A:middle
-or use the X code
-feature capabilities menu
-
 00:29:01.866 --> 00:29:04.996 A:middle
 to enable this.
 
@@ -2442,10 +2335,6 @@ manage a rate limit for you.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.346 --> 00:30:04.956 A:middle
-So iOS and our push servers will
-manage a rate limit for you.
-
 00:30:05.926 --> 00:30:08.376 A:middle
 And the thing you need
 to get out of this is
@@ -2520,10 +2409,6 @@ through and of course,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.266 --> 00:31:00.516 A:middle
-it just sends straight
-through and of course,
 
 00:31:00.886 --> 00:31:01.776 A:middle
 they don't wake up the device.
@@ -2610,10 +2495,6 @@ realize that the device
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:56.996 --> 00:32:00.306 A:middle
-All you need to do is
-realize that the device
 
 00:32:00.356 --> 00:32:02.516 A:middle
 and the servers will take
@@ -2704,10 +2585,6 @@ kind of functionality.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.616 --> 00:33:02.956 A:middle
-of read some stories later
-kind of functionality.
-
 00:33:03.256 --> 00:33:06.366 A:middle
 And some applications
 have actually gone so far
@@ -2793,9 +2670,6 @@ with documents, same thing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.946 --> 00:34:00.196 A:middle
-with documents, same thing.
-
 00:34:00.726 --> 00:34:04.776 A:middle
 Just send that notification
 when it's ready, and then go.
@@ -2877,10 +2751,6 @@ back to sleep at this point
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.666 --> 00:35:00.966 A:middle
-so the application can go
-back to sleep at this point
-
 00:35:01.556 --> 00:35:04.116 A:middle
 and then once it's completed,
 the application just wakes up,
@@ -2954,10 +2824,6 @@ effort and time.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.286 --> 00:36:02.706 A:middle
-to help save you
-effort and time.
 
 00:36:02.906 --> 00:36:05.826 A:middle
 So here were the two APIs that
@@ -3041,10 +2907,6 @@ every single second.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.376 --> 00:37:01.746 A:middle
-like they're updating
-every single second.
-
 00:37:02.566 --> 00:37:07.406 A:middle
 And for Remote Notifications,
 it's fine if it's very frequent
@@ -3116,9 +2978,6 @@ In iOS 7, we've changed this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.116 --> 00:38:01.466 A:middle
-In iOS 7, we've changed this.
 
 00:38:01.846 --> 00:38:04.496 A:middle
 We're providing a service that
@@ -3193,10 +3052,6 @@ class called NSURLSession today.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:57.616 --> 00:39:03.256 A:middle
-So we are introducing a new
-class called NSURLSession today.
 
 00:39:03.606 --> 00:39:05.356 A:middle
 It's part of the
@@ -3281,10 +3136,6 @@ you to do is reconnect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.396 --> 00:40:01.076 A:middle
-And what this allows
-you to do is reconnect
 
 00:40:01.076 --> 00:40:03.886 A:middle
 to your NSURLSession by
@@ -3452,10 +3303,6 @@ a lot to the ecosystem
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.556 --> 00:42:00.276 A:middle
-We think that they add
-a lot to the ecosystem
-
 00:42:00.596 --> 00:42:06.466 A:middle
 and we really can't wait to
 see what you guys do with it.
@@ -3547,10 +3394,6 @@ and that there's nothing obvious
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:57.126 --> 00:43:01.136 A:middle
-as little CPU time as possible
-and that there's nothing obvious
-
 00:43:01.166 --> 00:43:04.116 A:middle
 that you can get rid off.
 
@@ -3634,10 +3477,6 @@ your snapshot
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.776 --> 00:44:01.296 A:middle
-So like I said before,
-your snapshot
-
 00:44:01.296 --> 00:44:03.776 A:middle
 and your state restoration
 is saved
@@ -3720,10 +3559,6 @@ at the end of the session,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.476 --> 00:45:01.176 A:middle
-to and we'll have a link
-at the end of the session,
 
 00:45:02.426 --> 00:45:04.576 A:middle
 but let's explain
@@ -3809,10 +3644,6 @@ users-- usernames and passwords
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.496 --> 00:46:02.916 A:middle
-and credential, so let's say,
-users-- usernames and passwords
-
 00:46:02.916 --> 00:46:06.366 A:middle
 and log-in tokens
 or cookies should be
@@ -3895,10 +3726,6 @@ after the very first unlock.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.536 --> 00:47:02.636 A:middle
-where the data is available
-after the very first unlock.
-
 00:47:04.336 --> 00:47:07.806 A:middle
 So what we encourage you to
 do is to actually create--
@@ -3967,10 +3794,6 @@ it, it can be secured.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:57.376 --> 00:48:01.096 A:middle
-and as soon as you close
-it, it can be secured.
 
 00:48:02.956 --> 00:48:06.376 A:middle
 And then once that main
@@ -4045,10 +3868,6 @@ there will be for your app
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.776 --> 00:49:01.796 A:middle
-the more opportunities
-there will be for your app
 
 00:49:01.796 --> 00:49:03.536 A:middle
 and other apps to get launched.
@@ -4210,10 +4029,6 @@ through and, you know,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.966 --> 00:51:02.616 A:middle
-So that the user can go
-through and, you know,
-
 00:51:02.616 --> 00:51:05.506 A:middle
 turn off particular applications
 
@@ -4279,10 +4094,6 @@ will let you learn more
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:58.736 --> 00:52:01.546 A:middle
-The keychain session
-will let you learn more
 
 00:52:01.546 --> 00:52:03.606 A:middle
 about the data protection

--- a/2013/205.srt
+++ b/2013/205.srt
@@ -148,10 +148,6 @@ iCloud documents as well.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.206 --> 00:02:00.956 A:middle
-You can see the tags and their
-iCloud documents as well.
-
 00:02:01.326 --> 00:02:04.476 A:middle
 You can go ahead and assign tags
 to files as you're saving them
@@ -419,10 +415,6 @@ protocol.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.596 --> 00:05:01.336 A:middle
-the appearance customization
-protocol.
-
 00:05:01.666 --> 00:05:04.906 A:middle
 You can go ahead and the set
 the appearance of that View
@@ -509,10 +501,6 @@ new class we've added
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.376 --> 00:06:00.226 A:middle
-NSStackView is a
-new class we've added
 
 00:06:00.226 --> 00:06:02.136 A:middle
 to AppKit in Mavericks.
@@ -686,10 +674,6 @@ in Layouts such as the spacing,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:55.806 --> 00:08:00.026 A:middle
-that lets you specify properties
-in Layouts such as the spacing,
-
 00:08:00.026 --> 00:08:01.856 A:middle
 the priority, what the clipping
 
@@ -784,10 +768,6 @@ a new workflow to deal
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.756 --> 00:09:01.016 A:middle
-In addition, we have
-a new workflow to deal
-
 00:09:01.016 --> 00:09:02.516 A:middle
 with Auto Layout in Xcode.
 
@@ -874,10 +854,6 @@ scrolls, they see this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.906 --> 00:10:02.976 A:middle
-In 10.8, when the user
-scrolls, they see this.
-
 00:10:04.346 --> 00:10:07.186 A:middle
 Now, really what's
 happening under the covers is
@@ -960,9 +936,6 @@ There is the Run Loop there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.516 --> 00:11:00.866 A:middle
-There is the Run Loop there.
 
 00:11:01.066 --> 00:11:02.726 A:middle
 You know, things are happening.
@@ -1058,9 +1031,6 @@ Here is our ScrollView again
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.916 --> 00:12:01.246 A:middle
-Here is our ScrollView again
-
 00:12:01.556 --> 00:12:04.856 A:middle
 and this time we have a visible
 area, the area that user sees.
@@ -1146,10 +1116,6 @@ returning yes you say
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.946 --> 00:13:01.876 A:middle
-by overwriting and
-returning yes you say
 
 00:13:02.216 --> 00:13:04.326 A:middle
 "I'm doing responsive
@@ -1238,10 +1204,6 @@ printing just a safe field.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.406 --> 00:14:02.266 A:middle
-It does nothing to do with
-printing just a safe field.
 
 00:14:02.736 --> 00:14:03.936 A:middle
 And you can go ahead and save.
@@ -1339,10 +1301,6 @@ overwrite this method--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.666 --> 00:15:01.626 A:middle
-In that case, you can
-overwrite this method--
-
 00:15:02.096 --> 00:15:05.616 A:middle
 I'm sorry, I skipped the
 PDF print operation method
@@ -1431,10 +1389,6 @@ about is Media Library Access.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.276 --> 00:16:00.876 A:middle
-Next thing I want to talk
-about is Media Library Access.
-
 00:16:01.626 --> 00:16:05.316 A:middle
 So the media library is the
 user's library of images,
@@ -1515,10 +1469,6 @@ browse through locations, faces,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.946 --> 00:17:01.056 A:middle
-They can also go ahead and
-browse through locations, faces,
 
 00:17:01.056 --> 00:17:04.766 A:middle
 et cetera just like it appears
@@ -1610,10 +1560,6 @@ groups that make sense
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.016 --> 00:18:01.146 A:middle
-ML MediaGroup represents
-groups that make sense
-
 00:18:01.146 --> 00:18:07.056 A:middle
 within that source for
 instance playlists or locations
@@ -1700,10 +1646,6 @@ implement your selector.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.466 --> 00:19:01.226 A:middle
-And then you go ahead and
-implement your selector.
 
 00:19:01.926 --> 00:19:04.086 A:middle
 And inside that selector,
@@ -1811,10 +1753,6 @@ a subsystem and you want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.156 --> 00:20:02.746 A:middle
-Now, however, if you're
-a subsystem and you want
-
 00:20:02.816 --> 00:20:05.566 A:middle
 that sheet of your stuff here
 immediately for some reason,
@@ -1911,10 +1849,6 @@ screen at any given time.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.956 --> 00:21:02.796 A:middle
-so that's you have a one active
-screen at any given time.
-
 00:21:03.086 --> 00:21:05.106 A:middle
 So the user can go ahead
 and interact with iPhoto put
@@ -1995,10 +1929,6 @@ is each screen has its own set
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.316 --> 00:22:01.746 A:middle
-and in this mode what happens
-is each screen has its own set
 
 00:22:01.746 --> 00:22:03.626 A:middle
 of spaces as you saw.
@@ -2089,10 +2019,6 @@ to those screens
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:58.286 --> 00:23:00.766 A:middle
-up your portables
-to those screens
 
 00:23:00.766 --> 00:23:02.386 A:middle
 and see how well your
@@ -2190,9 +2116,6 @@ using before.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.726 --> 00:24:00.456 A:middle
-using before.
-
 00:24:00.456 --> 00:24:03.296 A:middle
 If you're calling NS
 Font system font of size,
@@ -2272,9 +2195,6 @@ and also State of the Union.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.956 --> 00:25:01.196 A:middle
-and also State of the Union.
 
 00:25:01.946 --> 00:25:05.156 A:middle
 So App Nap is a new system
@@ -2361,10 +2281,6 @@ going off every 10 seconds,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:57.756 --> 00:26:00.616 A:middle
-That timer will now start
-going off every 10 seconds,
 
 00:26:01.176 --> 00:26:03.456 A:middle
 so you know it's really
@@ -2457,10 +2373,6 @@ that drawing so we really want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:56.626 --> 00:27:00.036 A:middle
-visibly while the user is seeing
-that drawing so we really want
-
 00:27:00.036 --> 00:27:03.396 A:middle
 that drawing to continue
 playing audio as well
@@ -2550,10 +2462,6 @@ do misbehave sometimes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.596 --> 00:28:00.866 A:middle
-of apps out there that
-do misbehave sometimes
-
 00:28:00.866 --> 00:28:02.606 A:middle
 and they're sitting in the
 background just chewing
@@ -2641,10 +2549,6 @@ activity APIs,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.026 --> 00:29:01.106 A:middle
-Now earlier I mentioned
-activity APIs,
 
 00:29:01.106 --> 00:29:03.166 A:middle
 let me just give a
@@ -2738,9 +2642,6 @@ giving you stock price updates.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.086 --> 00:30:00.076 A:middle
-giving you stock price updates.
 
 00:30:00.076 --> 00:30:01.376 A:middle
 The user might have
@@ -2928,10 +2829,6 @@ timer can fire anywhere
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.236 --> 00:32:00.656 A:middle
-of 1 second, then the
-timer can fire anywhere
-
 00:32:00.656 --> 00:32:02.536 A:middle
 between 2 to 3 seconds.
 
@@ -3024,10 +2921,6 @@ at 10:15,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.436 --> 00:33:01.126 A:middle
-That's tomorrow morning
-at 10:15,
-
 00:33:01.416 --> 00:33:03.336 A:middle
 "Improving Power
 Efficiency with App Nap."
@@ -3113,10 +3006,6 @@ the work that's represented
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:57.146 --> 00:34:00.906 A:middle
-and for the user to cancel
-the work that's represented
-
 00:34:00.936 --> 00:34:01.846 A:middle
 by that progress.
 
@@ -3199,10 +3088,6 @@ one that's observing it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.556 --> 00:35:01.096 A:middle
-be different than the
-one that's observing it.
 
 00:35:01.286 --> 00:35:03.316 A:middle
 A great example of
@@ -3302,10 +3187,6 @@ step and make those cancelable.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.496 --> 00:36:02.326 A:middle
-Now, you can also go to the next
-step and make those cancelable.
-
 00:36:02.786 --> 00:36:04.636 A:middle
 To do that, you would
 go ahead and say
@@ -3401,10 +3282,6 @@ bottom is showing the progress
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.806 --> 00:37:00.886 A:middle
-but the little bar at the
-bottom is showing the progress
 
 00:37:00.886 --> 00:37:02.276 A:middle
 and the X in the corner there
@@ -3510,10 +3387,6 @@ some time in today?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:57.706 --> 00:38:00.316 A:middle
-Is this NSDate object
-some time in today?
-
 00:38:00.896 --> 00:38:03.196 A:middle
 One-line call now to your
 appropriate calendar.
@@ -3601,10 +3474,6 @@ NSDate representing 2:30 a.m.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.956 --> 00:39:01.916 A:middle
-Let's say you want to create
-NSDate representing 2:30 a.m.
 
 00:39:02.126 --> 00:39:02.696 A:middle
 every day.
@@ -3698,10 +3567,6 @@ course there's no 2:30
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.356 --> 00:40:00.246 A:middle
-and in this case of
-course there's no 2:30
 
 00:40:00.246 --> 00:40:02.736 A:middle
 on March 9th time
@@ -3798,10 +3663,6 @@ turns out, treats zero
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.346 --> 00:41:02.186 A:middle
-For instance, even French
-turns out, treats zero
-
 00:41:02.186 --> 00:41:05.486 A:middle
 and one differently
 than the plural cases.
@@ -3888,10 +3749,6 @@ even more like up
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.646 --> 00:42:01.376 A:middle
-turns out some have
-even more like up
 
 00:42:01.376 --> 00:42:02.996 A:middle
 to five in some languages.
@@ -3988,10 +3845,6 @@ substring file count is actually
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.906 --> 00:43:01.946 A:middle
-File count selected and that
-substring file count is actually
 
 00:43:01.946 --> 00:43:03.586 A:middle
 being selected out of
@@ -4090,10 +3943,6 @@ it works implicitly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:57.926 --> 00:44:00.646 A:middle
-SDKs, this is the way
-it works implicitly.
-
 00:44:01.026 --> 00:44:04.506 A:middle
 So this means that when you
 send NSArray and ELAC method,
@@ -4166,10 +4015,6 @@ return ID so the compiler think
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:56.906 --> 00:45:00.026 A:middle
-to the 10.8 is declared to
-return ID so the compiler think
 
 00:45:00.026 --> 00:45:00.886 A:middle
 that it's a good match here.
@@ -4265,10 +4110,6 @@ many cases where we--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:57.326 --> 00:46:00.066 A:middle
-because we found out
-many cases where we--
-
 00:46:00.146 --> 00:46:01.686 A:middle
 we've gotten warnings
 due to this,
@@ -4362,10 +4203,6 @@ discontiguous blocks of data.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.416 --> 00:47:03.426 A:middle
-Dispatch data ts can represent
-discontiguous blocks of data.
-
 00:47:05.156 --> 00:47:06.206 A:middle
 There's a slight, you know,
 
@@ -4453,10 +4290,6 @@ straightforward.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.736 --> 00:48:01.896 A:middle
-The API is fairly
-straightforward.
 
 00:48:02.106 --> 00:48:03.706 A:middle
 You can initialize
@@ -4550,10 +4383,6 @@ cancelable asynchronous
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.496 --> 00:49:00.616 A:middle
-that lets you do simple
-cancelable asynchronous
 
 00:49:00.616 --> 00:49:02.846 A:middle
 operations which has
@@ -4655,10 +4484,6 @@ journaling
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.856 --> 00:50:00.706 A:middle
-This replaces rollback
-journaling
 
 00:50:00.706 --> 00:50:02.276 A:middle
 that was on by default before.
@@ -4920,10 +4745,6 @@ these applications
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:59.086 --> 00:53:00.456 A:middle
-you can now import
-these applications
-
 00:53:00.456 --> 00:53:03.396 A:middle
 to iOS with a lot more ease.
 
@@ -5017,10 +4838,6 @@ level attribute names you no
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:58.046 --> 00:54:01.976 A:middle
-NS metadata APIs and foundation
-level attribute names you no
-
 00:54:01.976 --> 00:54:04.016 A:middle
 longer have to go
 to CF level APIs
@@ -5112,10 +4929,6 @@ is if you have an iOS App,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.306 --> 00:55:00.516 A:middle
-that I haven't talked about
-is if you have an iOS App,
 
 00:55:00.516 --> 00:55:01.946 A:middle
 you're thinking of

--- a/2013/206.srt
+++ b/2013/206.srt
@@ -52,10 +52,6 @@ to cover today?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.426 --> 00:01:01.976 A:middle
-What are we going
-to cover today?
-
 00:01:01.976 --> 00:01:06.126 A:middle
 First, the core concepts in
 architecture of dynamics.
@@ -115,10 +111,6 @@ integrated with the UIKit model.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:56.726 --> 00:02:00.616 A:middle
-Easier to use API, web
-integrated with the UIKit model.
-
 00:02:01.526 --> 00:02:05.016 A:middle
 And we actually include
 that a lot in iOS 7.
@@ -171,10 +163,6 @@ screen refresh level.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.546 --> 00:03:03.466 A:middle
-and animate things at
-screen refresh level.
 
 00:03:03.796 --> 00:03:11.116 A:middle
 And of course, you can actually
@@ -274,10 +262,6 @@ corner of this picture,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.536 --> 00:05:03.126 A:middle
-But when I drag by the
-corner of this picture,
-
 00:05:04.296 --> 00:05:06.906 A:middle
 it will react the
 way you would expect
@@ -323,10 +307,6 @@ a WWDC demo app.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:55.896 --> 00:06:00.946 A:middle
-So of course, that's
-a WWDC demo app.
 
 00:06:00.946 --> 00:06:03.176 A:middle
 How complex is that?
@@ -383,10 +363,6 @@ world inspired interactions.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.166 --> 00:07:00.556 A:middle
-to [inaudible] model real
-world inspired interactions.
 
 00:07:01.106 --> 00:07:04.856 A:middle
 And we wanted also
@@ -453,10 +429,6 @@ for the tap bounce effect.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.426 --> 00:08:03.316 A:middle
-There is a predefined animation
-for the tap bounce effect.
-
 00:08:04.216 --> 00:08:07.466 A:middle
 And because it's a
 completely predefine animation,
@@ -515,10 +487,6 @@ thinking about this API,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:55.786 --> 00:09:02.606 A:middle
-How? When we start to
-thinking about this API,
-
 00:09:02.606 --> 00:09:08.786 A:middle
 an interesting question was,
 where should we add that?
@@ -569,10 +537,6 @@ compose Predefined behaviors
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:54.566 --> 00:10:00.436 A:middle
-And in dynamics, we
-compose Predefined behaviors
 
 00:10:00.586 --> 00:10:02.366 A:middle
 for you own behaviors.
@@ -626,10 +590,6 @@ then you associate behaviors,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:56.816 --> 00:11:01.366 A:middle
-which provides the context, and
-then you associate behaviors,
-
 00:11:01.856 --> 00:11:05.356 A:middle
 UIDynamicBehavior
 subclasses to this animator.
@@ -675,10 +635,6 @@ of that reference view.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:54.206 --> 00:12:00.466 A:middle
-of the view hierarchy
-of that reference view.
 
 00:12:00.686 --> 00:12:05.716 A:middle
 So that's-- see in more
@@ -738,10 +694,6 @@ something that is going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.116 --> 00:13:00.666 A:middle
-UIDynamicBehavior is
-something that is going
-
 00:13:00.666 --> 00:13:02.886 A:middle
 to be associated
 with DynamicAnimator.
@@ -793,9 +745,6 @@ And it's really easy to use.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:56.506 --> 00:14:01.316 A:middle
-And it's really easy to use.
 
 00:14:01.316 --> 00:14:02.606 A:middle
 Usually, you just want
@@ -852,10 +801,6 @@ before or after adding it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:53.346 --> 00:15:02.196 A:middle
-You can configure a behavior
-before or after adding it
-
 00:15:02.576 --> 00:15:09.066 A:middle
 to an animator and the influence
 of a behavior stops as soon
@@ -906,10 +851,6 @@ instance, or density.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.366 --> 00:16:03.096 A:middle
-like friction, for
-instance, or density.
 
 00:16:04.226 --> 00:16:07.386 A:middle
 So, let's explore this
@@ -963,10 +904,6 @@ remove items at any time.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:55.746 --> 00:17:00.856 A:middle
-And you can add and
-remove items at any time.
-
 00:17:01.436 --> 00:17:04.866 A:middle
 It's quite easy to use.
 
@@ -1016,9 +953,6 @@ points on devices.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.516 --> 00:18:04.296 A:middle
-[ Applause ]
 
 00:18:04.796 --> 00:18:07.636 A:middle
 Collision behavior, that is
@@ -1070,10 +1004,6 @@ views and boundaries.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:56.846 --> 00:19:00.426 A:middle
-or a views colliding with
-views and boundaries.
 
 00:19:02.936 --> 00:19:07.706 A:middle
 Like gravity, you can
@@ -1128,10 +1058,6 @@ cost we have to detect,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.586 --> 00:20:01.466 A:middle
-so collisions do have a
-cost we have to detect,
-
 00:20:01.856 --> 00:20:04.506 A:middle
 compute when we have collisions.
 
@@ -1180,10 +1106,6 @@ that we basically approximate
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:56.516 --> 00:21:00.116 A:middle
-In that case, you have to know
-that we basically approximate
 
 00:21:00.246 --> 00:21:03.056 A:middle
 that with a set off lines.
@@ -1240,10 +1162,6 @@ with a view,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.646 --> 00:22:02.196 A:middle
-So, when a view collides
-with a view,
 
 00:22:03.156 --> 00:22:06.476 A:middle
 you can implement this
@@ -1327,10 +1245,6 @@ in UIAttachmentBehavior.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:57.796 --> 00:24:02.736 A:middle
-There is a nice feature
-in UIAttachmentBehavior.
 
 00:24:09.036 --> 00:24:14.616 A:middle
 Springs. You can configure an
@@ -1430,10 +1344,6 @@ way of the screen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.966 --> 00:26:01.766 A:middle
-in a very strange
-way of the screen.
-
 00:26:02.316 --> 00:26:09.096 A:middle
 So, again, to start with
 a very simple attachment.
@@ -1478,10 +1388,6 @@ that view or pull it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:55.106 --> 00:27:00.696 A:middle
-I can actually push
-that view or pull it.
 
 00:27:01.316 --> 00:27:04.556 A:middle
 And just because of
@@ -1537,10 +1443,6 @@ just pass an item and a point
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:57.496 --> 00:28:05.306 A:middle
-To create a Snap behavior, you
-just pass an item and a point
-
 00:28:05.306 --> 00:28:09.876 A:middle
 in the reference view coordinate
 system, and you just add
@@ -1593,10 +1495,6 @@ force vector, xComponent,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.676 --> 00:29:03.416 A:middle
-It's defined with a very simple
-force vector, xComponent,
 
 00:29:03.416 --> 00:29:07.296 A:middle
 yComponent, or magnitude
@@ -1654,9 +1552,6 @@ to accelerate 1 kilogram to
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.016 --> 00:30:01.000 A:middle
-[ Laughter ]
 
 00:30:02.176 --> 00:30:03.576 A:middle
 UIKit Newton.
@@ -1719,10 +1614,6 @@ kick it a little bit.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.996 --> 00:31:02.426 A:middle
-over time it will just
-kick it a little bit.
 
 00:31:03.546 --> 00:31:09.076 A:middle
 And it's going to
@@ -1847,9 +1738,6 @@ Yup, that's correct.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.646 --> 00:33:00.916 A:middle
-Yup, that's correct.
-
 00:33:01.306 --> 00:33:08.386 A:middle
 And the third mode is Push
 behavior in instantaneous mode.
@@ -1896,9 +1784,6 @@ have for Push behaviors.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:51.516 --> 00:34:01.536 A:middle
-[ Applause ]
 
 00:34:02.036 --> 00:34:03.856 A:middle
 UIDynamicItemBehavior.
@@ -1953,10 +1838,6 @@ one is elasticity
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.936 --> 00:35:02.716 A:middle
-Another interesting
-one is elasticity
 
 00:35:02.716 --> 00:35:09.226 A:middle
 which is the restitution when
@@ -2070,10 +1951,6 @@ points per second.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.816 --> 00:37:02.896 A:middle
-it's expressed in
-points per second.
-
 00:37:07.136 --> 00:37:08.366 A:middle
 Applying Dynamics.
 
@@ -2120,10 +1997,6 @@ active behavior and we detect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:53.956 --> 00:38:00.496 A:middle
-As soon as we have a view in an
-active behavior and we detect
 
 00:38:00.496 --> 00:38:04.886 A:middle
 that the system is not
@@ -2173,10 +2046,6 @@ really have animations, right?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:55.076 --> 00:39:01.306 A:middle
-with that boundary, you won't
-really have animations, right?
 
 00:39:02.116 --> 00:39:05.036 A:middle
 And we are going to be
@@ -2229,10 +2098,6 @@ add your views,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.236 --> 00:40:00.396 A:middle
-Start with one behavior,
-add your views,
 
 00:40:01.046 --> 00:40:03.806 A:middle
 configure that behavior,
@@ -2296,10 +2161,6 @@ we do not support explicitly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.936 --> 00:41:02.026 A:middle
-That is your configuration that
-we do not support explicitly.
-
 00:41:02.566 --> 00:41:11.036 A:middle
 And that's really a core
 concept of dynamics.
@@ -2347,10 +2208,6 @@ behavior to be animated.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:55.576 --> 00:42:00.696 A:middle
-with a Predefined
-behavior to be animated.
 
 00:42:01.096 --> 00:42:04.996 A:middle
 And what UIKit needs
@@ -2405,10 +2262,6 @@ own dynamic item.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.896 --> 00:43:02.156 A:middle
-You can define your
-own dynamic item.
 
 00:43:02.886 --> 00:43:07.796 A:middle
 Your own classes
@@ -2465,10 +2318,6 @@ size, and that's not UIView.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:56.296 --> 00:44:01.266 A:middle
-to transform and which has a
-size, and that's not UIView.
 
 00:44:05.376 --> 00:44:07.146 A:middle
 CollectionViewLayoutAttributes.
@@ -2578,9 +2427,6 @@ a little bit silly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:54.516 --> 00:46:00.116 A:middle
-[ Pause ]
-
 00:46:00.616 --> 00:46:01.966 A:middle
 That's a CollectionView.
 
@@ -2687,10 +2533,6 @@ custom transition using
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:56.776 --> 00:48:01.946 A:middle
-We have some related sessions
-custom transition using
 
 00:48:01.946 --> 00:48:02.836 A:middle
 View Controllers.

--- a/2013/207.srt
+++ b/2013/207.srt
@@ -71,10 +71,6 @@ radars and around the web.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.346 --> 00:01:00.786 A:middle
-on developer forums, in
-radars and around the web.
-
 00:01:01.606 --> 00:01:04.626 A:middle
 And so, the improvements
 that we've made require us
@@ -154,10 +150,6 @@ to frame it by talking
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.736 --> 00:02:01.826 A:middle
-I'd like to take a moment
-to frame it by talking
 
 00:02:01.826 --> 00:02:04.476 A:middle
 about our goals and
@@ -240,10 +232,6 @@ to build effective applications
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.246 --> 00:03:01.656 A:middle
-that this hampered your ability
-to build effective applications
-
 00:03:01.996 --> 00:03:03.706 A:middle
 that worked on top
 of our integration.
@@ -321,10 +309,6 @@ a pairing, if you will,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.676 --> 00:04:00.986 A:middle
-And this would produce
-a pairing, if you will,
 
 00:04:01.056 --> 00:04:03.226 A:middle
 of a local persistent store file
@@ -413,10 +397,6 @@ that's in use on a system,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.706 --> 00:05:02.186 A:middle
-for each iCloud account
-that's in use on a system,
-
 00:05:03.136 --> 00:05:04.806 A:middle
 and this requires
 that we change a bit
@@ -496,10 +476,6 @@ and for this reason,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.836 --> 00:06:01.596 A:middle
-to the fallback store,
-and for this reason,
 
 00:06:01.596 --> 00:06:03.606 A:middle
 we'll log some new
@@ -589,9 +565,6 @@ up the store asynchronously.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.956 --> 00:07:01.356 A:middle
-up the store asynchronously.
 
 00:07:02.736 --> 00:07:05.046 A:middle
 You may be familiar
@@ -747,10 +720,6 @@ iCloud store was available,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.426 --> 00:09:00.486 A:middle
-to the iCloud store after the
-iCloud store was available,
-
 00:09:01.186 --> 00:09:04.116 A:middle
 you would have to do a
 lot of extra work to scope
@@ -834,10 +803,6 @@ that you wish to persist,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.196 --> 00:10:01.706 A:middle
-in your managed object context
-that you wish to persist,
 
 00:10:02.286 --> 00:10:05.126 A:middle
 and then you can call
@@ -923,10 +888,6 @@ this is a special case scenario.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.686 --> 00:11:01.866 A:middle
-Now, I need to mention that
-this is a special case scenario.
-
 00:11:02.516 --> 00:11:04.686 A:middle
 You will only see these
 notifications during our
@@ -1007,10 +968,6 @@ and Mac OS X 10.8,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.776 --> 00:12:02.126 A:middle
-Normally in iOS 6
-and Mac OS X 10.8,
-
 00:12:02.696 --> 00:12:05.966 A:middle
 when the iCloud account changes,
 the only way to notice this is
@@ -1086,10 +1043,6 @@ at all.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.906 --> 00:13:00.556 A:middle
-of the iCloud notifications
-at all.
 
 00:13:01.206 --> 00:13:04.096 A:middle
 You simply implement your will
@@ -1176,10 +1129,6 @@ context, you can still write
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.966 --> 00:14:02.926 A:middle
-out your managed object
-context, you can still write
-
 00:14:02.926 --> 00:14:04.426 A:middle
 to the managed object context
 
@@ -1251,10 +1200,6 @@ that's managed by Core Data
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.026 --> 00:15:01.006 A:middle
-This is a special store
-that's managed by Core Data
-
 00:15:01.006 --> 00:15:02.766 A:middle
 so that you don't have
 to do anything special
@@ -1325,10 +1270,6 @@ the file from the cloud.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.506 --> 00:16:00.006 A:middle
-because we can rebuild
-the file from the cloud.
 
 00:16:00.366 --> 00:16:02.716 A:middle
 So we want to free up as
@@ -1404,10 +1345,6 @@ called NSPersistentStore
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:57.866 --> 00:17:00.686 A:middle
-to us and as an option
-called NSPersistentStore
-
 00:17:00.836 --> 00:17:04.896 A:middle
 UbiquitousContentURLKey,
 and this is how we know
@@ -1482,10 +1419,6 @@ value in so we can find it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.836 --> 00:18:00.326 A:middle
-you need to pass this
-value in so we can find it.
 
 00:18:00.936 --> 00:18:03.186 A:middle
 Otherwise, we'll
@@ -1571,10 +1504,6 @@ need to pass us this option
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.756 --> 00:19:02.116 A:middle
-that isn't the first one, you
-need to pass us this option
 
 00:19:02.116 --> 00:19:03.836 A:middle
 so that we know which
@@ -1664,10 +1593,6 @@ built from the cloud.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.256 --> 00:20:00.976 A:middle
-with one that's freshly
-built from the cloud.
-
 00:20:03.116 --> 00:20:05.056 A:middle
 We're also introducing
 a new option
@@ -1748,10 +1673,6 @@ we can correctly identify the
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.786 --> 00:21:03.276 A:middle
-that you normally pass so that
-we can correctly identify the
-
 00:21:03.276 --> 00:21:05.586 A:middle
 store and its content
 in the iCloud account.
@@ -1825,10 +1746,6 @@ iCloud content, as well.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:57.266 --> 00:22:00.566 A:middle
-and then nuke the
-iCloud content, as well.
 
 00:22:01.276 --> 00:22:03.846 A:middle
 And we have some special
@@ -1913,10 +1830,6 @@ events related to iCloud.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.826 --> 00:23:01.166 A:middle
-for handling transition
-events related to iCloud.
-
 00:23:02.736 --> 00:23:05.346 A:middle
 The user info dictionary
 will contain instances
@@ -1996,9 +1909,6 @@ that developers have to write.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.686 --> 00:24:00.906 A:middle
-that developers have to write.
 
 00:24:01.726 --> 00:24:04.836 A:middle
 And so, with the Will
@@ -2083,9 +1993,6 @@ with our iCloud integration.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.656 --> 00:25:00.986 A:middle
-with our iCloud integration.
-
 00:25:00.986 --> 00:25:03.376 A:middle
 And so that's all
 for the new API.
@@ -2168,10 +2075,6 @@ every single file inside the
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.136 --> 00:26:02.016 A:middle
-You can also see a list of
-every single file inside the
 
 00:26:02.016 --> 00:26:04.526 A:middle
 container, including
@@ -2256,10 +2159,6 @@ settings on your Mac.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.036 --> 00:27:00.016 A:middle
-without having to change
-settings on your Mac.
-
 00:27:00.586 --> 00:27:05.806 A:middle
 As well, you can also test sync
 between a Mac and an iOS device
@@ -2340,10 +2239,6 @@ so if you turn that up,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.476 --> 00:28:01.026 A:middle
-Number 3 is the highest,
-so if you turn that up,
 
 00:28:01.086 --> 00:28:02.716 A:middle
 expect to get a lot of logs.
@@ -2582,9 +2477,6 @@ that we've made this year.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:57.516 --> 00:31:02.186 A:middle
-[ Applause ]
-
 00:31:02.686 --> 00:31:03.836 A:middle
 &gt;&gt; Melissa Turner:
 I'm Melissa Turner.
@@ -2669,10 +2561,6 @@ here is, well, a hang as I wait
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.256 --> 00:32:02.926 A:middle
-And what you're not seeing
-here is, well, a hang as I wait
-
 00:32:02.926 --> 00:32:07.796 A:middle
 for addPersistentStore to return
 with my ubiquitized store.
@@ -2750,10 +2638,6 @@ about your iCloud status.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.396 --> 00:33:01.546 A:middle
-about your application and
-about your iCloud status.
 
 00:33:02.096 --> 00:33:04.466 A:middle
 If you bring up this pane when
@@ -2858,10 +2742,6 @@ and you really don't need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.656 --> 00:34:03.286 A:middle
-in your ubiquity container,
-and you really don't need
-
 00:34:03.286 --> 00:34:05.376 A:middle
 to pay attention to the
 stuff that starts with a dot,
@@ -2937,10 +2817,6 @@ but it's still in the cloud
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.646 --> 00:35:01.056 A:middle
-whether we know it exists
-but it's still in the cloud
 
 00:35:01.056 --> 00:35:02.746 A:middle
 because it's a large file
@@ -3089,10 +2965,6 @@ of you who are
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.586 --> 00:37:02.356 A:middle
-to Wi-Fi, and those
-of you who are
-
 00:37:02.356 --> 00:37:04.646 A:middle
 in the front rows
 can probably see
@@ -3158,10 +3030,6 @@ my Ethernet cable and plug
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.856 --> 00:38:04.506 A:middle
-but first I'm going to find
-my Ethernet cable and plug
-
 00:38:04.506 --> 00:38:10.236 A:middle
 in my Ethernet cable and log in.
 
@@ -3208,10 +3076,6 @@ when Core Data tries to go out
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.356 --> 00:39:03.016 A:middle
-This is the log you'll see
-when Core Data tries to go out
 
 00:39:03.016 --> 00:39:09.836 A:middle
 and connect to the iCloud
@@ -3285,10 +3149,6 @@ the Core Data SQLite store.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.166 --> 00:40:01.936 A:middle
-that we've been making to
-the Core Data SQLite store.
 
 00:40:03.516 --> 00:40:09.526 A:middle
 [ Applause ]
@@ -3365,10 +3225,6 @@ out of the main database file
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.336 --> 00:41:00.836 A:middle
-SQLite copies the original pages
-out of the main database file
 
 00:41:00.836 --> 00:41:04.136 A:middle
 into a file on the side just
@@ -3453,9 +3309,6 @@ floating alongside of it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.466 --> 00:42:00.966 A:middle
-floating alongside of it.
-
 00:42:01.346 --> 00:42:05.306 A:middle
 And then when you commit the
 transaction, it'll go through
@@ -3535,10 +3388,6 @@ transient state of affairs,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.836 --> 00:43:02.306 A:middle
-but that's going to be a fairly
-transient state of affairs,
 
 00:43:02.506 --> 00:43:04.366 A:middle
 and generally you're
@@ -3626,10 +3475,6 @@ a pretty big difference
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.346 --> 00:44:01.666 A:middle
-And this has actually been
-a pretty big difference
-
 00:44:01.716 --> 00:44:03.786 A:middle
 on [inaudible] devices and iOS.
 
@@ -3708,10 +3553,6 @@ you have this SQLite file
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:55.596 --> 00:45:00.556 A:middle
-So for leveraging concurrency,
-you have this SQLite file
 
 00:45:00.556 --> 00:45:02.496 A:middle
 that you're sharing between
@@ -3806,9 +3647,6 @@ operation in the background.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.426 --> 00:46:00.486 A:middle
-operation in the background.
-
 00:46:00.486 --> 00:46:03.196 A:middle
 So this is particularly
 useful for responsiveness
@@ -3902,10 +3740,6 @@ as their documents and some
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.246 --> 00:47:01.586 A:middle
-of free standing SQLite files
-as their documents and some
-
 00:47:01.586 --> 00:47:03.056 A:middle
 of them is running
 to some challenges
@@ -3983,10 +3817,6 @@ really shouldn't be using any
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:57.336 --> 00:48:01.046 A:middle
-Now, some general caveats is you
-really shouldn't be using any
 
 00:48:01.046 --> 00:48:03.046 A:middle
 file system routines directly
@@ -4080,10 +3910,6 @@ machines simultaneously is not
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.136 --> 00:49:01.956 A:middle
-across multiple different
-machines simultaneously is not
-
 00:49:01.956 --> 00:49:02.946 A:middle
 going to end very well.
 
@@ -4159,9 +3985,6 @@ that's being used.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.416 --> 00:50:00.176 A:middle
-that's being used.
 
 00:50:00.176 --> 00:50:02.436 A:middle
 We're not going to go

--- a/2013/208.srt
+++ b/2013/208.srt
@@ -62,10 +62,6 @@ eventually and talk
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:56.516 --> 00:01:00.156 A:middle
-to introduce Mike Stern
-eventually and talk
-
 00:01:00.156 --> 00:01:02.176 A:middle
 about what the new
 user interface means
@@ -124,10 +120,6 @@ on so many different levels.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:57.766 --> 00:02:05.586 A:middle
-The way something actually works
-on so many different levels.
-
 00:02:05.806 --> 00:02:07.936 A:middle
 Ultimately, of course,
 design defines
@@ -170,10 +162,6 @@ structure that is coherent
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.106 --> 00:03:00.856 A:middle
-It has a whole new
-structure that is coherent
 
 00:03:01.336 --> 00:03:08.166 A:middle
 and it is applied
@@ -228,9 +216,6 @@ of your context.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.076 --> 00:04:01.066 A:middle
-of your context.
-
 00:04:01.606 --> 00:04:06.036 A:middle
 These planes, combined with
 new approaches to animation
@@ -283,9 +268,6 @@ across the entire system.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.916 --> 00:05:00.466 A:middle
-across the entire system.
-
 00:05:00.466 --> 00:05:01.056 A:middle
 [ Music ]
 
@@ -337,9 +319,6 @@ and in many ways, a beginning.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.096 --> 00:06:00.096 A:middle
-[ Applause ]
 
 00:06:00.566 --> 00:06:02.436 A:middle
 &gt;&gt; Greg Christie: I won't
@@ -416,10 +395,6 @@ unnecessary edges and borders,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.406 --> 00:07:03.626 A:middle
-blowing out the edges, removing
-unnecessary edges and borders,
-
 00:07:04.266 --> 00:07:06.876 A:middle
 refining the typography,
 refining the line work,
@@ -492,10 +467,6 @@ the rest of the information.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.256 --> 00:08:01.366 A:middle
-yet fit in a sound design with
-the rest of the information.
 
 00:08:02.716 --> 00:08:06.216 A:middle
 Being clear means clearly
@@ -570,10 +541,6 @@ reinforcing clarity
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.456 --> 00:09:01.366 A:middle
-Another way that we're
-reinforcing clarity
-
 00:09:01.816 --> 00:09:04.316 A:middle
 and this difference between
 controls and content,
@@ -633,9 +600,6 @@ of apps that are on iOS.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.786 --> 00:10:01.456 A:middle
-of apps that are on iOS.
 
 00:10:02.416 --> 00:10:04.516 A:middle
 This also applies to the
@@ -785,10 +749,6 @@ final design for Mail.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:56.766 --> 00:13:00.126 A:middle
-Then this is the
-final design for Mail.
-
 00:13:00.676 --> 00:13:03.676 A:middle
 As you can see when photos
 were added they were made to be
@@ -853,10 +813,6 @@ designer for 17 years
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:57.686 --> 00:14:00.666 A:middle
-I've worked as an interface
-designer for 17 years
 
 00:14:01.086 --> 00:14:03.296 A:middle
 and I've worked on countless
@@ -1007,10 +963,6 @@ didn't stop there.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.776 --> 00:16:00.516 A:middle
-but of course we
-didn't stop there.
-
 00:16:01.496 --> 00:16:03.706 A:middle
 Text that has more
 space between characters
@@ -1096,10 +1048,6 @@ screen is the most important
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.346 --> 00:17:02.266 A:middle
-The Inbox, the title for the
-screen is the most important
-
 00:17:02.266 --> 00:17:04.195 A:middle
 thing here so you
 know where you are,
@@ -1174,10 +1122,6 @@ are really important
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.686 --> 00:18:00.356 A:middle
-These kinds of details
-are really important
 
 00:18:00.356 --> 00:18:02.636 A:middle
 with visual design.
@@ -1414,10 +1358,6 @@ but we improved upon it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.676 --> 00:21:02.136 A:middle
-that we particularly innovated
-but we improved upon it,
-
 00:21:02.276 --> 00:21:03.116 A:middle
 we can make it better.
 
@@ -1506,10 +1446,6 @@ mode, so it's really seamless.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:57.396 --> 00:22:00.526 A:middle
-which is to go into this Edit
-mode, so it's really seamless.
 
 00:22:00.836 --> 00:22:02.086 A:middle
 Think about that with your apps.
@@ -1742,10 +1678,6 @@ talk about animation
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:57.856 --> 00:25:00.446 A:middle
-Now I also want to
-talk about animation
-
 00:25:00.446 --> 00:25:01.766 A:middle
 and moving across days.
 
@@ -1834,10 +1766,6 @@ talk about with animation is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.656 --> 00:26:04.696 A:middle
-So the next thing I want to
-talk about with animation is
-
 00:26:04.696 --> 00:26:07.956 A:middle
 that making really
 good animations is kind
@@ -1915,10 +1843,6 @@ feel more deeply lifelike.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.156 --> 00:27:02.466 A:middle
-that to your apps to make them
-feel more deeply lifelike.
 
 00:27:03.686 --> 00:27:07.356 A:middle
 It's great stuff.
@@ -2003,10 +1927,6 @@ no doubt where, how you get back
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.826 --> 00:28:03.896 A:middle
-Your eye follows it so there's
-no doubt where, how you get back
 
 00:28:03.896 --> 00:28:04.996 A:middle
 to where you were before.
@@ -2174,10 +2094,6 @@ available at any point
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.026 --> 00:30:01.046 A:middle
-so it's immediately
-available at any point
-
 00:30:01.586 --> 00:30:02.536 A:middle
 when you're using Calendar.
 
@@ -2268,10 +2184,6 @@ seen these icons a million times
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:57.236 --> 00:31:00.446 A:middle
-And it works because you've
-seen these icons a million times
-
 00:31:00.976 --> 00:31:04.346 A:middle
 and every time you've pressed
 one of those icons it responded
@@ -2357,10 +2269,6 @@ to find the answers you get.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.856 --> 00:32:01.226 A:middle
-You might be really surprised
-to find the answers you get.
-
 00:32:02.086 --> 00:32:05.256 A:middle
 It's often more clear
 to use text.
@@ -2435,9 +2343,6 @@ This was Notes.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.906 --> 00:33:02.166 A:middle
-This was Notes.
-
 00:33:02.766 --> 00:33:05.106 A:middle
 This was Notes from iOS 6
 
@@ -2505,9 +2410,6 @@ It's 2007, there is no iPhone,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.426 --> 00:34:00.866 A:middle
-It's 2007, there is no iPhone,
 
 00:34:01.056 --> 00:34:02.546 A:middle
 you don't know what
@@ -2580,10 +2482,6 @@ starts to ruin the illusion.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.085 --> 00:35:00.066 A:middle
-So when you add that it
-starts to ruin the illusion.
 
 00:35:00.676 --> 00:35:01.886 A:middle
 Things start to breakdown.
@@ -2661,10 +2559,6 @@ iOS 7 and that's the title.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.956 --> 00:36:02.486 A:middle
-There's something missing in
-iOS 7 and that's the title.
 
 00:36:03.326 --> 00:36:06.066 A:middle
 Now we've always advised
@@ -2748,10 +2642,6 @@ you'll see this yellow color
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:56.806 --> 00:37:00.286 A:middle
-Now you'll see that the color,
-you'll see this yellow color
-
 00:37:00.286 --> 00:37:02.946 A:middle
 in Notes and that's the tint
 color of the application.
@@ -2825,9 +2715,6 @@ so that they matched each other.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.966 --> 00:38:00.576 A:middle
-so that they matched each other.
-
 00:38:01.886 --> 00:38:04.196 A:middle
 They're straightforward,
 front on,
@@ -2900,10 +2787,6 @@ make icons match each other,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:57.176 --> 00:39:02.206 A:middle
-Now it wasn't sufficient to just
-make icons match each other,
 
 00:39:03.156 --> 00:39:06.316 A:middle
 they also match the
@@ -2979,10 +2862,6 @@ a lot of you know what it means
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.346 --> 00:40:03.116 A:middle
-Now this is a $5 word and I know
-a lot of you know what it means
 
 00:40:04.036 --> 00:40:05.966 A:middle
 but I've heard different
@@ -3066,10 +2945,6 @@ the previous version of Weather
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:58.376 --> 00:41:01.276 A:middle
-of all this data that we saw in
-the previous version of Weather
 
 00:41:01.556 --> 00:41:03.406 A:middle
 and it was there for a
@@ -3156,10 +3031,6 @@ we play with it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.546 --> 00:42:01.066 A:middle
-rotate everything,
-we play with it.
-
 00:42:01.066 --> 00:42:02.106 A:middle
 It feels comfortable.
 
@@ -3242,9 +3113,6 @@ As a result Weather is a simple,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:57.466 --> 00:43:02.306 A:middle
-As a result Weather is a simple,
-
 00:43:02.846 --> 00:43:05.786 A:middle
 beautiful app that's
 really easy to use.
@@ -3317,10 +3185,6 @@ what this was for?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.946 --> 00:44:02.146 A:middle
-so you understood
-what this was for?
-
 00:44:02.656 --> 00:44:06.276 A:middle
 No. And did it limit what
 was possible with Compass?
@@ -3386,10 +3250,6 @@ so they're more legible.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.996 --> 00:45:02.426 A:middle
-the letters stay upright
-so they're more legible.
 
 00:45:02.766 --> 00:45:05.996 A:middle
 Again, if we had done this
@@ -3530,10 +3390,6 @@ this consistent way
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.316 --> 00:47:00.716 A:middle
-Selection is shown in
-this consistent way
-
 00:47:00.986 --> 00:47:05.696 A:middle
 so each control reinforces
 how selection is indicated.
@@ -3607,10 +3463,6 @@ is really easy to see
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:56.996 --> 00:48:00.746 A:middle
-and which value is selected
-is really easy to see
 
 00:48:00.876 --> 00:48:01.906 A:middle
 because it's darker text,
@@ -3690,10 +3542,6 @@ would press on the Back button.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:56.626 --> 00:49:00.686 A:middle
-Now, to get back previously you
-would press on the Back button.
 
 00:49:01.176 --> 00:49:04.746 A:middle
 That makes sense and you still
@@ -3781,10 +3629,6 @@ just reinforces that sense
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:57.906 --> 00:50:01.786 A:middle
-and the colors coming through
-just reinforces that sense
-
 00:50:01.786 --> 00:50:05.266 A:middle
 of depth, and that's
 important because you bring
@@ -3869,10 +3713,6 @@ time talking about these icons.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.646 --> 00:51:01.116 A:middle
-so we'll spend a little bit of
-time talking about these icons.
-
 00:51:02.446 --> 00:51:06.726 A:middle
 Gone are the heaviest of
 textures, the stripes,
@@ -3950,9 +3790,6 @@ that all have a bunch
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.866 --> 00:52:00.576 A:middle
-that all have a bunch
 
 00:52:00.576 --> 00:52:02.686 A:middle
 of ornamentation it
@@ -4034,10 +3871,6 @@ simpler but the approach
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:56.956 --> 00:53:00.146 A:middle
-Now these icons they're
-simpler but the approach
-
 00:53:00.146 --> 00:53:01.916 A:middle
 to designing them
 wasn't simplistic.
@@ -4098,10 +3931,6 @@ this template our icons share
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:56.036 --> 00:54:02.416 A:middle
-But as a result of following
-this template our icons share
 
 00:54:02.796 --> 00:54:06.236 A:middle
 things like this blue dot
@@ -4179,9 +4008,6 @@ So some final thoughts.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:54:59.706 --> 00:55:02.386 A:middle
-So some final thoughts.
-
 00:55:03.916 --> 00:55:09.716 A:middle
 The values that were at the
 heart of iOS 7 were clarity,
@@ -4230,9 +4056,6 @@ so you can see the detail.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:56.646 --> 00:56:02.576 A:middle
-so you can see the detail.
 
 00:56:04.296 --> 00:56:06.206 A:middle
 Depth. Now I didn't
@@ -4370,10 +4193,6 @@ developers making apps.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:57:58.196 --> 00:58:01.026 A:middle
-about it, for you
-developers making apps.
-
 00:58:02.056 --> 00:58:06.416 A:middle
 There's some amazing new tools
 in iOS 7 and we've applied those
@@ -4447,10 +4266,6 @@ make some cool stuff
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:58:57.556 --> 00:59:00.576 A:middle
-So go out there,
-make some cool stuff
 
 00:59:01.436 --> 00:59:02.726 A:middle
 and let's regroup in a year.

--- a/2013/209.srt
+++ b/2013/209.srt
@@ -81,10 +81,6 @@ for this talk, energy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.466 --> 00:01:01.666 A:middle
-and most importantly
-for this talk, energy.
-
 00:01:02.246 --> 00:01:06.656 A:middle
 So in designing this feature, we
 wanted to focus system resources
@@ -163,10 +159,6 @@ space that's been moved away is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:55.966 --> 00:02:00.316 A:middle
-by other windows or on another
-space that's been moved away is
 
 00:02:00.316 --> 00:02:02.196 A:middle
 typically doing less
@@ -262,9 +254,6 @@ Okay, so here we go.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.446 --> 00:03:01.276 A:middle
-Okay, so here we go.
 
 00:03:01.276 --> 00:03:03.476 A:middle
 If you've ever been to a
@@ -366,10 +355,6 @@ move my Activity Monitor window
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.696 --> 00:04:02.096 A:middle
-So what I'm going to do is
-move my Activity Monitor window
-
 00:04:02.096 --> 00:04:06.136 A:middle
 in front of these other
 two windows and we'll see
@@ -460,10 +445,6 @@ stored potential to do work.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.526 --> 00:05:03.836 A:middle
-Energy on the other hand is the
-stored potential to do work.
-
 00:05:04.096 --> 00:05:06.576 A:middle
 And one way to measure that
 might be in watt hours.
@@ -545,9 +526,6 @@ to have the most impact on.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.026 --> 00:06:00.356 A:middle
-to have the most impact on.
 
 00:06:00.776 --> 00:06:02.146 A:middle
 But second and most importantly,
@@ -638,10 +616,6 @@ need to avoid unnecessary work
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:56.916 --> 00:07:00.366 A:middle
-And to do that - Number 2 - we
-need to avoid unnecessary work
 
 00:07:00.726 --> 00:07:02.546 A:middle
 like drawing a pair of
@@ -736,10 +710,6 @@ Apple.com into the address bar
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.016 --> 00:08:02.236 A:middle
-At the beginning, I was typing
-Apple.com into the address bar
-
 00:08:02.336 --> 00:08:04.596 A:middle
 and so that's not just the key
 presses that we need to handle:
@@ -831,10 +801,6 @@ more energy than Safari,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.436 --> 00:09:01.976 A:middle
-is using significantly
-more energy than Safari,
-
 00:09:01.976 --> 00:09:03.496 A:middle
 rendering an entire webpage.
 
@@ -916,10 +882,6 @@ there's so much API
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.296 --> 00:10:00.116 A:middle
-And that's because
-there's so much API
 
 00:10:00.116 --> 00:10:01.586 A:middle
 that actually involves timers.
@@ -1009,9 +971,6 @@ The first is timer coalescing
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.566 --> 00:11:01.206 A:middle
-The first is timer coalescing
 
 00:11:01.276 --> 00:11:03.356 A:middle
 and the second is
@@ -1107,10 +1066,6 @@ to our lowest power state.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.776 --> 00:12:02.816 A:middle
-between that deadline to go
-to our lowest power state.
-
 00:12:02.996 --> 00:12:05.516 A:middle
 So instead, we choose
 something a little bit less.
@@ -1196,10 +1151,6 @@ could also turn on the screen
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.796 --> 00:13:00.496 A:middle
-you might use the CPU but you
-could also turn on the screen
 
 00:13:00.956 --> 00:13:03.296 A:middle
 or do some drawing
@@ -1294,10 +1245,6 @@ see here reduce the impact
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.216 --> 00:14:02.786 A:middle
-And what that does is you
-see here reduce the impact
 
 00:14:02.786 --> 00:14:03.856 A:middle
 of the second order effect.
@@ -1394,10 +1341,6 @@ about why: what's the result?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.616 --> 00:15:00.886 A:middle
-But first I want to talk
-about why: what's the result?
 
 00:15:00.886 --> 00:15:04.846 A:middle
 The end game in doing all of
@@ -1570,10 +1513,6 @@ entire talk about these kinds
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:56.496 --> 00:17:00.146 A:middle
-So we actually have an
-entire talk about these kinds
-
 00:17:00.146 --> 00:17:02.056 A:middle
 of patterns and ways
 that you can do better.
@@ -1669,9 +1608,6 @@ which is Update Mouse Locations.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.926 --> 00:18:00.526 A:middle
-which is Update Mouse Locations.
 
 00:18:00.956 --> 00:18:05.106 A:middle
 And here what we do is you
@@ -1835,10 +1771,6 @@ using Event Monitor.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.286 --> 00:20:01.906 A:middle
-In its place, I'm
-using Event Monitor.
-
 00:20:02.256 --> 00:20:05.156 A:middle
 Now this is an API that
 was added all the way back
@@ -1930,10 +1862,6 @@ overhead transition time
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.136 --> 00:21:02.046 A:middle
-event, that means a lot less
-overhead transition time
 
 00:21:02.046 --> 00:21:04.506 A:middle
 because now we're just doing
@@ -2031,10 +1959,6 @@ can actually improve with some
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.726 --> 00:22:01.986 A:middle
-So this is something that we
-can actually improve with some
-
 00:22:01.986 --> 00:22:03.316 A:middle
 of the new API that we've added.
 
@@ -2124,10 +2048,6 @@ lower the priority of apps
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.886 --> 00:23:02.216 A:middle
-For CPU, we're going to
-lower the priority of apps
-
 00:23:02.216 --> 00:23:05.696 A:middle
 in AppNap lower than other
 apps but still higher
@@ -2215,10 +2135,6 @@ doing as an application
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.786 --> 00:24:01.556 A:middle
-about what you're
-doing as an application
-
 00:24:01.556 --> 00:24:02.726 A:middle
 on behalf of the user.
 
@@ -2303,10 +2219,6 @@ out of date so it's a real waste
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.336 --> 00:25:03.396 A:middle
-Now stock data is pretty rapidly
-out of date so it's a real waste
 
 00:25:03.396 --> 00:25:07.006 A:middle
 if the user can't even see the
@@ -2396,10 +2308,6 @@ that to be occluded.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.676 --> 00:26:01.086 A:middle
-to the dock, we consider
-that to be occluded.
 
 00:26:01.086 --> 00:26:04.876 A:middle
 And for application
@@ -2498,10 +2406,6 @@ So we only have 1 bit set right
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.216 --> 00:27:02.716 A:middle
-So we only have 1 bit set right
--- or 1 bit defined right now.
-
 00:27:03.126 --> 00:27:05.586 A:middle
 That's NS Application
 Occlusion Stayed Visible.
@@ -2595,10 +2499,6 @@ basically a default tolerance
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:57.556 --> 00:28:00.546 A:middle
-with timer coalescing is apply
-basically a default tolerance
-
 00:28:00.546 --> 00:28:01.386 A:middle
 to all timers.
 
@@ -2682,10 +2582,6 @@ system has in aligning them
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.496 --> 00:29:00.296 A:middle
-the better flexibility the
-system has in aligning them
 
 00:29:00.296 --> 00:29:01.466 A:middle
 to save the most energy.
@@ -2784,10 +2680,6 @@ before though was ignored.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.486 --> 00:30:00.266 A:middle
-The last parameter
-before though was ignored.
-
 00:30:00.466 --> 00:30:03.046 A:middle
 So now starting in
 Mavericks, we are going
@@ -2881,10 +2773,6 @@ in for that argument.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.456 --> 00:31:00.906 A:middle
-So please never pass zero
-in for that argument.
-
 00:31:01.406 --> 00:31:06.636 A:middle
 So again we suggest
 about 10 percent
@@ -2976,10 +2864,6 @@ or asynchronous work
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.186 --> 00:32:01.556 A:middle
-It's used for long running
-or asynchronous work
 
 00:32:02.976 --> 00:32:05.966 A:middle
 and it's a Cocoa -- it's
@@ -3169,10 +3053,6 @@ let the system sleep or not?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.706 --> 00:34:01.676 A:middle
-to finish beforehand and then
-let the system sleep or not?
-
 00:34:02.086 --> 00:34:04.716 A:middle
 And that's sort of really up
 to you in your application
@@ -3265,10 +3145,6 @@ is a new API to interface
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:55.366 --> 00:35:00.436 A:middle
-So I said earlier, this
-is a new API to interface
 
 00:35:00.436 --> 00:35:03.336 A:middle
 with I/O K Power Assertions and
@@ -3369,10 +3245,6 @@ excuse me, Batch Process Option.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.556 --> 00:36:02.056 A:middle
-Then I'm going to begin -- or
-excuse me, Batch Process Option.
-
 00:36:02.396 --> 00:36:04.206 A:middle
 Then I'm going to begin
 activity with options.
@@ -3461,9 +3333,6 @@ on the main thread for example.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.826 --> 00:37:01.166 A:middle
-on the main thread for example.
 
 00:37:01.736 --> 00:37:06.486 A:middle
 And finally, please remember
@@ -3565,9 +3434,6 @@ to help you debug.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.946 --> 00:38:00.726 A:middle
-to help you debug.
-
 00:38:01.116 --> 00:38:03.556 A:middle
 So use this tool to verify
 that you have an assertion
@@ -3653,10 +3519,6 @@ that we talked about earlier
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.206 --> 00:39:01.086 A:middle
-and this uses the NS Event API
-that we talked about earlier
-
 00:39:01.346 --> 00:39:03.636 A:middle
 to remove the event monitors
 that we had installed.
@@ -3730,10 +3592,6 @@ corner that Eyes is telling us
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.486 --> 00:40:02.636 A:middle
-you can see here in the
-corner that Eyes is telling us
 
 00:40:02.676 --> 00:40:05.496 A:middle
 that it's currently
@@ -3819,10 +3677,6 @@ to keep the system from falling
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.286 --> 00:41:00.156 A:middle
-So there's no reason for Eyes
-to keep the system from falling
-
 00:41:00.156 --> 00:41:01.206 A:middle
 into idle system sleep."
 
@@ -3895,9 +3749,6 @@ the AppNap column remains at No.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.866 --> 00:42:00.386 A:middle
-the AppNap column remains at No.
 
 00:42:00.836 --> 00:42:04.496 A:middle
 And that's because using the
@@ -3986,10 +3837,6 @@ high dynamic range.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.436 --> 00:43:01.956 A:middle
-And the CPU has that
-high dynamic range.
-
 00:43:01.996 --> 00:43:03.976 A:middle
 So what we're doing
 in our applications
@@ -4076,10 +3923,6 @@ processing, and so forth.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.806 --> 00:44:02.656 A:middle
-like recording, batch
-processing, and so forth.
 
 00:44:03.006 --> 00:44:04.566 A:middle
 And please remember
@@ -4172,10 +4015,6 @@ conference, then please get
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.326 --> 00:45:01.996 A:middle
-If you're not here at the
-conference, then please get
 
 00:45:01.996 --> 00:45:05.056 A:middle
 in contact with our

--- a/2013/210.srt
+++ b/2013/210.srt
@@ -64,9 +64,6 @@ And finally, we're going to wrap
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.346 --> 00:01:00.636 A:middle
-And finally, we're going to wrap
-
 00:01:00.636 --> 00:01:05.396 A:middle
 up with an awesome demo
 showing you how to use
@@ -129,10 +126,6 @@ apps using the stack.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.546 --> 00:02:00.786 A:middle
-and I made great
-apps using the stack.
 
 00:02:00.786 --> 00:02:03.926 A:middle
 But occasionally,
@@ -199,10 +192,6 @@ this time is not lost.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.656 --> 00:03:04.436 A:middle
-up to speed on Core Text,
-this time is not lost.
 
 00:03:04.916 --> 00:03:06.206 A:middle
 The way the system is layered,
@@ -275,10 +264,6 @@ that were built on top
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.946 --> 00:04:03.286 A:middle
-for UIText components
-that were built on top
-
 00:04:03.286 --> 00:04:04.826 A:middle
 of WebViews like TextView.
 
@@ -342,9 +327,6 @@ It's built on top of Core Text.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:56.996 --> 00:05:00.206 A:middle
-It's built on top of Core Text.
-
 00:05:01.216 --> 00:05:02.436 A:middle
 And so this is awesome.
 
@@ -406,10 +388,6 @@ over all of the text rendering
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:56.416 --> 00:06:00.226 A:middle
-this gives you complete control
-over all of the text rendering
-
 00:06:01.006 --> 00:06:02.776 A:middle
 in your UIText elements.
 
@@ -467,10 +445,6 @@ you about today is I want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.346 --> 00:07:00.866 A:middle
-The next thing I want to tell
-you about today is I want
 
 00:07:00.866 --> 00:07:04.556 A:middle
 to give you a high-level
@@ -537,10 +511,6 @@ messaging service.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.936 --> 00:08:02.876 A:middle
-for a popular internet
-messaging service.
-
 00:08:04.606 --> 00:08:06.106 A:middle
 Just pretend, this
 is hypothetical.
@@ -606,10 +576,6 @@ when you're using some
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:56.486 --> 00:09:00.546 A:middle
-And sometimes, especially
-when you're using some
 
 00:09:00.546 --> 00:09:04.256 A:middle
 of the new text styles,
@@ -681,10 +647,6 @@ and everyone else
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.066 --> 00:10:01.206 A:middle
-And as Toby and Jason
-and everyone else
 
 00:10:01.206 --> 00:10:04.146 A:middle
 with Toby this week,
@@ -759,9 +721,6 @@ And again, it's user-centric.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.716 --> 00:11:02.666 A:middle
-And again, it's user-centric.
-
 00:11:02.666 --> 00:11:04.756 A:middle
 Your user is able
 to pick the size.
@@ -829,10 +788,6 @@ return the results in the form
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.506 --> 00:12:02.746 A:middle
-to query for a font and it will
-return the results in the form
 
 00:12:02.836 --> 00:12:05.906 A:middle
 of more font descriptors which
@@ -912,10 +867,6 @@ regular unadorned type styles,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.806 --> 00:13:02.936 A:middle
-You can see here we have our
-regular unadorned type styles,
-
 00:13:03.246 --> 00:13:04.156 A:middle
 a nice list of them.
 
@@ -994,10 +945,6 @@ see the session What's New
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.876 --> 00:14:03.056 A:middle
-to fonts in WebKit, you should
-see the session What's New
-
 00:14:03.056 --> 00:14:05.816 A:middle
 in Safari and WebKit
 for developers.
@@ -1059,10 +1006,6 @@ features for you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.576 --> 00:15:01.236 A:middle
-this unlocks other
-features for you.
 
 00:15:02.236 --> 00:15:03.606 A:middle
 Like, again, when
@@ -1150,9 +1093,6 @@ for an NSLayoutManager.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.286 --> 00:16:00.806 A:middle
-for an NSLayoutManager.
 
 00:16:01.646 --> 00:16:04.586 A:middle
 As we talked about,
@@ -1311,10 +1251,6 @@ attribute changes,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.206 --> 00:18:02.486 A:middle
-programmatic manipulations,
-attribute changes,
-
 00:18:02.486 --> 00:18:06.546 A:middle
 whatever you do, NSLayoutManager
 always stays up-to-date.
@@ -1382,9 +1318,6 @@ The user taps or long-presses,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.236 --> 00:19:01.226 A:middle
-The user taps or long-presses,
 
 00:19:01.556 --> 00:19:06.176 A:middle
 and up comes an action sheet
@@ -1463,10 +1396,6 @@ it's affected by text layout.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.976 --> 00:20:00.966 A:middle
-It affects text layout and
-it's affected by text layout.
-
 00:20:02.426 --> 00:20:05.706 A:middle
 And, of course, it
 contains the geometry
@@ -1533,9 +1462,6 @@ What I'd like to call out is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.786 --> 00:21:00.586 A:middle
-What I'd like to call out is
 
 00:21:00.586 --> 00:21:04.186 A:middle
 that this collection view is
@@ -1609,10 +1535,6 @@ body text inside of our cells.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.166 --> 00:22:01.916 A:middle
-because this represents some
-body text inside of our cells.
-
 00:22:02.346 --> 00:22:06.796 A:middle
 Now if I build and run again --
 
@@ -1669,10 +1591,6 @@ building and running now,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:54.226 --> 00:23:00.436 A:middle
-Now, if I build and run,
-building and running now,
 
 00:23:02.256 --> 00:23:03.856 A:middle
 going into basic interaction.
@@ -1748,10 +1666,6 @@ interact with URL in range.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.426 --> 00:24:03.286 A:middle
-I just implement TextView should
-interact with URL in range.
 
 00:24:04.356 --> 00:24:09.366 A:middle
 In this case, I compare the
@@ -1890,10 +1804,6 @@ the new one line support
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.596 --> 00:26:03.786 A:middle
-In viewDidLload, I'll use
-the new one line support
-
 00:26:04.256 --> 00:26:10.656 A:middle
 in UITextView to set the
 exclusion paths then I'll handle
@@ -1956,9 +1866,6 @@ you can see how fluidly --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:57.516 --> 00:27:03.606 A:middle
-[ Applause ]
 
 00:27:04.106 --> 00:27:05.276 A:middle
 You can see how fluidly
@@ -2031,10 +1938,6 @@ over to my colleague, Ian Baird.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.846 --> 00:28:00.786 A:middle
-Next, I'd like to turn it back
-over to my colleague, Ian Baird.
 
 00:28:01.516 --> 00:28:06.616 A:middle
 [ Applause ]
@@ -2184,10 +2087,6 @@ spec like the one we showed you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.306 --> 00:30:00.986 A:middle
-So again, if you have a detailed
-spec like the one we showed you
 
 00:30:00.986 --> 00:30:03.426 A:middle
 in Mail, you'll need
@@ -2351,10 +2250,6 @@ the intrinsic content size
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.696 --> 00:32:02.106 A:middle
-on that view will invalidate
-the intrinsic content size
-
 00:32:02.106 --> 00:32:04.196 A:middle
 and Auto Layout will just
 layout everything for you.
@@ -2437,10 +2332,6 @@ you in this demo is how to deal
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:57.226 --> 00:33:00.356 A:middle
-The next thing we'd like to show
-you in this demo is how to deal
-
 00:33:00.356 --> 00:33:04.836 A:middle
 with some of these complex
 designs and also how to account
@@ -2516,10 +2407,6 @@ do is declare a method
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:57.276 --> 00:34:01.726 A:middle
-First thing I'm going to
-do is declare a method
-
 00:34:02.656 --> 00:34:05.176 A:middle
 that our notification
 can call when it happens.
@@ -2589,9 +2476,6 @@ out a little bit differently.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.766 --> 00:35:01.426 A:middle
-out a little bit differently.
-
 00:35:01.426 --> 00:35:06.056 A:middle
 And again, when your users goes
 to change their text size --
@@ -2655,10 +2539,6 @@ wanted a profile picture
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:56.496 --> 00:36:00.206 A:middle
-In this case, our designer
-wanted a profile picture
 
 00:36:00.206 --> 00:36:01.526 A:middle
 in the upper left
@@ -2740,10 +2620,6 @@ few things at the top and all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.616 --> 00:37:01.676 A:middle
-that you can adjust just a
-few things at the top and all
 
 00:37:01.676 --> 00:37:03.506 A:middle
 of the rest of your layout
@@ -2937,9 +2813,6 @@ Now, what do I mean by that?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.256 --> 00:40:00.616 A:middle
-Now, what do I mean by that?
-
 00:40:01.976 --> 00:40:07.536 A:middle
 If you've used the UITextView
 on iOS 6 before, you may recall
@@ -2991,9 +2864,6 @@ We send change notifications
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.866 --> 00:41:01.816 A:middle
-We send change notifications
 
 00:41:02.606 --> 00:41:07.516 A:middle
 that will inform the
@@ -3054,10 +2924,6 @@ beginning of the story "Alice
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.506 --> 00:42:04.196 A:middle
-and in this case, we have the
-beginning of the story "Alice
-
 00:42:04.196 --> 00:42:09.856 A:middle
 and Wonderland" and we want
 to modify the name Alice
@@ -3110,10 +2976,6 @@ we modify each instance.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.506 --> 00:43:01.956 A:middle
-Next, what we're doing is
-we modify each instance.
 
 00:43:01.956 --> 00:43:05.046 A:middle
 For example, we loop over the
@@ -3297,10 +3159,6 @@ actual static storage.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.056 --> 00:46:01.726 A:middle
-Two of them deal with
-actual static storage.
-
 00:46:01.976 --> 00:46:04.696 A:middle
 You can inquire the string
 and inquire about attributes,
@@ -3430,10 +3288,6 @@ to the text storage.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:57.906 --> 00:48:00.866 A:middle
-and add the LayoutManager
-to the text storage.
 
 00:48:02.346 --> 00:48:07.296 A:middle
 Finally, instead of creating
@@ -3637,9 +3491,6 @@ Let's run this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.456 --> 00:51:01.776 A:middle
-Let's run this.
-
 00:51:01.986 --> 00:51:05.526 A:middle
 And now, if I type,
 you can already see
@@ -3705,10 +3556,6 @@ wrap this up.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.826 --> 00:52:01.926 A:middle
-And with that, let's
-wrap this up.
 
 00:52:04.256 --> 00:52:07.246 A:middle
 Text Kit is an extremely
@@ -3832,10 +3679,6 @@ to override certain things
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:57.596 --> 00:54:01.156 A:middle
-and Peter will show you how
-to override certain things
 
 00:54:01.156 --> 00:54:03.536 A:middle
 on NSLayoutManager

--- a/2013/211.srt
+++ b/2013/211.srt
@@ -79,10 +79,6 @@ even more limited with memory
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.026 --> 00:01:02.866 A:middle
-In iOS, obviously, you're
-even more limited with memory
-
 00:01:02.866 --> 00:01:03.796 A:middle
 than you are on the desktop,
 
@@ -184,10 +180,6 @@ requests and predicates.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.886 --> 00:02:01.426 A:middle
-to our model, to fetch
-requests and predicates.
 
 00:02:01.726 --> 00:02:04.856 A:middle
 We're looking at concurrency
@@ -299,10 +291,6 @@ but how long is too long?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.696 --> 00:03:01.346 A:middle
-obviously that can take longer,
-but how long is too long?
 
 00:03:01.346 --> 00:03:02.956 A:middle
 How short is the right amount?
@@ -498,10 +486,6 @@ set a fetch batch size
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.076 --> 00:05:01.146 A:middle
-so do that we just
-set a fetch batch size
-
 00:05:01.226 --> 00:05:02.406 A:middle
 on the request itself.
 
@@ -611,10 +595,6 @@ then we're re-profile the app,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.166 --> 00:06:00.866 A:middle
-Let's change it to 20, and
-then we're re-profile the app,
-
 00:06:02.026 --> 00:06:04.796 A:middle
 so product, profile,
 Core Data Instruments.
@@ -715,10 +695,6 @@ you've got subsequent lines
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.316 --> 00:07:01.536 A:middle
-for the initial fetch and then
-you've got subsequent lines
-
 00:07:01.536 --> 00:07:04.136 A:middle
 appearing, ten lines again
 to bring in more objects.
@@ -807,10 +783,6 @@ don't over-normalize.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.006 --> 00:08:01.176 A:middle
-and in particular saying
-don't over-normalize.
 
 00:08:01.526 --> 00:08:04.506 A:middle
 And normalization in a
@@ -907,10 +879,6 @@ we'll write it to a file
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.626 --> 00:09:00.596 A:middle
-If it's above the threshold,
-we'll write it to a file
 
 00:09:00.596 --> 00:09:01.486 A:middle
 and store a reference.
@@ -1015,10 +983,6 @@ launches quickly again,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.236 --> 00:10:02.006 A:middle
-This time the app
-launches quickly again,
-
 00:10:02.006 --> 00:10:02.976 A:middle
 but there's some
 marks appearing.
@@ -1111,10 +1075,6 @@ right thing to do in this case
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.326 --> 00:11:00.016 A:middle
-but that might not be the
-right thing to do in this case
 
 00:11:00.466 --> 00:11:01.806 A:middle
 because our photo is 10 Meg.
@@ -1213,10 +1173,6 @@ have dropped dramatically,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.496 --> 00:12:00.656 A:middle
-This time my fetch durations
-have dropped dramatically,
 
 00:12:00.956 --> 00:12:03.006 A:middle
 so the longest thing right
@@ -1318,10 +1274,6 @@ Instrument, and I'm going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.636 --> 00:13:00.426 A:middle
-Let's look at the Fetches
-Instrument, and I'm going
-
 00:13:00.426 --> 00:13:03.656 A:middle
 to hit my little
 refresh button in my UI,
@@ -1408,10 +1360,6 @@ possible, and the reason
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:56.766 --> 00:14:00.656 A:middle
-to a minimum wherever
-possible, and the reason
 
 00:14:00.656 --> 00:14:02.966 A:middle
 that that's bad is that we're
@@ -1522,9 +1470,6 @@ That's an update, and we go
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.406 --> 00:15:00.286 A:middle
-That's an update, and we go
-
 00:15:00.286 --> 00:15:01.696 A:middle
 to the next object
 in each enumerator.
@@ -1625,10 +1570,6 @@ a few pixels wide,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.966 --> 00:16:01.676 A:middle
-It's a little bit wide,
-a few pixels wide,
-
 00:16:01.676 --> 00:16:03.026 A:middle
 but it's a certainly
 better than before.
@@ -1727,9 +1668,6 @@ Maybe it's 550.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.896 --> 00:17:00.126 A:middle
-Maybe it's 550.
 
 00:17:00.676 --> 00:17:02.426 A:middle
 Just that little bit
@@ -1840,10 +1778,6 @@ is to reset the context
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.466 --> 00:18:01.726 A:middle
-The most efficient way
-is to reset the context
-
 00:18:01.806 --> 00:18:04.136 A:middle
 by calling reset,
 and this will clear
@@ -1932,10 +1866,6 @@ we're not using too much memory
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.336 --> 00:19:03.036 A:middle
-to be very, very short and
-we're not using too much memory
 
 00:19:03.036 --> 00:19:05.136 A:middle
 because we're using a
@@ -2146,10 +2076,6 @@ set the properties to fetch.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.676 --> 00:21:02.886 A:middle
-on the fetch request and
-set the properties to fetch.
-
 00:21:03.376 --> 00:21:06.176 A:middle
 I just want this expression
 description to come back,
@@ -2235,10 +2161,6 @@ group by, specify magnitude.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.476 --> 00:22:00.186 A:middle
-to group the results using
-group by, specify magnitude.
 
 00:22:00.186 --> 00:22:02.356 A:middle
 And this will actually
@@ -2352,10 +2274,6 @@ and writing the values back
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:57.946 --> 00:23:00.106 A:middle
-or how long an insert took
-and writing the values back
-
 00:23:00.106 --> 00:23:03.316 A:middle
 and forth, but it does give
 you a lot of information
@@ -2443,10 +2361,6 @@ Again,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.616 --> 00:24:01.296 A:middle
-Again,
--Com.Apple.CoreData.SQLDebug.
 
 00:24:01.426 --> 00:24:02.996 A:middle
 Let's specify a value of one.
@@ -2630,10 +2544,6 @@ using a nested context.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.176 --> 00:26:00.796 A:middle
-Maybe this time you're
-using a nested context.
-
 00:26:00.796 --> 00:26:02.806 A:middle
 Maybe a main queue talks
 to the private queue,
@@ -2731,10 +2641,6 @@ the top right, that will have
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:57.766 --> 00:27:01.286 A:middle
-in the main queue context up on
-the top right, that will have
-
 00:27:01.316 --> 00:27:04.346 A:middle
 to wait until the lock is
 removed, but you can continue
@@ -2820,10 +2726,6 @@ a different concurrency style,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.946 --> 00:28:01.116 A:middle
-You might want to consider using
-a different concurrency style,
 
 00:28:01.116 --> 00:28:03.616 A:middle
 and this time you have two
@@ -3013,10 +2915,6 @@ background import over here
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.876 --> 00:30:01.726 A:middle
-and you're doing a
-background import over here
-
 00:30:01.726 --> 00:30:04.246 A:middle
 and it's saving data into
 the store, there are no locks
@@ -3105,10 +3003,6 @@ a text query to happen first,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.176 --> 00:31:00.876 A:middle
-In this case I'm asking for
-a text query to happen first,
 
 00:31:00.876 --> 00:31:04.496 A:middle
 so I'm saying I want to query
@@ -3208,10 +3102,6 @@ one that doesn't match,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.916 --> 00:32:00.286 A:middle
-As soon as we come across
-one that doesn't match,
 
 00:32:00.286 --> 00:32:01.236 A:middle
 we can move on to the next one.
@@ -3321,9 +3211,6 @@ How can we deal with that?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.596 --> 00:33:00.646 A:middle
-How can we deal with that?
-
 00:33:01.976 --> 00:33:04.456 A:middle
 And again, let's come
 back to this idea
@@ -3426,10 +3313,6 @@ search,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.076 --> 00:34:00.616 A:middle
-and diacritic insensitive
-search,
-
 00:34:01.126 --> 00:34:02.876 A:middle
 so that's another way
 to speed things up.
@@ -3516,10 +3399,6 @@ you can now query
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.956 --> 00:35:00.076 A:middle
-from the text and
-you can now query
 
 00:35:00.076 --> 00:35:01.836 A:middle
 against those using
@@ -3622,10 +3501,6 @@ enough, then you might need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.026 --> 00:36:03.786 A:middle
-If that still doesn't give
-enough, then you might need
-
 00:36:03.786 --> 00:36:06.986 A:middle
 to consider having a hash
 table in memory, and for this,
@@ -3717,10 +3592,6 @@ of transfer activity,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.026 --> 00:37:00.306 A:middle
-You'll get a little graph
-of transfer activity,
 
 00:37:00.396 --> 00:37:02.416 A:middle
 so as information goes up to
@@ -3825,10 +3696,6 @@ time, see how long it's taking.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.766 --> 00:38:02.096 A:middle
-If something's taken a long
-time, see how long it's taking.
-
 00:38:02.176 --> 00:38:05.476 A:middle
 Wherever possible don't
 bring more information
@@ -3932,9 +3799,6 @@ Thank you very much.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:55.516 --> 00:39:00.516 A:middle
-[ Applause ]
 
 00:39:01.016 --> 00:39:03.306 A:middle
 [ Silence ]

--- a/2013/213.srt
+++ b/2013/213.srt
@@ -86,10 +86,6 @@ we added in 10.8
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.956 --> 00:01:02.286 A:middle
-of NSAnimation Contest
-we added in 10.8
-
 00:01:02.286 --> 00:01:04.146 A:middle
 and I'm going to cover that.
 
@@ -185,9 +181,6 @@ The method I want to introduce
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.636 --> 00:02:00.336 A:middle
-The method I want to introduce
 
 00:02:00.336 --> 00:02:02.436 A:middle
 to you here is the animator
@@ -472,10 +465,6 @@ and the values
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.626 --> 00:05:00.486 A:middle
-that are being changed
-and the values
-
 00:05:00.486 --> 00:05:03.056 A:middle
 in the dictionary are
 CAAnimationObjects describing
@@ -572,10 +561,6 @@ animator like we always did.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.486 --> 00:06:00.586 A:middle
-And then we just talk to the
-animator like we always did.
-
 00:06:00.716 --> 00:06:04.396 A:middle
 View.animator.linefitness=40
 and we wind up with an animation
@@ -667,10 +652,6 @@ is just used along the way.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.566 --> 00:07:00.746 A:middle
-The stuff in the animation
-is just used along the way.
 
 00:07:00.966 --> 00:07:04.156 A:middle
 So if we see what this
@@ -779,10 +760,6 @@ formatter class,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.346 --> 00:08:00.766 A:middle
-to implement my own
-formatter class,
-
 00:08:00.766 --> 00:08:03.596 A:middle
 in this case the cleverly named
 my formatter but we're going
@@ -886,10 +863,6 @@ you get this animation.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.566 --> 00:09:02.146 A:middle
-And when you do this
-you get this animation.
 
 00:09:03.046 --> 00:09:06.186 A:middle
 We are actually formatting
@@ -1054,10 +1027,6 @@ we can take this program here
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.376 --> 00:11:00.826 A:middle
-So I'm going to show you how
-we can take this program here
 
 00:11:00.826 --> 00:11:02.166 A:middle
 and implement all of that.
@@ -1243,10 +1212,6 @@ container view instead
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.686 --> 00:13:00.436 A:middle
-to take the MidX of the
-container view instead
-
 00:13:00.706 --> 00:13:03.226 A:middle
 and instead of subtracting
 1/2 of our width we're going
@@ -1298,10 +1263,6 @@ with our animation there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:51.106 --> 00:14:00.946 A:middle
-so view.animations=frameorigin,
-with our animation there.
 
 00:14:00.996 --> 00:14:03.526 A:middle
 And then we tell
@@ -1381,9 +1342,6 @@ So we're going to go ahead
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.956 --> 00:15:00.266 A:middle
-So we're going to go ahead
 
 00:15:00.266 --> 00:15:04.326 A:middle
 and open animation group
@@ -1476,10 +1434,6 @@ animation group again.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.036 --> 00:16:01.976 A:middle
-So I'm going to begin an
-animation group again.
-
 00:16:08.986 --> 00:16:13.316 A:middle
 And I'm going to copy and paste
 our code that enumerates our
@@ -1546,10 +1500,6 @@ or remove something
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.856 --> 00:17:01.266 A:middle
-if we did add something
-or remove something
 
 00:17:01.766 --> 00:17:04.945 A:middle
 after our animation has
@@ -1627,10 +1577,6 @@ already used it and enjoyed it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.026 --> 00:18:01.226 A:middle
-And some of you have probably
-already used it and enjoyed it
 
 00:18:01.226 --> 00:18:02.816 A:middle
 and or have been
@@ -1918,10 +1864,6 @@ why have one of everything
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.056 --> 00:21:01.636 A:middle
-for core animation as well,
-why have one of everything
-
 00:21:01.636 --> 00:21:04.126 A:middle
 when we can have more than one?
 
@@ -2016,10 +1958,6 @@ might do this besides animation,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.736 --> 00:22:03.966 A:middle
-And there's a few reasons you
-might do this besides animation,
 
 00:22:04.246 --> 00:22:07.006 A:middle
 performance and memory are the
@@ -2201,10 +2139,6 @@ things from this point on.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.756 --> 00:24:01.976 A:middle
-but it does different
-things from this point on.
-
 00:24:02.556 --> 00:24:04.936 A:middle
 It evaluates the animation
 but only evaluates it as part
@@ -2294,10 +2228,6 @@ in greater detail in session 215
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:57.256 --> 00:25:00.766 A:middle
-and again that will be covered
-in greater detail in session 215
-
 00:25:00.766 --> 00:25:02.496 A:middle
 in this room right
 after this session.
@@ -2384,10 +2314,6 @@ easy ways to fix this
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.626 --> 00:26:02.356 A:middle
-so there's at least two
-easy ways to fix this
 
 00:26:02.356 --> 00:26:03.346 A:middle
 and I'm going to
@@ -2573,10 +2499,6 @@ with window resizing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.336 --> 00:28:02.146 A:middle
-And it interacts well
-with window resizing
-
 00:28:02.256 --> 00:28:04.346 A:middle
 so you can make a stack
 view that prevents you
@@ -2663,10 +2585,6 @@ just passing an array of views
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.306 --> 00:29:00.906 A:middle
-You can create a StackView with
-just passing an array of views
 
 00:29:00.906 --> 00:29:03.786 A:middle
 to NSStackView, StackView
@@ -2757,10 +2675,6 @@ going to put in our StackView.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.806 --> 00:30:01.166 A:middle
-So here's the views that we're
-going to put in our StackView.
-
 00:30:01.396 --> 00:30:03.736 A:middle
 We have the header view.
 
@@ -2843,10 +2757,6 @@ a list of all our views,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.826 --> 00:31:03.036 A:middle
-We're going to start by making
-a list of all our views,
 
 00:31:03.036 --> 00:31:04.896 A:middle
 the header, the filter,
@@ -2942,10 +2852,6 @@ a constraint.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.036 --> 00:32:00.926 A:middle
-We'll start by creating
-a constraint.
-
 00:32:00.926 --> 00:32:03.036 A:middle
 This is the centering
 constraint that I showed you.
@@ -3013,10 +2919,6 @@ disclosure view animate?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.136 --> 00:33:00.926 A:middle
-so how would we make this
-disclosure view animate?
 
 00:33:02.296 --> 00:33:04.476 A:middle
 Well the desire is that
@@ -3105,10 +3007,6 @@ but this is really bad,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.876 --> 00:34:02.326 A:middle
-And this might seem to work
-but this is really bad,
 
 00:34:02.326 --> 00:34:03.996 A:middle
 you can see it's
@@ -3206,10 +3104,6 @@ view and all of its descendants
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.346 --> 00:35:01.946 A:middle
-If you just want to animate that
-view and all of its descendants
-
 00:35:02.406 --> 00:35:04.106 A:middle
 or you can call window
 layoutIfNeeded
@@ -3272,9 +3166,6 @@ to a nicely animated control.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:55.516 --> 00:36:01.666 A:middle
-[ Applause ]
 
 00:36:02.166 --> 00:36:05.086 A:middle
 It's nice when things
@@ -3358,10 +3249,6 @@ give you a demo of how
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.566 --> 00:37:03.596 A:middle
-So let's, I'm going to
-give you a demo of how
-
 00:37:03.596 --> 00:37:08.676 A:middle
 to use this technique to make
 our StackView animated again.
@@ -3433,9 +3320,6 @@ of my view, of me?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.666 --> 00:38:00.846 A:middle
-of my view, of me?
 
 00:38:01.546 --> 00:38:03.906 A:middle
 So it's equal to
@@ -3519,10 +3403,6 @@ to doing the implicit animation
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.006 --> 00:39:01.946 A:middle
-So I if that out, now we're back
-to doing the implicit animation
-
 00:39:01.946 --> 00:39:02.946 A:middle
 and triggering layout.
 
@@ -3595,10 +3475,6 @@ animation on the main thread
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.396 --> 00:40:00.566 A:middle
-that will do an AppKit driven
-animation on the main thread
 
 00:40:00.566 --> 00:40:02.666 A:middle
 so it will not be concurrent
@@ -3688,10 +3564,6 @@ what we want is instead all the
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.286 --> 00:41:03.066 A:middle
-But with this kind of animation
-what we want is instead all the
-
 00:41:03.066 --> 00:41:07.816 A:middle
 slack should be taken up
 by the pane on the left.
@@ -3775,10 +3647,6 @@ priority of the first subview
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.556 --> 00:42:03.736 A:middle
-We're going to lower the holding
-priority of the first subview
 
 00:42:04.106 --> 00:42:05.776 A:middle
 to 1, which is very low.
@@ -3872,9 +3740,6 @@ to invoke NSSplitView.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.556 --> 00:43:00.706 A:middle
-to invoke NSSplitView.
-
 00:43:01.936 --> 00:43:05.616 A:middle
 So the solution is we're going
 to shrink the pane as small
@@ -3950,10 +3815,6 @@ slides nicely in and out
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.526 --> 00:44:00.956 A:middle
-that the split view
-slides nicely in and out
 
 00:44:00.956 --> 00:44:03.256 A:middle
 and I can you know
@@ -4038,10 +3899,6 @@ the window by that amount
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:57.396 --> 00:45:00.216 A:middle
-Then we have to resize
-the window by that amount
-
 00:45:00.356 --> 00:45:01.806 A:middle
 so that the right
 edge stays fixed.
@@ -4116,9 +3973,6 @@ So that's what we have.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.926 --> 00:46:00.186 A:middle
-So that's what we have.
 
 00:46:00.496 --> 00:46:03.076 A:middle
 For more information you
@@ -4215,10 +4069,6 @@ which is you set
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.926 --> 00:47:02.196 A:middle
-We saw a third technique
-which is you set
 
 00:47:02.196 --> 00:47:03.566 A:middle
 up your constraints

--- a/2013/214.srt
+++ b/2013/214.srt
@@ -76,10 +76,6 @@ your application
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.856 --> 00:01:00.476 A:middle
-for how you can customize
-your application
-
 00:01:01.326 --> 00:01:04.166 A:middle
 and finally how you can create
 your own custom controls
@@ -163,10 +159,6 @@ to mention one thing and that's
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.146 --> 00:02:03.126 A:middle
-But before I start, I wanted
-to mention one thing and that's
 
 00:02:03.126 --> 00:02:05.436 A:middle
 that all of the existing
@@ -332,9 +324,6 @@ So, here in the messages
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.796 --> 00:04:00.096 A:middle
-So, here in the messages
-
 00:04:00.346 --> 00:04:03.556 A:middle
 and profiles view we're using
 a navigation controller.
@@ -419,10 +408,6 @@ launches we'll draw a live
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.976 --> 00:05:01.126 A:middle
-and that way as your application
-launches we'll draw a live
-
 00:05:01.196 --> 00:05:02.266 A:middle
 Status Bar on top of it
 
@@ -503,10 +488,6 @@ your older default images
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.396 --> 00:06:02.506 A:middle
-for iOS 7 but still keep
-your older default images
 
 00:06:02.626 --> 00:06:05.986 A:middle
 for older versions of iOS.
@@ -666,9 +647,6 @@ Now, if you ran that same code
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.716 --> 00:08:00.956 A:middle
-Now, if you ran that same code
-
 00:08:01.196 --> 00:08:03.416 A:middle
 in iOS 7 you'd get
 something very different.
@@ -759,10 +737,6 @@ looks kind of like a grid
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.686 --> 00:09:02.586 A:middle
-to set this custom image that
-looks kind of like a grid
-
 00:09:02.796 --> 00:09:05.566 A:middle
 to match with our
 tic-tac-toe theme.
@@ -852,10 +826,6 @@ the full height background image
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.776 --> 00:10:01.956 A:middle
-in our sample application using
-the full height background image
-
 00:10:02.876 --> 00:10:04.616 A:middle
 and this-- these changes apply
 
@@ -937,10 +907,6 @@ different custom background
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.756 --> 00:11:00.896 A:middle
-So this way, you can set
-different custom background
 
 00:11:00.896 --> 00:11:02.856 A:middle
 images that have
@@ -1027,10 +993,6 @@ your bar and above the content
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.786 --> 00:12:02.776 A:middle
-shown in just an area beneath
-your bar and above the content
-
 00:12:03.456 --> 00:12:06.486 A:middle
 and that allows you to create
 exactly the custom shadow image
@@ -1106,10 +1068,6 @@ Translucent Property directly
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:57.776 --> 00:13:00.136 A:middle
-that you can always set the
-Translucent Property directly
 
 00:13:00.136 --> 00:13:01.096 A:middle
 to whatever you want.
@@ -1199,10 +1157,6 @@ navigation bars and in the rest
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.156 --> 00:14:01.206 A:middle
-that appear both the
-navigation bars and in the rest
 
 00:14:01.206 --> 00:14:04.856 A:middle
 of your application is that
@@ -1365,10 +1319,6 @@ a triangular shape
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.656 --> 00:16:01.896 A:middle
-use a mask image that's
-a triangular shape
-
 00:16:02.586 --> 00:16:05.406 A:middle
 to mask the text as its
 moving during the transition.
@@ -1456,10 +1406,6 @@ now wiped by default.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.006 --> 00:17:01.526 A:middle
-in iOS 7 is that they're
-now wiped by default.
-
 00:17:02.396 --> 00:17:04.536 A:middle
 But they also have a
 new bar style property
@@ -1541,10 +1487,6 @@ has had an image property
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.176 --> 00:18:01.496 A:middle
-So, traditionally UItabBarItem
-has had an image property
-
 00:18:01.966 --> 00:18:05.046 A:middle
 that lets you set your own
 image on the tab bar item
@@ -1619,9 +1561,6 @@ between the different sections.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.036 --> 00:19:00.046 A:middle
-between the different sections.
 
 00:19:00.916 --> 00:19:03.716 A:middle
 So, redesigning your app
@@ -1782,10 +1721,6 @@ the selection indicator to show
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.036 --> 00:21:02.746 A:middle
-When you do that we'll show
-the selection indicator to show
 
 00:21:02.746 --> 00:21:03.956 A:middle
 that your button
@@ -1959,10 +1894,6 @@ way to think
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.396 --> 00:23:00.796 A:middle
-This is just a conceptual
-way to think
-
 00:23:00.796 --> 00:23:03.066 A:middle
 about how this property
 works and try
@@ -2049,10 +1980,6 @@ because it's non-nil instead
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.006 --> 00:24:00.476 A:middle
-specific Tint Color
-because it's non-nil instead
-
 00:24:00.476 --> 00:24:01.996 A:middle
 of inheriting the
 system default.
@@ -2135,10 +2062,6 @@ the Inherited Tint Color
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:58.126 --> 00:25:00.116 A:middle
-which it then becomes
-the Inherited Tint Color
 
 00:25:00.766 --> 00:25:02.896 A:middle
 and which then is also
@@ -2375,10 +2298,6 @@ TintAdjustmentMode of the window
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:57.816 --> 00:28:00.106 A:middle
-So, we'll set the
-TintAdjustmentMode of the window
-
 00:28:00.296 --> 00:28:03.556 A:middle
 to be dimmed, but you'll notice
 that there's a problem here.
@@ -2471,10 +2390,6 @@ have one it will use the system
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.866 --> 00:29:00.946 A:middle
-and if its superview doesn't
-have one it will use the system
 
 00:29:00.946 --> 00:29:03.636 A:middle
 default TintAdjusmentMode,
@@ -2651,10 +2566,6 @@ Colors remain the same.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.236 --> 00:31:00.506 A:middle
-All of the Specific Tint
-Colors remain the same.
-
 00:31:01.116 --> 00:31:03.656 A:middle
 So, the red and green are
 still there, they're just kind
@@ -2744,9 +2655,6 @@ and how to use them in iOS 7.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.596 --> 00:32:02.936 A:middle
-and how to use them in iOS 7.
 
 00:32:03.096 --> 00:32:05.766 A:middle
 Now, another part of
@@ -2841,10 +2749,6 @@ about Template Images is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.476 --> 00:33:00.756 A:middle
-And the great thing
-about Template Images is
 
 00:33:00.756 --> 00:33:03.486 A:middle
 that they can be recolored
@@ -3008,10 +2912,6 @@ the Imagerendering Mode method
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:56.306 --> 00:35:00.016 A:middle
-So, all we need to do is use
-the Imagerendering Mode method
-
 00:35:00.376 --> 00:35:01.456 A:middle
 on the image that we have
 
@@ -3104,10 +3004,6 @@ these two things separately or,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.406 --> 00:36:02.886 A:middle
-and you can now do either of
-these two things separately or,
-
 00:36:02.886 --> 00:36:03.896 A:middle
 of course, combine
 them together.
@@ -3199,10 +3095,6 @@ recolored and, of course,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.756 --> 00:37:01.806 A:middle
-So, they won't be
-recolored and, of course,
-
 00:37:01.856 --> 00:37:04.416 A:middle
 you can use the AlwaysTemplate
 Rendering Mode if you want
@@ -3291,10 +3183,6 @@ that when we set those images
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.566 --> 00:38:02.746 A:middle
-of our Profile view, you'll see
-that when we set those images
 
 00:38:02.856 --> 00:38:05.366 A:middle
 on our Table View Cells
@@ -3388,10 +3276,6 @@ Applications properties
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.206 --> 00:39:01.236 A:middle
-controlled by UI
-Applications properties
 
 00:39:01.606 --> 00:39:03.236 A:middle
 where you set the
@@ -3582,10 +3466,6 @@ change the value return from one
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.586 --> 00:41:01.486 A:middle
-And once again whenever you
-change the value return from one
-
 00:41:01.486 --> 00:41:03.936 A:middle
 of these you can-- you need
 to call the same method,
@@ -3668,10 +3548,6 @@ actually invert the background
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:57.376 --> 00:42:00.016 A:middle
-but when the game is over it'll
-actually invert the background
 
 00:42:00.046 --> 00:42:03.346 A:middle
 to be black and so it will
@@ -3761,10 +3637,6 @@ on the UIKit Controls
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.116 --> 00:43:00.166 A:middle
-We worked really hard
-on the UIKit Controls
-
 00:43:00.456 --> 00:43:01.956 A:middle
 to make sure they
 always work great.
@@ -3849,10 +3721,6 @@ like this UIButton in iOS 7,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.946 --> 00:44:03.016 A:middle
-When we create a control
-like this UIButton in iOS 7,
-
 00:44:03.496 --> 00:44:05.186 A:middle
 we don't actually start
 with a blank slate.
@@ -3935,10 +3803,6 @@ set the Selective Properties
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.736 --> 00:45:02.026 A:middle
-between them we can just
-set the Selective Properties
 
 00:45:02.256 --> 00:45:05.436 A:middle
 of our buttons.
@@ -4024,9 +3888,6 @@ out an image from the context.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.866 --> 00:46:01.406 A:middle
-out an image from the context.
-
 00:46:02.376 --> 00:46:05.926 A:middle
 So, we're using UI [Inaudible]
 path to do our drawings here
@@ -4109,10 +3970,6 @@ this same background image
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.276 --> 00:47:01.016 A:middle
-And this way our-- we can use
-this same background image
-
 00:47:01.236 --> 00:47:04.126 A:middle
 in all of our ratings controls
 and no matter what size
@@ -4187,10 +4044,6 @@ automatically get called
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.476 --> 00:48:00.676 A:middle
-on our View Controller will
-automatically get called
 
 00:48:00.976 --> 00:48:03.296 A:middle
 whenever the user changes
@@ -4281,10 +4134,6 @@ thing that you need to know
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.516 --> 00:49:01.276 A:middle
-However, there's one last
-thing that you need to know
-
 00:49:01.276 --> 00:49:04.066 A:middle
 about Tint Color and that's how
 to update it when it changes.
@@ -4368,10 +4217,6 @@ and their subviews
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:58.896 --> 00:50:00.686 A:middle
-and all of its subviews
-and their subviews
-
 00:50:01.116 --> 00:50:04.316 A:middle
 as their Tint Colors
 change as well.
@@ -4450,10 +4295,6 @@ important thing to consider
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:57.946 --> 00:51:01.586 A:middle
-So, there's one last really
-important thing to consider
 
 00:51:01.586 --> 00:51:03.076 A:middle
 when you're implementing
@@ -4549,10 +4390,6 @@ control is this Count view
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:59.196 --> 00:52:03.406 A:middle
-Now our other custom
-control is this Count view
-
 00:52:04.176 --> 00:52:06.376 A:middle
 and we'll also need to
 add Accessibility here.
@@ -4626,10 +4463,6 @@ and you'll notice
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:56.526 --> 00:53:01.326 A:middle
-to play our pieces
-and you'll notice
-
 00:53:01.806 --> 00:53:04.786 A:middle
 that when the game finishes we
 automatically transition the
@@ -4700,10 +4533,6 @@ System button that we've used
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:57.206 --> 00:54:00.486 A:middle
-You can also see here a
-System button that we've used
-
 00:54:01.266 --> 00:54:03.206 A:middle
 where we haven't set
 the Rendering Mode
@@ -4769,9 +4598,6 @@ customized application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:59.516 --> 00:55:05.756 A:middle
-[ Applause ]
 
 00:55:06.256 --> 00:55:08.526 A:middle
 &gt;&gt; So, today I've showed

--- a/2013/215.srt
+++ b/2013/215.srt
@@ -74,10 +74,6 @@ doing this inside your drawRect.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.936 --> 00:01:02.086 A:middle
-So you're probably already
-doing this inside your drawRect.
-
 00:01:02.176 --> 00:01:04.766 A:middle
 Inside of your drawRect
 implementation, you're looking
@@ -170,10 +166,6 @@ actually really dirty.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.566 --> 00:02:00.476 A:middle
-in those Rects that are
-actually really dirty.
-
 00:02:01.126 --> 00:02:04.316 A:middle
 Or, what you can also do here is
 just pull in your model objects
@@ -261,10 +253,6 @@ do that are performant, well,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.916 --> 00:03:01.376 A:middle
-Now, other things that you can
-do that are performant, well,
-
 00:03:01.636 --> 00:03:03.926 A:middle
 hiding a view may
 be actually better
@@ -338,10 +326,6 @@ do some work on the background.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.366 --> 00:04:00.566 A:middle
-add an operation with block to
-do some work on the background.
 
 00:04:01.106 --> 00:04:02.646 A:middle
 You can actually do
@@ -421,10 +405,6 @@ do inside drawRect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.216 --> 00:05:01.026 A:middle
-Definitely, do not
-do inside drawRect
 
 00:05:01.446 --> 00:05:02.696 A:middle
 because it's bad
@@ -518,10 +498,6 @@ calling GState, allocateGState,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.756 --> 00:06:03.966 A:middle
-So if you're overriding or
-calling GState, allocateGState,
-
 00:06:03.966 --> 00:06:08.606 A:middle
 releaseGState and in particular,
 setupGState and renewGState,
@@ -599,10 +575,6 @@ Animation and what you can do.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.356 --> 00:07:02.686 A:middle
-of the best practices for Core
-Animation and what you can do.
-
 00:07:03.036 --> 00:07:06.476 A:middle
 So last year, we gave a
 talk on layer-backed views
@@ -675,10 +647,6 @@ calling setNeedsDisplay.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.656 --> 00:08:01.326 A:middle
-you are responsible for
-calling setNeedsDisplay.
 
 00:08:02.066 --> 00:08:05.836 A:middle
 We do not automatically call
@@ -754,10 +722,6 @@ wantsUpdateLayer, which is more
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.756 --> 00:09:02.756 A:middle
-So let's say you say no to
-wantsUpdateLayer, which is more
 
 00:09:02.756 --> 00:09:05.216 A:middle
 of a traditional drawing
@@ -932,10 +896,6 @@ if your view is opaque
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.216 --> 00:11:02.596 A:middle
-As I mentioned before,
-if your view is opaque
-
 00:11:02.596 --> 00:11:04.456 A:middle
 and you're saying
 yes from isOpaque,
@@ -1011,9 +971,6 @@ of little individual tiles.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.706 --> 00:12:01.016 A:middle
-of little individual tiles.
 
 00:12:01.686 --> 00:12:05.476 A:middle
 Now, your view still has
@@ -1098,9 +1055,6 @@ for one particular visible area.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.326 --> 00:13:00.706 A:middle
-for one particular visible area.
 
 00:13:01.406 --> 00:13:05.886 A:middle
 Of course, we're actually
@@ -1190,10 +1144,6 @@ problem with this?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:57.046 --> 00:14:00.526 A:middle
-What could be the
-problem with this?
-
 00:14:01.026 --> 00:14:04.086 A:middle
 Well, as I mentioned before,
 if you're using drawRect,
@@ -1273,10 +1223,6 @@ called CanDrawSubviewsIntoLayer
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:56.116 --> 00:15:01.266 A:middle
-to use some new Mac OS 10.9 API
-called CanDrawSubviewsIntoLayer
 
 00:15:01.266 --> 00:15:03.926 A:middle
 and the setter,
@@ -1364,10 +1310,6 @@ its own layer because you want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.376 --> 00:16:02.566 A:middle
-to view a subview that has
-its own layer because you want
-
 00:16:02.566 --> 00:16:03.876 A:middle
 to animate that button around,
 
@@ -1454,10 +1396,6 @@ those individual subviews,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.986 --> 00:17:02.546 A:middle
-YES for each of them and all
-those individual subviews,
-
 00:17:02.546 --> 00:17:05.516 A:middle
 the image, the text and
 whatnot will be drawn instead
@@ -1530,10 +1468,6 @@ horrible things during drawRect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:56.256 --> 00:18:01.426 A:middle
-And this test app does lots of
-horrible things during drawRect
 
 00:18:01.426 --> 00:18:04.796 A:middle
 so your drawRect performance
@@ -1611,10 +1545,6 @@ that's all that was drawn.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.016 --> 00:19:00.876 A:middle
-and traditionally,
-that's all that was drawn.
 
 00:19:00.876 --> 00:19:02.796 A:middle
 When we get responsive
@@ -1712,10 +1642,6 @@ already doing,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.236 --> 00:20:00.756 A:middle
-that your app wasn't
-already doing,
 
 00:20:00.756 --> 00:20:02.046 A:middle
 you can access the
@@ -1816,9 +1742,6 @@ so we'll just go up and down.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.516 --> 00:21:00.036 A:middle
-so we'll just go up and down.
-
 00:21:00.036 --> 00:21:01.226 A:middle
 So we have a little bit more.
 
@@ -1910,10 +1833,6 @@ general, you won't have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.976 --> 00:22:00.546 A:middle
-And this is great and in
-general, you won't have
 
 00:22:00.546 --> 00:22:03.216 A:middle
 to do anything but sometimes
@@ -2007,10 +1926,6 @@ area that we want currently
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:57.686 --> 00:23:01.476 A:middle
-It includes the entire overdraw
-area that we want currently
-
 00:23:01.476 --> 00:23:03.806 A:middle
 which is always going to at
 least include your visible rect
@@ -2102,10 +2017,6 @@ overdraw ready to be scrolled
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.246 --> 00:24:02.536 A:middle
-and we'll have that in the
-overdraw ready to be scrolled
-
 00:24:02.536 --> 00:24:04.516 A:middle
 to for the user at
 a moment's notice.
@@ -2191,10 +2102,6 @@ ask for that area to be drawn
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.326 --> 00:25:02.366 A:middle
-then we'll of course-- we won't
-ask for that area to be drawn
-
 00:25:02.726 --> 00:25:05.296 A:middle
 and we're going to stop
 asking for overdraw
@@ -2276,10 +2183,6 @@ content that you're showing
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.796 --> 00:26:00.646 A:middle
-to totally change the
-content that you're showing
 
 00:26:00.646 --> 00:26:04.766 A:middle
 in the scroll view and the
@@ -2365,10 +2268,6 @@ rect API that we have.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:57.966 --> 00:27:01.126 A:middle
-and use the prepared content
-rect API that we have.
 
 00:27:01.856 --> 00:27:03.196 A:middle
 So that's overdraw.
@@ -2465,10 +2364,6 @@ we break that cycle and once
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.126 --> 00:28:00.626 A:middle
-Well with Responsive scrolling,
-we break that cycle and once
 
 00:28:00.626 --> 00:28:02.966 A:middle
 that first event comes in
@@ -2569,10 +2464,6 @@ screen is the red dashed area.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.056 --> 00:29:02.166 A:middle
-Though what the users sees on
-screen is the red dashed area.
-
 00:29:02.646 --> 00:29:06.066 A:middle
 So, that's an important thing to
 realize as what the users sees
@@ -2660,10 +2551,6 @@ synchronization request does is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.516 --> 00:30:03.106 A:middle
-The other thing that the
-synchronization request does is
 
 00:30:03.106 --> 00:30:05.506 A:middle
 if your app-- if your main
@@ -2765,10 +2652,6 @@ we want to avoid.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.776 --> 00:31:01.506 A:middle
-But it's a situation
-we want to avoid.
-
 00:31:01.896 --> 00:31:04.726 A:middle
 So, my point here is
 it's not a silver bullet.
@@ -2857,10 +2740,6 @@ is obviously isn't going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:55.666 --> 00:32:00.486 A:middle
-Overriding scroll wheel
-is obviously isn't going
-
 00:32:00.486 --> 00:32:02.396 A:middle
 to work the way that it used
 to because scroll will use
@@ -2945,10 +2824,6 @@ of those and you can respond
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.086 --> 00:33:00.186 A:middle
-And this way, you'll catch all
-of those and you can respond
 
 00:33:00.186 --> 00:33:02.116 A:middle
 to them appropriately
@@ -3043,10 +2918,6 @@ bunch of dids and did end.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.416 --> 00:34:01.826 A:middle
-into one will start, a whole
-bunch of dids and did end.
 
 00:34:02.426 --> 00:34:06.556 A:middle
 Not only that, we will
@@ -3155,10 +3026,6 @@ issued on the main thread.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.716 --> 00:35:02.826 A:middle
-these notifications are being
-issued on the main thread.
-
 00:35:02.886 --> 00:35:04.356 A:middle
 So that's an important
 thing to point out.
@@ -3247,10 +3114,6 @@ in your content, it scrolls
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.766 --> 00:36:00.706 A:middle
-generally, you have a subview
-in your content, it scrolls
-
 00:36:00.706 --> 00:36:02.336 A:middle
 and you change the
 frame of this view.
@@ -3337,10 +3200,6 @@ a whole lot there going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:53.866 --> 00:37:01.136 A:middle
-So that was a whole-- there's
-a whole lot there going
-
 00:37:01.136 --> 00:37:02.356 A:middle
 on with responsive scrolling.
 
@@ -3420,10 +3279,6 @@ can use this explicit API
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.036 --> 00:38:01.046 A:middle
-But from this point on, you
-can use this explicit API
 
 00:38:01.286 --> 00:38:03.576 A:middle
 isCompatibleWithResponsive
@@ -3515,10 +3370,6 @@ just isn't applicable.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.176 --> 00:39:01.216 A:middle
-that we do overdraw
-just isn't applicable.
 
 00:39:01.216 --> 00:39:03.566 A:middle
 So, please stop overriding
@@ -3617,10 +3468,6 @@ we're not sure what's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.586 --> 00:40:02.726 A:middle
-which is the default case, then
-we're not sure what's going
-
 00:40:02.726 --> 00:40:04.136 A:middle
 on there and we won't
 be able to adopt you
@@ -3706,10 +3553,6 @@ performance characteristics
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.946 --> 00:41:01.446 A:middle
-There are different
-performance characteristics
 
 00:41:01.446 --> 00:41:03.106 A:middle
 when you go layer-back,
@@ -3800,9 +3643,6 @@ We want green.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.916 --> 00:42:00.506 A:middle
-We want green.
 
 00:42:01.056 --> 00:42:05.456 A:middle
 So, if everything turns out--
@@ -4065,9 +3905,6 @@ your drawRect speed is crucial
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:57.736 --> 00:45:00.116 A:middle
-your drawRect speed is crucial
-
 00:45:00.116 --> 00:45:03.156 A:middle
 to getting responsive
 feedback to the user.
@@ -4155,10 +3992,6 @@ the current bounds are
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.476 --> 00:46:01.636 A:middle
-and all you have is whatever
-the current bounds are
 
 00:46:01.636 --> 00:46:02.826 A:middle
 of the clip view.
@@ -4255,10 +4088,6 @@ with responsive scrolling
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.216 --> 00:47:02.266 A:middle
-These are still very important
-with responsive scrolling
-
 00:47:02.266 --> 00:47:06.036 A:middle
 as you've seen, it can get
 over a lot of rough edges and--
@@ -4350,10 +4179,6 @@ relates to responsive scrolling.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.016 --> 00:48:04.256 A:middle
-in the release notes as it
-relates to responsive scrolling.
 
 00:48:07.276 --> 00:48:09.176 A:middle
 The Best Practices

--- a/2013/216.srt
+++ b/2013/216.srt
@@ -72,10 +72,6 @@ be in every single one of them.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.866 --> 00:01:02.606 A:middle
-Yeah, and we want your apps to
-be in every single one of them.
-
 00:01:02.836 --> 00:01:04.696 A:middle
 And we're here to show
 you how to do that.
@@ -229,10 +225,6 @@ you guidance to use controls
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:55.016 --> 00:03:00.616 A:middle
-and as such, we've given
-you guidance to use controls
-
 00:03:00.616 --> 00:03:03.976 A:middle
 and buttons that are
 44 points by 44 points.
@@ -317,10 +309,6 @@ able to drag files and texts
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.886 --> 00:04:03.426 A:middle
-They're going to expect to be
-able to drag files and texts
-
 00:04:03.426 --> 00:04:07.596 A:middle
 and images into, out of, and
 between windows in your apps.
@@ -397,10 +385,6 @@ you already know from iOS.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.836 --> 00:05:03.216 A:middle
-of existing knowledge that
-you already know from iOS.
 
 00:05:03.666 --> 00:05:05.096 A:middle
 For instance, the
@@ -557,10 +541,6 @@ lot of the frameworks
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.266 --> 00:07:01.966 A:middle
-Number one is that a
-lot of the frameworks
-
 00:07:01.966 --> 00:07:04.976 A:middle
 on iOS are the exact
 same as they are in OS X.
@@ -644,10 +624,6 @@ things will feel very familiar.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.686 --> 00:08:00.806 A:middle
-That means that a lot of the
-things will feel very familiar.
 
 00:08:00.986 --> 00:08:04.816 A:middle
 And we're going to talk about
@@ -740,10 +716,6 @@ for your data structures,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.986 --> 00:09:02.736 A:middle
-is only supposed to be used
-for your data structures,
-
 00:09:03.556 --> 00:09:04.896 A:middle
 your business rules and logic.
 
@@ -824,9 +796,6 @@ Well, it's really easy.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.156 --> 00:10:01.926 A:middle
-Well, it's really easy.
 
 00:10:02.636 --> 00:10:04.416 A:middle
 Adapt NSInteger and NSUInterger.
@@ -982,10 +951,6 @@ of reusable cells that's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.726 --> 00:12:02.886 A:middle
-They both encourage the use
-of reusable cells that's going
-
 00:12:02.886 --> 00:12:04.076 A:middle
 to maximize your performance.
 
@@ -1070,10 +1035,6 @@ going to see a TableView
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.206 --> 00:13:00.336 A:middle
-So here on your left, you're
-going to see a TableView
 
 00:13:00.336 --> 00:13:04.716 A:middle
 that the user selecting a region
@@ -1248,9 +1209,6 @@ Here's what it looks like.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.336 --> 00:15:00.416 A:middle
-Here's what it looks like.
-
 00:15:00.556 --> 00:15:04.366 A:middle
 In UIView, you've got your upper
 left origin, NSView, lower left,
@@ -1334,10 +1292,6 @@ better, see if it fits
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.756 --> 00:16:01.216 A:middle
-Try it out, see if it works
-better, see if it fits
 
 00:16:01.216 --> 00:16:04.456 A:middle
 in within the resources you
@@ -1510,10 +1464,6 @@ the idea here it's a lot
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.826 --> 00:18:02.936 A:middle
-And TapGestureRecognizer,
-the idea here it's a lot
-
 00:18:02.936 --> 00:18:04.656 A:middle
 of times you use for
 a simple interactions
@@ -1597,10 +1547,6 @@ time, you're going to want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.106 --> 00:19:01.116 A:middle
-But 99 percent of the
-time, you're going to want
 
 00:19:01.116 --> 00:19:02.536 A:middle
 to use a Right Click instead
@@ -1688,10 +1634,6 @@ what you're used to in iOS.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.066 --> 00:20:00.346 A:middle
-So-- and that's kind of
-what you're used to in iOS.
 
 00:20:01.046 --> 00:20:03.586 A:middle
 But what if you wanted to do
@@ -1781,10 +1723,6 @@ the start location.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.926 --> 00:21:02.176 A:middle
-to pass is the location,
-the start location.
-
 00:21:02.686 --> 00:21:05.016 A:middle
 And the dragOffset
 actually is ignored
@@ -1870,9 +1808,6 @@ for migrating the controller?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.656 --> 00:22:00.746 A:middle
-for migrating the controller?
 
 00:22:00.936 --> 00:22:04.696 A:middle
 First off, this is the common
@@ -1965,10 +1900,6 @@ without using any code inside
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.796 --> 00:23:03.466 A:middle
-up your user interface
-without using any code inside
-
 00:23:03.466 --> 00:23:04.286 A:middle
 of Interface Builder.
 
@@ -2053,10 +1984,6 @@ app on OS X, you're going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.586 --> 00:24:01.806 A:middle
-if you set up a document-based
-app on OS X, you're going
 
 00:24:01.806 --> 00:24:04.236 A:middle
 to get a File, Edit, and
@@ -2143,10 +2070,6 @@ I'm first going to start off
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.996 --> 00:25:02.476 A:middle
-OK. I'm going to show you--
-I'm first going to start off
-
 00:25:02.476 --> 00:25:06.566 A:middle
 with my awesome iOS application
 that I'm working on some
@@ -2221,10 +2144,6 @@ lot of this right now but it--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.986 --> 00:26:01.996 A:middle
-Don't need to go through a whole
-lot of this right now but it--
 
 00:26:02.206 --> 00:26:04.066 A:middle
 but the important thing
@@ -2310,9 +2229,6 @@ You don't have to call it--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.406 --> 00:27:00.986 A:middle
-You don't have to call it--
-
 00:27:01.016 --> 00:27:03.176 A:middle
 if you don't have the OS X
 at the end, I'm just going
@@ -2385,9 +2301,6 @@ I can make many of them,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.326 --> 00:28:00.276 A:middle
-I can make many of them,
 
 00:28:01.276 --> 00:28:05.396 A:middle
 I got all of the menu bar
@@ -2473,10 +2386,6 @@ going to talk about it in terms
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:56.836 --> 00:29:02.126 A:middle
-And so to help with this, we're
-going to talk about it in terms
 
 00:29:02.236 --> 00:29:03.766 A:middle
 of a particular example.
@@ -2637,10 +2546,6 @@ CGRect frame, and we're going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:56.216 --> 00:31:00.396 A:middle
-We'll make the frame, the
-CGRect frame, and we're going
-
 00:31:00.396 --> 00:31:01.786 A:middle
 to create it with initWithFrame.
 
@@ -2732,10 +2637,6 @@ us a lot of flexibility.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.896 --> 00:32:00.346 A:middle
-Well, it's going to give
-us a lot of flexibility.
-
 00:32:00.746 --> 00:32:02.706 A:middle
 So we're going to
 have things on iOS,
@@ -2822,10 +2723,6 @@ that will give us code
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:57.266 --> 00:33:00.406 A:middle
-And it turns out that
-that will give us code
 
 00:33:00.406 --> 00:33:02.656 A:middle
 that is cross-platform
@@ -2920,10 +2817,6 @@ to the low level framework.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.776 --> 00:34:01.096 A:middle
-of functionality by dropping
-to the low level framework.
-
 00:34:01.096 --> 00:34:04.236 A:middle
 There's a reason why
 we're making NSColor
@@ -3017,10 +2910,6 @@ interface for iOS and OS X.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.766 --> 00:35:04.086 A:middle
-and that would give us the same
-interface for iOS and OS X.
-
 00:35:04.086 --> 00:35:06.446 A:middle
 And let me just modify
 this slightly.
@@ -3103,10 +2992,6 @@ UIColor as the underlying color.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:56.236 --> 00:36:00.586 A:middle
-that class, we'll place a
-UIColor as the underlying color.
 
 00:36:00.646 --> 00:36:04.406 A:middle
 And so, whenever we need to
@@ -3210,10 +3095,6 @@ to color, you're going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.206 --> 00:37:00.996 A:middle
-So any place that you need
-to color, you're going
 
 00:37:00.996 --> 00:37:01.956 A:middle
 to call XPlatformColor.
@@ -3396,9 +3277,6 @@ Let me say that again.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.946 --> 00:39:00.766 A:middle
-Let me say that again.
-
 00:39:00.766 --> 00:39:02.446 A:middle
 Only for supported classes.
 
@@ -3480,10 +3358,6 @@ some custom archiving.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.916 --> 00:40:00.976 A:middle
-it's going to require
-some custom archiving.
 
 00:40:01.046 --> 00:40:03.326 A:middle
 because if you archive,
@@ -3586,10 +3460,6 @@ if you have a testing plan,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.206 --> 00:41:01.076 A:middle
-And testing plans, you know,
-if you have a testing plan,
-
 00:41:01.346 --> 00:41:03.236 A:middle
 then it means that every
 single time that you come
@@ -3681,10 +3551,6 @@ the toolbar at the bottom,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.306 --> 00:42:00.536 A:middle
-and you see instead of
-the toolbar at the bottom,
-
 00:42:00.536 --> 00:42:03.106 A:middle
 I have a toolbar on the
 top that has selectors
@@ -3764,10 +3630,6 @@ by dotting in this document.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.626 --> 00:43:00.966 A:middle
-for free just by do-- but
-by dotting in this document.
 
 00:43:01.936 --> 00:43:04.256 A:middle
 And I can go-- oh, this is
@@ -3861,10 +3723,6 @@ using-- when I encode it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.736 --> 00:44:03.796 A:middle
-So you can see, I'm
-using-- when I encode it,
-
 00:44:04.556 --> 00:44:07.796 A:middle
 I'm actually using a CIColor
 to archive it to a file
@@ -3936,10 +3794,6 @@ is the data, same code.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:54.936 --> 00:45:00.736 A:middle
-And then it does-- this
-is the data, same code.
 
 00:45:00.736 --> 00:45:03.386 A:middle
 So this takes the archiving
@@ -4039,10 +3893,6 @@ separated from your view
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.806 --> 00:46:02.366 A:middle
-so that your model is cleanly
-separated from your view
-
 00:46:02.366 --> 00:46:03.066 A:middle
 and you're controller.
 
@@ -4136,10 +3986,6 @@ of Auto Layout in Xcode 5.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.946 --> 00:47:01.916 A:middle
-So we have taken control
-of Auto Layout in Xcode 5.
 
 00:47:02.316 --> 00:47:03.516 A:middle
 If you want to know
@@ -4242,9 +4088,6 @@ all of that is on OS X
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.606 --> 00:48:01.126 A:middle
-all of that is on OS X
 
 00:48:01.236 --> 00:48:02.816 A:middle
 and you're code can

--- a/2013/217.srt
+++ b/2013/217.srt
@@ -83,10 +83,6 @@ again this year and we'll get
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.356 --> 00:01:01.176 A:middle
-And we're going to do that
-again this year and we'll get
-
 00:01:01.176 --> 00:01:02.146 A:middle
 to that in just a minute.
 
@@ -171,10 +167,6 @@ side, we've got the first page
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.966 --> 00:02:00.216 A:middle
-Over here on the right hand
-side, we've got the first page
 
 00:02:00.546 --> 00:02:02.326 A:middle
 and we're just swiping back
@@ -268,9 +260,6 @@ to rest at the beginning.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.226 --> 00:03:00.136 A:middle
-to rest at the beginning.
 
 00:03:00.776 --> 00:03:02.276 A:middle
 If we were to finish
@@ -366,10 +355,6 @@ applications in iOS 7-- oops.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.546 --> 00:04:03.666 A:middle
-that the way that we kill
-applications in iOS 7-- oops.
-
 00:04:04.836 --> 00:04:08.466 A:middle
 The way that we kill running
 applications in iOS7 is
@@ -457,10 +442,6 @@ the multitasking UI,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.086 --> 00:05:00.626 A:middle
-So again here in
-the multitasking UI,
 
 00:05:01.216 --> 00:05:03.346 A:middle
 you can see that there are
@@ -563,10 +544,6 @@ ScrollViews scrolling
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.246 --> 00:06:01.696 A:middle
-So this idea of multiple
-ScrollViews scrolling
-
 00:06:01.696 --> 00:06:04.106 A:middle
 through the same content at
 different rates is showing
@@ -660,10 +637,6 @@ thing can be found in Safari.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.996 --> 00:07:02.706 A:middle
-Another example of this kind of
-thing can be found in Safari.
 
 00:07:03.236 --> 00:07:06.176 A:middle
 If we go into the new Tab
@@ -760,10 +733,6 @@ conversation and you scroll
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.986 --> 00:08:01.876 A:middle
-that when you go into a
-conversation and you scroll
-
 00:08:01.876 --> 00:08:03.756 A:middle
 around it, the Chat
 Bubbles have a little bit
@@ -854,9 +823,6 @@ by the width of those two pages.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:56.596 --> 00:09:00.466 A:middle
-by the width of those two pages.
 
 00:09:00.616 --> 00:09:04.026 A:middle
 Now, that ScrollView is actually
@@ -967,10 +933,6 @@ we would do that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.346 --> 00:10:01.046 A:middle
-So let's look at how
-we would do that.
-
 00:10:02.236 --> 00:10:04.606 A:middle
 Well, where might we want to
 implement this kind of thing?
@@ -1067,10 +1029,6 @@ outer ScrollView
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.736 --> 00:11:01.206 A:middle
-So we'll take that
-outer ScrollView
-
 00:11:01.406 --> 00:11:04.376 A:middle
 and shift its contentOffset by
 the delta we just calculated.
@@ -1152,10 +1110,6 @@ a horizontally scrolling
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.626 --> 00:12:01.566 A:middle
-in the collection view contains
-a horizontally scrolling
 
 00:12:01.826 --> 00:12:04.286 A:middle
 ScrollView that scrolls
@@ -1325,10 +1279,6 @@ cell side of things,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.176 --> 00:14:00.466 A:middle
-to implement this scrolling
-cell side of things,
-
 00:14:00.466 --> 00:14:02.626 A:middle
 I'm going to head over
 to the View Controller
@@ -1408,9 +1358,6 @@ of the outer paging ScrollView.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.616 --> 00:15:01.156 A:middle
-of the outer paging ScrollView.
 
 00:15:01.566 --> 00:15:03.276 A:middle
 And because we're going to--
@@ -1508,10 +1455,6 @@ cell implementation
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.256 --> 00:16:00.266 A:middle
-to the scrolling
-cell implementation
-
 00:16:00.666 --> 00:16:04.866 A:middle
 and we can see how to go
 about calling these methods
@@ -1596,10 +1539,6 @@ contentOffset.x. Now let's
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:56.476 --> 00:17:01.176 A:middle
-it's just the ScrollView's
-contentOffset.x. Now let's
 
 00:17:01.176 --> 00:17:04.986 A:middle
 figure out whether this offset
@@ -1692,9 +1631,6 @@ to our outer paging ScrollView.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:59.496 --> 00:18:01.406 A:middle
-to our outer paging ScrollView.
 
 00:18:01.436 --> 00:18:03.356 A:middle
 That would have some
@@ -1791,10 +1727,6 @@ may have some momentum
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.376 --> 00:19:02.046 A:middle
-Alternatively, you
-may have some momentum
-
 00:19:02.156 --> 00:19:03.466 A:middle
 when you lift your
 finger, at which point,
@@ -1888,10 +1820,6 @@ building view not all the way
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.546 --> 00:20:02.246 A:middle
-between page boundaries with our
-building view not all the way
-
 00:20:02.306 --> 00:20:02.926 A:middle
 in the picture.
 
@@ -1980,10 +1908,6 @@ bugs, the zooming out from
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.806 --> 00:21:00.986 A:middle
-But now for the other two
-bugs, the zooming out from
 
 00:21:00.986 --> 00:21:02.346 A:middle
 under your finger
@@ -2076,10 +2000,6 @@ the left have now pulled away
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.986 --> 00:22:02.756 A:middle
-which started out aligned on
-the left have now pulled away
-
 00:22:02.756 --> 00:22:05.216 A:middle
 from each other 'cause the
 inner one has moved a bit
@@ -2167,10 +2087,6 @@ as it its containers.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.926 --> 00:23:00.136 A:middle
-it's the exact same width
-as it its containers.
 
 00:23:00.176 --> 00:23:01.646 A:middle
 So that gives it
@@ -2273,10 +2189,6 @@ the inner ScrollView.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.086 --> 00:24:00.776 A:middle
-as she was scrolling
-the inner ScrollView.
 
 00:24:01.666 --> 00:24:02.956 A:middle
 So, why was that happening?
@@ -2386,9 +2298,6 @@ And the really bad part here is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.546 --> 00:25:01.546 A:middle
-And the really bad part here is
-
 00:25:01.546 --> 00:25:04.496 A:middle
 that the red area representing
 our frame is now moving
@@ -2487,10 +2396,6 @@ everything will work right.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.906 --> 00:26:00.236 A:middle
-in place on screen and
-everything will work right.
-
 00:26:00.286 --> 00:26:02.736 A:middle
 So what's that going to
 look like in our code
@@ -2584,10 +2489,6 @@ wasn't wide enough given
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.636 --> 00:27:02.046 A:middle
-that was causing the problem,
-wasn't wide enough given
-
 00:27:02.046 --> 00:27:03.996 A:middle
 that we have this pull
 threshold to contend with.
@@ -2662,10 +2563,6 @@ a Transform which simply uses
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.056 --> 00:28:01.446 A:middle
-of our subviews and we'll set
-a Transform which simply uses
 
 00:28:01.446 --> 00:28:02.626 A:middle
 that very same pull offset
@@ -2751,10 +2648,6 @@ may not be immediately obvious
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.036 --> 00:29:04.736 A:middle
-So, there's one bug here that
-may not be immediately obvious
-
 00:29:04.736 --> 00:29:05.626 A:middle
 and I'm going to do something
 
@@ -2837,10 +2730,6 @@ moving back, of course,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.686 --> 00:30:00.686 A:middle
-So when this starts
-moving back, of course,
 
 00:30:01.086 --> 00:30:03.036 A:middle
 while the inner ScrollView
@@ -2937,10 +2826,6 @@ inner ScrollView has to move,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.706 --> 00:31:01.536 A:middle
-to move compared to how far the
-inner ScrollView has to move,
-
 00:31:01.726 --> 00:31:03.486 A:middle
 and then we're going to
 slow down the scrolling
@@ -3027,10 +2912,6 @@ when the scrolling ends,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.906 --> 00:32:03.406 A:middle
-And then, of course,
-when the scrolling ends,
-
 00:32:03.406 --> 00:32:05.176 A:middle
 I just need to remember
 to clear that flag.
@@ -3109,10 +2990,6 @@ same thing we did before.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.896 --> 00:33:03.036 A:middle
-we're going to do the
-same thing we did before.
-
 00:33:03.206 --> 00:33:07.066 A:middle
 But if we are decelerating back
 to zero, we're instead going
@@ -3187,10 +3064,6 @@ really, really cool stuff.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.606 --> 00:34:00.276 A:middle
-Now, this is actually a
-really, really cool stuff.
 
 00:34:00.276 --> 00:34:01.666 A:middle
 And if you didn't have a chance
@@ -3296,9 +3169,6 @@ that when our user scrolls them,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.606 --> 00:35:00.866 A:middle
-that when our user scrolls them,
-
 00:35:01.146 --> 00:35:03.136 A:middle
 we're going to have them
 get this really nice
@@ -3396,10 +3266,6 @@ we actually want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.266 --> 00:36:01.476 A:middle
-And when we scroll,
-we actually want
-
 00:36:01.476 --> 00:36:04.486 A:middle
 to move the attachment points
 instead of the views themselves.
@@ -3490,10 +3356,6 @@ to build this UI,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.646 --> 00:37:00.786 A:middle
-to understand in order
-to build this UI,
 
 00:37:00.786 --> 00:37:02.536 A:middle
 but there's a lot
@@ -3591,10 +3453,6 @@ CollectionViewLayout subclass,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.206 --> 00:38:00.536 A:middle
-to create this
-CollectionViewLayout subclass,
 
 00:38:00.566 --> 00:38:02.096 A:middle
 so let's see what
@@ -3704,10 +3562,6 @@ UIDynamicAnimator which is going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.256 --> 00:39:01.806 A:middle
-we're going to create a
-UIDynamicAnimator which is going
-
 00:39:01.806 --> 00:39:03.596 A:middle
 to represent that physics world
 
@@ -3803,9 +3657,6 @@ subclass method.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.866 --> 00:40:00.626 A:middle
-subclass method.
 
 00:40:01.216 --> 00:40:02.586 A:middle
 So with those two
@@ -3909,10 +3760,6 @@ display content on screen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.966 --> 00:41:03.086 A:middle
-to help a collection view
-display content on screen.
-
 00:41:03.946 --> 00:41:06.166 A:middle
 scrollViewDidScroll is a
 scrollView delegate method.
@@ -4009,10 +3856,6 @@ vertical scrolling in this case,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.616 --> 00:42:00.896 A:middle
-We're only carrying about
-vertical scrolling in this case,
-
 00:42:01.136 --> 00:42:02.326 A:middle
 so that's really easy to do,
 
@@ -4105,10 +3948,6 @@ that value by changing it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.696 --> 00:43:02.286 A:middle
-But we're going to go and update
-that value by changing it,
-
 00:43:02.286 --> 00:43:03.586 A:middle
 we just saw on the
 previous line,
@@ -4192,9 +4031,6 @@ So we will make a new class,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.286 --> 00:44:02.016 A:middle
-So we will make a new class,
-
 00:44:02.016 --> 00:44:07.706 A:middle
 we'll call it "Springy Flow
 Layout" and it's a subclass
@@ -4262,9 +4098,6 @@ and fill it with springs.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.936 --> 00:45:01.886 A:middle
-and fill it with springs.
 
 00:45:02.206 --> 00:45:06.516 A:middle
 And we're going to do that by
@@ -4343,10 +4176,6 @@ hundreds of thousands of things
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.496 --> 00:46:01.276 A:middle
-If you had a collection of
-hundreds of thousands of things
 
 00:46:01.276 --> 00:46:03.466 A:middle
 or even maybe thousands of
@@ -4436,10 +4265,6 @@ guaranteed to come
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.916 --> 00:47:00.426 A:middle
-then it wouldn't be
-guaranteed to come
 
 00:47:00.426 --> 00:47:02.476 A:middle
 to rest right at
@@ -4539,10 +4364,6 @@ super implementation
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.416 --> 00:48:01.676 A:middle
-And notice that the
-super implementation
-
 00:48:01.676 --> 00:48:04.336 A:middle
 of this wouldn't work
 because we're moving the items
@@ -4619,9 +4440,6 @@ that its contentOffset changes,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.156 --> 00:49:00.566 A:middle
-that its contentOffset changes,
 
 00:49:00.796 --> 00:49:02.586 A:middle
 we're going to find this
@@ -4701,10 +4519,6 @@ the dynamic animator is going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.756 --> 00:50:03.366 A:middle
-We're going to say No because
-the dynamic animator is going
 
 00:50:03.366 --> 00:50:04.646 A:middle
 to be moving the items around
@@ -4897,10 +4711,6 @@ were trying to build.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:58.476 --> 00:52:00.096 A:middle
-and clearly not what we
-were trying to build.
-
 00:52:00.816 --> 00:52:03.676 A:middle
 So what change do we have to
 make in order to fix this?
@@ -5002,10 +4812,6 @@ they're individually going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:58.396 --> 00:53:03.116 A:middle
-If we let that go, then
-they're individually going
-
 00:53:03.116 --> 00:53:04.706 A:middle
 to bounce at different speeds.
 
@@ -5094,10 +4900,6 @@ that to figure out how far
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:59.656 --> 00:54:03.666 A:middle
-and we can take advantage of
-that to figure out how far
-
 00:54:03.666 --> 00:54:06.816 A:middle
 that touch location is from
 each individual spring.
@@ -5172,10 +4974,6 @@ the center of the item,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:57.776 --> 00:55:02.956 A:middle
-So now, when we adjust
-the center of the item,
 
 00:55:02.956 --> 00:55:05.176 A:middle
 instead of just adding the
@@ -5264,10 +5062,6 @@ of the scroll delta
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:57.806 --> 00:56:00.356 A:middle
-So we want the minimum
-of the scroll delta
-
 00:56:00.356 --> 00:56:04.516 A:middle
 and then the adjusted scroll
 delta by the scroll resistance.
@@ -5350,9 +5144,6 @@ we talked a lot about tiling.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:58.896 --> 00:57:00.106 A:middle
-we talked a lot about tiling.
 
 00:57:00.106 --> 00:57:02.626 A:middle
 So this is a slightly weird
@@ -5446,10 +5237,6 @@ that's always greater than zero
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:57:58.686 --> 00:58:01.706 A:middle
-you actually pick the value
-that's always greater than zero
 
 00:58:01.706 --> 00:58:03.286 A:middle
 and sometimes we
@@ -5549,10 +5336,6 @@ in the WWDC app that Jake has,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:58:57.556 --> 00:59:00.696 A:middle
-and watch some of these sessions
-in the WWDC app that Jake has,
 
 00:59:00.696 --> 00:59:02.906 A:middle
 you know, kindly given

--- a/2013/218.srt
+++ b/2013/218.srt
@@ -55,9 +55,6 @@ like helping decide whether
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.846 --> 00:01:01.256 A:middle
-like helping decide whether
-
 00:01:01.256 --> 00:01:06.216 A:middle
 or not a application should auto
 rotate, how it should be laid
@@ -119,10 +116,6 @@ to my intro.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.256 --> 00:02:00.566 A:middle
-So enough of my intro
-to my intro.
 
 00:02:02.246 --> 00:02:04.616 A:middle
 Let's quickly go over what
@@ -201,10 +194,6 @@ of that API.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.986 --> 00:03:01.406 A:middle
-in fact enhancements
-of that API.
 
 00:03:02.896 --> 00:03:07.316 A:middle
 We've introduced kind of a
@@ -357,10 +346,6 @@ we're going to go through it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.176 --> 00:05:02.356 A:middle
-There's a lot of API, and
-we're going to go through it.
-
 00:05:02.356 --> 00:05:04.666 A:middle
 There's going to be a lot of
 code that doesn't fit very well
@@ -440,10 +425,6 @@ your mind, but the user --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.316 --> 00:06:01.266 A:middle
-I mean you don't have to change
-your mind, but the user --
-
 00:06:01.266 --> 00:06:04.686 A:middle
 and certainly this is the case
 with the pop gesture in iOS 7 --
@@ -516,10 +497,6 @@ transitions, you probably want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.646 --> 00:07:01.176 A:middle
-of UIView level
-transitions, you probably want
-
 00:07:01.276 --> 00:07:03.966 A:middle
 to take your view controllers
 in for a tune-up, and your views
@@ -581,10 +558,6 @@ see throughout iOS.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.116 --> 00:08:01.596 A:middle
-animations that you
-see throughout iOS.
 
 00:08:01.716 --> 00:08:08.706 A:middle
 Sometimes you get caught
@@ -650,10 +623,6 @@ have to know about, you know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:57.266 --> 00:09:03.166 A:middle
-Great thing is you don't
-have to know about, you know,
 
 00:09:03.166 --> 00:09:06.536 A:middle
 solutions to single dimensional
@@ -793,10 +762,6 @@ of snapshots,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.726 --> 00:11:00.616 A:middle
-you can create snapshots
-of snapshots,
-
 00:11:00.616 --> 00:11:02.446 A:middle
 and that can also
 be pretty useful.
@@ -879,9 +844,6 @@ And the difference with --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.326 --> 00:12:00.796 A:middle
-And the difference with --
 
 00:12:00.796 --> 00:12:03.066 A:middle
 about that is that it
@@ -976,10 +938,6 @@ we can refer to those as layout
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.796 --> 00:13:03.306 A:middle
-and collection view controller,
-we can refer to those as layout
 
 00:13:03.306 --> 00:13:05.336 A:middle
 to layout navigation
@@ -1139,10 +1097,6 @@ bounce that comes in and out
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.106 --> 00:15:02.356 A:middle
-You'll notice a little kind of
-bounce that comes in and out
-
 00:15:02.356 --> 00:15:06.016 A:middle
 of that, and then it's
 critically damped going out.
@@ -1214,10 +1168,6 @@ different delegates.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.746 --> 00:16:00.276 A:middle
-I'm just setting
-different delegates.
 
 00:16:00.276 --> 00:16:01.926 A:middle
 And the code that you've written
@@ -1310,10 +1260,6 @@ much about UIKit dynamics,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:57.826 --> 00:17:01.066 A:middle
-So I'm not going to talk
-much about UIKit dynamics,
-
 00:17:01.216 --> 00:17:02.636 A:middle
 but I do want to
 whet your appetite
@@ -1390,10 +1336,6 @@ other, you go through this kind
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.466 --> 00:18:02.466 A:middle
-Now to move from one to the
-other, you go through this kind
 
 00:18:02.466 --> 00:18:03.946 A:middle
 of inconsistent phase.
@@ -1472,9 +1414,6 @@ So that highlighted --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.086 --> 00:19:00.136 A:middle
-So that highlighted --
 
 00:19:00.696 --> 00:19:03.386 A:middle
 those highlighted statements
@@ -1562,10 +1501,6 @@ transitions needs
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.206 --> 00:20:00.196 A:middle
-to create your custom
-transitions needs
 
 00:20:00.196 --> 00:20:01.586 A:middle
 to call back into that method.
@@ -1658,10 +1593,6 @@ ways, so that we'll try
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.126 --> 00:21:00.736 A:middle
-and a few different
-ways, so that we'll try
 
 00:21:00.736 --> 00:21:03.896 A:middle
 to demystify some of this stuff.
@@ -1846,10 +1777,6 @@ to say animate, transition,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.076 --> 00:23:04.116 A:middle
-At some point later we're going
-to say animate, transition,
-
 00:23:04.386 --> 00:23:05.896 A:middle
 and this is your code.
 
@@ -1925,10 +1852,6 @@ kind of consistent with a lot
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.736 --> 00:24:02.356 A:middle
-Just to make it clear, that's
-kind of consistent with a lot
 
 00:24:02.356 --> 00:24:05.386 A:middle
 of the previous ways
@@ -2015,10 +1938,6 @@ controllers' views are
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.676 --> 00:25:02.026 A:middle
-that the to and from view
-controllers' views are
-
 00:25:02.026 --> 00:25:05.706 A:middle
 where they need to be, and
 you call complete transition.
@@ -2092,10 +2011,6 @@ isn't necessarily the case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:56.826 --> 00:26:00.016 A:middle
-by gesture recognizers, that
-isn't necessarily the case.
-
 00:26:00.016 --> 00:26:03.306 A:middle
 You can -- anything that you
 can drive programmatically
@@ -2167,10 +2082,6 @@ transitioning really couldn't
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.846 --> 00:27:02.246 A:middle
-The protocol for interactive
-transitioning really couldn't
 
 00:27:02.246 --> 00:27:02.796 A:middle
 be simpler.
@@ -2246,10 +2157,6 @@ looks the same.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.536 --> 00:28:01.156 A:middle
-So far everything
-looks the same.
 
 00:28:02.196 --> 00:28:03.376 A:middle
 What's different is this.
@@ -2350,10 +2257,6 @@ recognizer is basically going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:57.546 --> 00:29:00.156 A:middle
-And your gesture
-recognizer is basically going
-
 00:29:00.156 --> 00:29:02.906 A:middle
 to be constantly calling
 update interactive transition,
@@ -2440,9 +2343,6 @@ that's in fact what we do.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.066 --> 00:30:00.326 A:middle
-that's in fact what we do.
-
 00:30:00.916 --> 00:30:06.326 A:middle
 Finally, animation ends,
 complete transition is called,
@@ -2521,9 +2421,6 @@ And instead of calling any --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.206 --> 00:31:01.806 A:middle
-And instead of calling any --
-
 00:31:02.006 --> 00:31:04.416 A:middle
 out to any of the context
 methods, you're just going
@@ -2598,10 +2495,6 @@ of this is driven
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.446 --> 00:32:01.656 A:middle
-the interactive portion
-of this is driven
 
 00:32:02.096 --> 00:32:03.636 A:middle
 with the percent-driven
@@ -2687,10 +2580,6 @@ percent-driven interaction
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.756 --> 00:33:00.926 A:middle
-If you've sub-classed
-percent-driven interaction
-
 00:33:00.926 --> 00:33:03.266 A:middle
 transition, you're going to
 get all of your interactivity
@@ -2760,10 +2649,6 @@ actually a new layout,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:56.826 --> 00:34:01.676 A:middle
-And that new API is
-actually a new layout,
-
 00:34:02.426 --> 00:34:04.896 A:middle
 UICollectionView
 TransitionLayout.
@@ -2824,10 +2709,6 @@ view transition layout,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.016 --> 00:35:01.846 A:middle
-If you use a UI collection
-view transition layout,
-
 00:35:03.486 --> 00:35:07.146 A:middle
 you can actually drive
 that transition progress,
@@ -2883,10 +2764,6 @@ view transition layout for you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.106 --> 00:36:00.166 A:middle
-we do that in UI collection
-view transition layout for you.
 
 00:36:00.766 --> 00:36:01.846 A:middle
 You don't have to do anything.
@@ -2947,10 +2824,6 @@ the old current layout,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:55.616 --> 00:37:01.016 A:middle
-or if you want to get back
-the old current layout,
 
 00:37:01.016 --> 00:37:03.816 A:middle
 just call cancel
@@ -3018,10 +2891,6 @@ changes to cell positions based
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.966 --> 00:38:02.716 A:middle
-Which means that you could drive
-changes to cell positions based
-
 00:38:03.136 --> 00:38:05.246 A:middle
 on the gesture position.
 
@@ -3087,10 +2956,6 @@ us to track your values,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.186 --> 00:39:03.766 A:middle
-So you can actually ask
-us to track your values,
 
 00:39:04.326 --> 00:39:09.796 A:middle
 and then in this final phase
@@ -3277,10 +3142,6 @@ collection view.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.426 --> 00:42:01.476 A:middle
-And that's it for
-collection view.
-
 00:42:01.476 --> 00:42:03.976 A:middle
 I'd like to bring
 back Bruce, thank you.
@@ -3348,10 +3209,6 @@ is we go from disappeared
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.086 --> 00:43:01.696 A:middle
-And typically what happens
-is we go from disappeared
 
 00:43:01.696 --> 00:43:03.346 A:middle
 to appearing, to
@@ -3433,10 +3290,6 @@ what it's saying is true.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:55.796 --> 00:44:00.686 A:middle
-But most of the time
-what it's saying is true.
-
 00:44:00.686 --> 00:44:02.326 A:middle
 But now you've got
 to kind of take
@@ -3515,10 +3368,6 @@ using block is what you can use
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.986 --> 00:45:03.956 A:middle
-notify when interaction ends
-using block is what you can use
 
 00:45:03.956 --> 00:45:08.256 A:middle
 to help manage the untoward
@@ -3686,10 +3535,6 @@ coordinator's kind of cool,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:56.756 --> 00:47:00.176 A:middle
-But the transition
-coordinator's kind of cool,
-
 00:47:00.176 --> 00:47:02.386 A:middle
 because as we implemented it,
 
@@ -3777,10 +3622,6 @@ the running transition.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.646 --> 00:48:03.186 A:middle
-that you can animate alongside
-the running transition.
-
 00:48:03.486 --> 00:48:06.166 A:middle
 So to make that more
 useful -- I mean this works,
@@ -3849,10 +3690,6 @@ in an animation block
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:56.076 --> 00:49:00.536 A:middle
-And basically you pass
-in an animation block
 
 00:49:00.536 --> 00:49:02.646 A:middle
 that animates alongside, you
@@ -3944,10 +3781,6 @@ transition.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:58.036 --> 00:50:00.676 A:middle
-to call animate alongside
-transition.
-
 00:50:00.676 --> 00:50:02.676 A:middle
 You don't even have
 to pass in anything
@@ -4020,9 +3853,6 @@ Alright. So, I like this quote.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.476 --> 00:51:01.266 A:middle
-Alright. So, I like this quote.
-
 00:51:02.096 --> 00:51:04.636 A:middle
 We've kind of created a lot
 
@@ -4092,10 +3922,6 @@ controller can be used now,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:57.746 --> 00:52:01.226 A:middle
-UICollectionView
-controller can be used now,
 
 00:52:01.706 --> 00:52:04.136 A:middle
 it can be used really
@@ -4171,10 +3997,6 @@ couple of related sessions,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:56.836 --> 00:53:00.756 A:middle
-I would like to point out a
-couple of related sessions,
 
 00:53:00.756 --> 00:53:02.886 A:middle
 and one of which is going

--- a/2013/219.srt
+++ b/2013/219.srt
@@ -74,10 +74,6 @@ know that just aren't so.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.186 --> 00:01:00.266 A:middle
-as the things you do
-know that just aren't so.
-
 00:01:02.146 --> 00:01:05.476 A:middle
 Now, there are some
 genuine challenges here.
@@ -237,10 +233,6 @@ language preference again
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:57.626 --> 00:03:00.136 A:middle
-You have the user's
-language preference again
-
 00:03:00.136 --> 00:03:02.416 A:middle
 that determines what
 localizations will be used,
@@ -320,10 +312,6 @@ all users of your app.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:56.756 --> 00:04:01.056 A:middle
-of user experience for
-all users of your app.
-
 00:04:01.696 --> 00:04:03.626 A:middle
 Now, today, I'm going
 to be talking about how
@@ -399,10 +387,6 @@ at run time is determined
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.056 --> 00:05:01.476 A:middle
-Whichever one gets loaded
-at run time is determined
 
 00:05:01.476 --> 00:05:03.916 A:middle
 by what the user selected
@@ -496,9 +480,6 @@ and works for this interface.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.016 --> 00:06:00.386 A:middle
-and works for this interface.
-
 00:06:01.466 --> 00:06:03.166 A:middle
 Like I said, while
 these work today,
@@ -587,10 +568,6 @@ to modify this one file,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.816 --> 00:07:01.666 A:middle
-As a developer, I only need
-to modify this one file,
-
 00:07:02.056 --> 00:07:04.456 A:middle
 and every single time I
 create a new localization,
@@ -678,10 +655,6 @@ use base internationalization.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.716 --> 00:08:02.766 A:middle
-So, let's get started on how to
-use base internationalization.
-
 00:08:02.966 --> 00:08:05.066 A:middle
 So in my project
 window for X code,
@@ -759,10 +732,6 @@ in my base.Lproj folder,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.986 --> 00:09:04.726 A:middle
-So, in this example here
-in my base.Lproj folder,
 
 00:09:04.726 --> 00:09:08.496 A:middle
 I just pass in the nib file that
@@ -844,10 +813,6 @@ size instead and as always
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.406 --> 00:10:02.946 A:middle
-to prefer an intrinsic content
-size instead and as always
 
 00:10:02.946 --> 00:10:07.366 A:middle
 if you, you should always
@@ -936,10 +901,6 @@ for a name key, it will look
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.196 --> 00:11:03.156 A:middle
-So, if my application is looking
-for a name key, it will look
 
 00:11:03.156 --> 00:11:05.756 A:middle
 in the name field for that
@@ -1032,10 +993,6 @@ it's highly recommended you use.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.116 --> 00:12:03.236 A:middle
-that will do this for you, and
-it's highly recommended you use.
-
 00:12:03.516 --> 00:12:05.496 A:middle
 It's called gen strings,
 
@@ -1118,10 +1075,6 @@ it to whatever language
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.976 --> 00:13:01.116 A:middle
-of the table to localize
-it to whatever language
 
 00:13:01.116 --> 00:13:07.646 A:middle
 that this is in, and
@@ -1206,10 +1159,6 @@ this issue where one part
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.486 --> 00:14:01.636 A:middle
-so you don't run into
-this issue where one part
 
 00:14:01.636 --> 00:14:03.436 A:middle
 of your application
@@ -1302,10 +1251,6 @@ engineers do quite often;
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.736 --> 00:15:01.126 A:middle
-which is something we as
-engineers do quite often;
-
 00:15:02.306 --> 00:15:04.976 A:middle
 the reason being is that if
 you compose phases together,
@@ -1393,10 +1338,6 @@ to make sure again
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:57.906 --> 00:16:00.356 A:middle
-So, it's very important
-to make sure again
-
 00:16:00.356 --> 00:16:04.236 A:middle
 that your user visible text
 each has their own unique key,
@@ -1482,10 +1423,6 @@ complete technical detail,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.556 --> 00:17:00.976 A:middle
-To learn more about this in
-complete technical detail,
-
 00:17:01.036 --> 00:17:03.466 A:middle
 check out the foundation
 release notes, but if you want
@@ -1570,10 +1507,6 @@ for any extra code
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.466 --> 00:18:01.746 A:middle
-So, there is no need
-for any extra code
-
 00:18:01.746 --> 00:18:03.396 A:middle
 to handle for localization.
 
@@ -1652,10 +1585,6 @@ will have trouble translating
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:56.806 --> 00:19:00.426 A:middle
-be aware that your localizers
-will have trouble translating
 
 00:19:00.426 --> 00:19:03.086 A:middle
 text in your image, as opposed
@@ -1748,10 +1677,6 @@ to alert other drivers
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.356 --> 00:20:00.956 A:middle
-or a beginner driver
-to alert other drivers
-
 00:20:00.956 --> 00:20:01.926 A:middle
 that she should probably
 get out of the way.
@@ -1839,10 +1764,6 @@ you can run your application
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:57.306 --> 00:21:00.986 A:middle
-or a file loads correctly,
-you can run your application
 
 00:21:00.986 --> 00:21:03.566 A:middle
 in X code using the dash
@@ -1937,10 +1858,6 @@ application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.656 --> 00:22:04.756 A:middle
-we wrote a tiny little
-application.
 
 00:22:04.756 --> 00:22:09.966 A:middle
 So, what this application
@@ -2057,10 +1974,6 @@ associated with it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.176 --> 00:24:03.076 A:middle
-we get a strings file
-associated with it
-
 00:24:03.766 --> 00:24:07.266 A:middle
 that contains the
 translations; we added a rough
@@ -2126,10 +2039,6 @@ put in appropriate translations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.396 --> 00:25:01.286 A:middle
-and then for German, where we
-put in appropriate translations
 
 00:25:01.656 --> 00:25:06.606 A:middle
 for each of the keys that
@@ -2205,10 +2114,6 @@ credits file that X code wants
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.846 --> 00:26:00.926 A:middle
-the strings dict, and that
-credits file that X code wants
-
 00:26:00.926 --> 00:26:04.736 A:middle
 to create for us,
 and when we run this,
@@ -2266,9 +2171,6 @@ with locale data.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.516 --> 00:27:00.946 A:middle
-[ Applause ]
 
 00:27:01.446 --> 00:27:02.506 A:middle
 &gt;&gt; Okay, hello, hello.
@@ -2366,10 +2268,6 @@ format preference pane.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.926 --> 00:28:01.936 A:middle
-in the languages and
-format preference pane.
 
 00:28:02.396 --> 00:28:05.516 A:middle
 In a concrete sense, it
@@ -2548,10 +2446,6 @@ and Chinese as used in China.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:57.506 --> 00:30:01.266 A:middle
-French as used in France,
-and Chinese as used in China.
-
 00:30:01.266 --> 00:30:04.106 A:middle
 Here we have the out of
 the box representation
@@ -2638,9 +2532,6 @@ of this same NSDate object,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.276 --> 00:31:00.706 A:middle
-of this same NSDate object,
 
 00:31:00.706 --> 00:31:04.886 A:middle
 you have to go beyond the
@@ -2735,10 +2626,6 @@ it, but, there is, oh, sorry,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.966 --> 00:32:01.596 A:middle
-So, this is the correct to do
-it, but, there is, oh, sorry,
-
 00:32:01.756 --> 00:32:06.326 A:middle
 finally, we set the date format
 on our date formatter instance.
@@ -2829,10 +2716,6 @@ followed by number in the US,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.326 --> 00:33:01.446 A:middle
-We have the month name
-followed by number in the US,
 
 00:33:01.846 --> 00:33:05.526 A:middle
 the vice versa in France, and
@@ -2925,10 +2808,6 @@ from C world will be familiar
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.006 --> 00:34:01.656 A:middle
-strings, so those of you coming
-from C world will be familiar
-
 00:34:01.656 --> 00:34:04.546 A:middle
 with the print F style
 C format strings.
@@ -3013,10 +2892,6 @@ literal, denoted by the at sign,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.526 --> 00:35:00.186 A:middle
-Let's start with an NSNumber
-literal, denoted by the at sign,
 
 00:35:00.186 --> 00:35:03.846 A:middle
 followed by the number, 1234.56,
@@ -3107,10 +2982,6 @@ locale as your app is running.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.476 --> 00:36:02.626 A:middle
-that the user has changed your
-locale as your app is running.
-
 00:36:03.736 --> 00:36:06.776 A:middle
 From there, if you
 want even more detail,
@@ -3197,10 +3068,6 @@ the distinction
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:56.576 --> 00:37:00.766 A:middle
-Keep in mind though,
-the distinction
 
 00:37:00.766 --> 00:37:02.686 A:middle
 between a locale
@@ -3289,9 +3156,6 @@ and the Hassay period in Japan,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.536 --> 00:38:00.956 A:middle
-and the Hassay period in Japan,
-
 00:38:01.276 --> 00:38:03.296 A:middle
 which happened as
 recently as 1989.
@@ -3378,10 +3242,6 @@ units that we wish to obtain.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:57.526 --> 00:39:00.106 A:middle
-and passing in the individual
-units that we wish to obtain.
-
 00:39:00.676 --> 00:39:03.796 A:middle
 Keep in mind here, you'll
 only obtain these units
@@ -3467,9 +3327,6 @@ despite what the song may say.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.426 --> 00:40:01.286 A:middle
-despite what the song may say.
-
 00:40:01.496 --> 00:40:03.206 A:middle
 So, for more information
 on this,
@@ -3551,10 +3408,6 @@ for full representation,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.946 --> 00:41:01.226 A:middle
-for an internal machinery
-for full representation,
-
 00:41:01.226 --> 00:41:03.686 A:middle
 but it's not the sort of thing
 I want to present to my users.
@@ -3634,10 +3487,6 @@ that I got on my date formatter,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.916 --> 00:42:03.946 A:middle
-and then I set that date format
-that I got on my date formatter,
-
 00:42:03.946 --> 00:42:06.656 A:middle
 and it's ready to go
 for my number formatter.
@@ -3712,10 +3561,6 @@ going to recreate my formatters
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.326 --> 00:43:01.786 A:middle
-that notification, I'm just
-going to recreate my formatters
-
 00:43:01.836 --> 00:43:03.256 A:middle
 with whatever the new locale is.
 
@@ -3766,10 +3611,6 @@ the system preferences,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.576 --> 00:44:01.946 A:middle
-So, now if I go into
-the system preferences,
-
 00:44:01.946 --> 00:44:05.686 A:middle
 I change my primary language
 to English, and my region
@@ -3815,10 +3656,6 @@ as the number of notes changes.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:56.286 --> 00:45:07.406 A:middle
-appropriately pluralized titles
-as the number of notes changes.
 
 00:45:08.266 --> 00:45:11.996 A:middle
 So, that's using date
@@ -3890,10 +3727,6 @@ Unicode and in particular,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:56.956 --> 00:46:01.456 A:middle
-The first one is, use
-Unicode and in particular,
 
 00:46:01.626 --> 00:46:04.676 A:middle
 the NSString class, which is
@@ -3968,10 +3801,6 @@ remember about using Unicode
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.736 --> 00:47:02.796 A:middle
-The thing I want you to
-remember about using Unicode
 
 00:47:02.796 --> 00:47:08.396 A:middle
 to represent text, is that you
@@ -4136,10 +3965,6 @@ corresponding to this character,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.516 --> 00:49:03.256 A:middle
-with the range and the string
-corresponding to this character,
-
 00:49:03.256 --> 00:49:08.086 A:middle
 whatever it may be,
 whether it's short or long.
@@ -4296,10 +4121,6 @@ use localized standard compare.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.046 --> 00:51:01.806 A:middle
-For user presentation of text,
-use localized standard compare.
-
 00:51:02.256 --> 00:51:03.616 A:middle
 That will be locale sensitive.
 
@@ -4382,10 +4203,6 @@ gets shown on the screen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:59.756 --> 00:52:03.586 A:middle
-correlated with what
-gets shown on the screen.
-
 00:52:04.006 --> 00:52:06.746 A:middle
 So, what gets shown on the
 screen is a sequence of glifs.
@@ -4459,10 +4276,6 @@ excellent sessions on this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.966 --> 00:53:01.806 A:middle
-and there are some
-excellent sessions on this.
 
 00:53:01.846 --> 00:53:03.676 A:middle
 There was an introductory
@@ -4544,10 +4357,6 @@ characters that are included
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:58.856 --> 00:54:01.466 A:middle
-there are some Unicode control
-characters that are included
-
 00:54:01.466 --> 00:54:04.756 A:middle
 in this text and these
 are things that may show
@@ -4626,10 +4435,6 @@ some options of choices,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:59.176 --> 00:55:02.086 A:middle
-Then the system shows them
-some options of choices,
 
 00:55:02.086 --> 00:55:03.766 A:middle
 and they pick the one
@@ -4715,10 +4520,6 @@ to operate on that,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:58.906 --> 00:56:00.376 A:middle
-You probably don't want
-to operate on that,
-
 00:56:00.376 --> 00:56:03.906 A:middle
 because it's only preliminary,
 it's not the final text.
@@ -4800,10 +4601,6 @@ at the foundation level
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:58.756 --> 00:57:01.206 A:middle
-There is also NSDataDetector
-at the foundation level
 
 00:57:01.206 --> 00:57:02.286 A:middle
 for doing this protomatically

--- a/2013/220.srt
+++ b/2013/220.srt
@@ -66,10 +66,6 @@ three main Text Kit objects,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.956 --> 00:01:04.286 A:middle
-Next, we're going to cover the
-three main Text Kit objects,
-
 00:01:04.635 --> 00:01:10.106 A:middle
 NSLayoutManager, NSTextContainer
 and NSTextStorage, the power,
@@ -129,10 +125,6 @@ to spice up your application,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:55.746 --> 00:02:02.896 A:middle
-who's going to tell you how
-to spice up your application,
 
 00:02:03.226 --> 00:02:04.856 A:middle
 what is the cool text effects.
@@ -208,10 +200,6 @@ exposing this to you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:56.846 --> 00:03:00.496 A:middle
-But now, in iOS 7, we're
-exposing this to you
 
 00:03:00.496 --> 00:03:03.146 A:middle
 through one attributed
@@ -291,9 +279,6 @@ to Text Kit session yesterday.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.846 --> 00:04:00.546 A:middle
-to Text Kit session yesterday.
-
 00:04:02.376 --> 00:04:05.676 A:middle
 In Text Kit, there are
 three classes that we use
@@ -365,10 +350,6 @@ and a document as long as War
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:56.556 --> 00:05:00.936 A:middle
-like a brief note or message,
-and a document as long as War
-
 00:05:00.936 --> 00:05:04.396 A:middle
 and Peace, so it should be
 totally perfect for your needs.
@@ -435,10 +416,6 @@ one area on the display
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.486 --> 00:06:01.436 A:middle
-Text Container represents
-one area on the display
 
 00:06:01.696 --> 00:06:03.166 A:middle
 in which you'd like
@@ -598,10 +575,6 @@ can implement a document
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.686 --> 00:08:02.896 A:middle
-of just how simple you
-can implement a document
-
 00:08:02.896 --> 00:08:05.406 A:middle
 of arbitrary length, a
 multi-paged document.
@@ -680,10 +653,6 @@ a text view which is going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.526 --> 00:09:01.566 A:middle
-And this just encapsulates
-a text view which is going
-
 00:09:01.566 --> 00:09:04.696 A:middle
 to draw the text on
 screen and the page number
@@ -755,10 +724,6 @@ the page view controller data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.686 --> 00:10:00.186 A:middle
-Next, we're going to implement
-the page view controller data
 
 00:10:00.186 --> 00:10:01.126 A:middle
 source methods.
@@ -835,10 +800,6 @@ flowed into this view perfectly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:56.106 --> 00:11:02.136 A:middle
-And as you can see our text is
-flowed into this view perfectly.
-
 00:11:02.746 --> 00:11:05.756 A:middle
 And as we scroll using the
 paging behavior our users have
@@ -910,10 +871,6 @@ class that orchestrates
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.066 --> 00:12:04.066 A:middle
-It's a Text Kit controller
-class that orchestrates
-
 00:12:04.216 --> 00:12:08.906 A:middle
 between NSTextContainer
 and NSTextStorage.
@@ -964,10 +921,6 @@ and subclassing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.976 --> 00:13:01.266 A:middle
-such as delegation
-and subclassing.
-
 00:13:04.176 --> 00:13:06.476 A:middle
 Before going any deeper,
 
@@ -1014,10 +967,6 @@ elements, they can be handled
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:55.986 --> 00:14:03.246 A:middle
-And since glyphs are graphical
-elements, they can be handled
 
 00:14:03.246 --> 00:14:05.846 A:middle
 by the graphic subsystem
@@ -1072,10 +1021,6 @@ precise location,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.156 --> 00:15:02.466 A:middle
-Also you can get the
-precise location,
 
 00:15:03.126 --> 00:15:06.616 A:middle
 fix your perfect location
@@ -1133,10 +1078,6 @@ of NSTextStorage.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.986 --> 00:16:01.896 A:middle
-to access the contents
-of NSTextStorage.
-
 00:16:02.236 --> 00:16:05.556 A:middle
 So glyph index character
 index, where are they?
@@ -1193,9 +1134,6 @@ and characters in bulk.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.586 --> 00:17:01.176 A:middle
-and characters in bulk.
-
 00:17:01.616 --> 00:17:06.486 A:middle
 And remember, it's important
 to remember that, in any case,
@@ -1248,10 +1186,6 @@ beginning of the Text Container
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:55.786 --> 00:18:00.076 A:middle
-glyphs are filled from the
-beginning of the Text Container
 
 00:18:00.076 --> 00:18:03.586 A:middle
 at index zero and
@@ -1316,10 +1250,6 @@ like this due
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:57.796 --> 00:19:01.226 A:middle
-into multiple pieces
-like this due
-
 00:19:01.226 --> 00:19:07.396 A:middle
 to NSTextContainer geometrical
 shape defined by exclusion path.
@@ -1371,10 +1301,6 @@ elements inside the
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.576 --> 00:20:02.086 A:middle
-among the three geometrical
-elements inside the
-
 00:20:02.086 --> 00:20:03.066 A:middle
 layout information.
 
@@ -1424,10 +1350,6 @@ upper left corner.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.966 --> 00:21:00.616 A:middle
-that start with the
-upper left corner.
-
 00:21:02.176 --> 00:21:09.106 A:middle
 And the glyphs are located at
 its baseline origin that starts
@@ -1475,9 +1397,6 @@ Then as we discussed earlier,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.316 --> 00:22:01.456 A:middle
-Then as we discussed earlier,
 
 00:22:02.876 --> 00:22:06.006 A:middle
 we want to convert the
@@ -1544,10 +1463,6 @@ primitive methods that acts
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.596 --> 00:23:00.896 A:middle
-In addition to the
-primitive methods that acts
 
 00:23:00.896 --> 00:23:03.506 A:middle
 as the layout information
@@ -1660,10 +1575,6 @@ needs while you can enjoy Text
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.376 --> 00:25:04.146 A:middle
-and extensibilities for your
-needs while you can enjoy Text
-
 00:25:04.536 --> 00:25:10.566 A:middle
 Kit and amenities such as
 old layout and accessibility.
@@ -1712,10 +1623,6 @@ Manager variable contains
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:55.936 --> 00:26:01.876 A:middle
-Here, it's assumed this Layout
-Manager variable contains
 
 00:26:02.156 --> 00:26:04.336 A:middle
 preconfigured Layout Manager.
@@ -1836,10 +1743,6 @@ NSBackgroundColorAttributeName.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.476 --> 00:28:01.656 A:middle
-such as
-NSBackgroundColorAttributeName.
-
 00:28:02.736 --> 00:28:08.016 A:middle
 But we recommend always using
 this method whenever you are
@@ -1958,9 +1861,6 @@ so that the location paths
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.336 --> 00:30:04.276 A:middle
-so that the location paths
-
 00:30:05.736 --> 00:30:08.756 A:middle
 to the rendering
 method can be arbitrary
@@ -2071,10 +1971,6 @@ line could be divided
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:56.356 --> 00:32:01.396 A:middle
-Remember, a visual
-line could be divided
-
 00:32:01.396 --> 00:32:05.696 A:middle
 into multiple line fragments
 because of the exclusion path.
@@ -2129,10 +2025,6 @@ the line fragment rect inside
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.696 --> 00:33:04.316 A:middle
-And here we are enumerating all
-the line fragment rect inside
-
 00:33:04.606 --> 00:33:13.536 A:middle
 the fixed container by comparing
 the stored last line fragment
@@ -2180,10 +2072,6 @@ the information stored
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:55.786 --> 00:34:00.426 A:middle
-in your text using
-the information stored
 
 00:34:00.426 --> 00:34:03.766 A:middle
 in NSLayoutManager and
@@ -2238,10 +2126,6 @@ it's being laid out.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.226 --> 00:35:04.466 A:middle
-of layout process while
-it's being laid out.
-
 00:35:05.076 --> 00:35:10.066 A:middle
 For example, you can
 override the line spacing.
@@ -2294,10 +2178,6 @@ rendering like this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:53.466 --> 00:36:01.036 A:middle
-for some other extra
-rendering like this.
 
 00:36:03.156 --> 00:36:08.196 A:middle
 [Inaudible] a lot annotation
@@ -2391,10 +2271,6 @@ glyph mapping.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:57.896 --> 00:38:00.156 A:middle
-That's the default
-glyph mapping.
 
 00:38:01.906 --> 00:38:05.746 A:middle
 You can override this
@@ -2500,10 +2376,6 @@ glyphs that's being truncated
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:58.576 --> 00:40:02.946 A:middle
-you can get the range of the
-glyphs that's being truncated
-
 00:40:02.946 --> 00:40:07.716 A:middle
 out from the user's view.
 
@@ -2551,10 +2423,6 @@ method get being called.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.306 --> 00:41:01.036 A:middle
-font:forGlyphRange
-method get being called.
 
 00:41:01.696 --> 00:41:05.566 A:middle
 And inside this method, you
@@ -2617,10 +2485,6 @@ any way you want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.796 --> 00:42:02.356 A:middle
-and you can override
-any way you want
-
 00:42:02.626 --> 00:42:06.276 A:middle
 until you have your delegate
 object and your implementation
@@ -2665,10 +2529,6 @@ NSLayoutManager often try
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.986 --> 00:43:02.836 A:middle
-and be efficient,
-NSLayoutManager often try
 
 00:43:02.836 --> 00:43:07.666 A:middle
 to pad the glyph range that's
@@ -2722,10 +2582,6 @@ as the glyph will be ignored
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:57.456 --> 00:44:02.806 A:middle
-the glyph will be treated
-as the glyph will be ignored
 
 00:44:02.806 --> 00:44:05.366 A:middle
 from both layout and rendering.
@@ -2788,9 +2644,6 @@ Now we're building and running.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.186 --> 00:45:02.526 A:middle
-Now we're building and running.
 
 00:45:02.656 --> 00:45:05.306 A:middle
 And when we run the
@@ -2864,10 +2717,6 @@ focus truncation renderer,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:57.796 --> 00:46:00.536 A:middle
-So if we go over to our
-focus truncation renderer,
-
 00:46:01.646 --> 00:46:03.526 A:middle
 you'll notice that when
 we setup the contents
@@ -2931,9 +2780,6 @@ Well, first, we're finding
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.976 --> 00:47:00.066 A:middle
-Well, first, we're finding
 
 00:47:00.066 --> 00:47:01.916 A:middle
 out if we have an
@@ -3015,10 +2861,6 @@ achieve multiple page,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.876 --> 00:48:05.996 A:middle
-And you learned how to
-achieve multiple page,
-
 00:48:05.996 --> 00:48:09.046 A:middle
 multiple document
 configuration easy--
@@ -3055,10 +2897,6 @@ and broad customizability,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.246 --> 00:49:01.316 A:middle
-comprehensive functionalities
-and broad customizability,
 
 00:49:02.696 --> 00:49:08.036 A:middle
 we believe it will be the last

--- a/2013/221.srt
+++ b/2013/221.srt
@@ -57,10 +57,6 @@ demo and architecture
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:55.506 --> 00:01:01.916 A:middle
-And we will end with great
-demo and architecture
-
 00:01:02.016 --> 00:01:05.316 A:middle
 about using view
 controllers with dynamics.
@@ -121,10 +117,6 @@ which gives us this context
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.656 --> 00:02:04.306 A:middle
-we have this DynamicAnimator
-which gives us this context
-
 00:02:04.586 --> 00:02:08.616 A:middle
 in which we associate
 various behaviors
@@ -182,10 +174,6 @@ be notified.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.726 --> 00:03:01.496 A:middle
-And you can actually
-be notified.
 
 00:03:02.476 --> 00:03:05.526 A:middle
 We have a
@@ -249,10 +237,6 @@ in this class is the ability
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.786 --> 00:04:04.666 A:middle
-And one of few things we have
-in this class is the ability
-
 00:04:04.666 --> 00:04:06.836 A:middle
 to add child behaviors,
 
@@ -311,9 +295,6 @@ by adding and removing children
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.706 --> 00:05:02.066 A:middle
-by adding and removing children
-
 00:05:02.506 --> 00:05:04.826 A:middle
 for a behavior or
 from the animator.
@@ -369,10 +350,6 @@ and it's going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:56.626 --> 00:06:00.196 A:middle
-in my UIAttachmentBehavior
-and it's going
 
 00:06:00.196 --> 00:06:02.526 A:middle
 to drag the view
@@ -432,10 +409,6 @@ Screen in iOS 7 can be built
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:55.566 --> 00:07:01.396 A:middle
-Something like the Lock
-Screen in iOS 7 can be built
 
 00:07:01.396 --> 00:07:05.126 A:middle
 as a combination of
@@ -549,9 +522,6 @@ and keep my attachment behavior.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.346 --> 00:09:02.176 A:middle
-and keep my attachment behavior.
-
 00:09:02.176 --> 00:09:04.826 A:middle
 So I see that this force on the
 view that's trying to move it
@@ -609,10 +579,6 @@ using predefined behaviors
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.956 --> 00:10:03.296 A:middle
-And the behavior tree can be
-using predefined behaviors
 
 00:10:03.296 --> 00:10:04.886 A:middle
 like a collision behavior.
@@ -730,9 +696,6 @@ to think in terms of API.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.146 --> 00:12:00.826 A:middle
-to think in terms of API.
 
 00:12:02.306 --> 00:12:04.486 A:middle
 What is the API you
@@ -864,10 +827,6 @@ distinct properties in each,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.556 --> 00:14:02.986 A:middle
-if you're configuring
-distinct properties in each,
-
 00:14:03.196 --> 00:14:05.766 A:middle
 because that's not going
 to conflict, right?
@@ -925,9 +884,6 @@ in my dynamic item?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.836 --> 00:15:01.586 A:middle
-in my dynamic item?
 
 00:15:02.936 --> 00:15:05.926 A:middle
 So let's walk the behavior tree.
@@ -994,10 +950,6 @@ remove this one.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.866 --> 00:16:03.206 A:middle
-Then now, let's actually
-remove this one.
-
 00:16:03.816 --> 00:16:08.106 A:middle
 In this case, we
 are basically going
@@ -1043,10 +995,6 @@ that are not necessary views
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.486 --> 00:17:03.606 A:middle
-to integrate in Dynamics things
-that are not necessary views
 
 00:17:03.916 --> 00:17:05.715 A:middle
 or collection view
@@ -1102,10 +1050,6 @@ state in the engine.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.396 --> 00:18:01.936 A:middle
-to inject an initial
-state in the engine.
-
 00:18:02.446 --> 00:18:06.296 A:middle
 Then we're going to
 run the simulation
@@ -1154,10 +1098,6 @@ is how do you change the size
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:57.586 --> 00:19:02.816 A:middle
-So one interesting question
-is how do you change the size
 
 00:19:03.286 --> 00:19:04.216 A:middle
 of something after the effect?
@@ -1212,10 +1152,6 @@ dynamic items is to sanitize
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:55.666 --> 00:20:00.006 A:middle
-One interesting use case for
-dynamic items is to sanitize
 
 00:20:00.006 --> 00:20:03.076 A:middle
 or change the value we sent.
@@ -1276,10 +1212,6 @@ call screen actually.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.216 --> 00:21:01.116 A:middle
-depends on what you
-call screen actually.
 
 00:21:03.596 --> 00:21:05.416 A:middle
 You could just log
@@ -1345,10 +1277,6 @@ and non-animated cells.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.896 --> 00:22:03.126 A:middle
-So you can combine animated
-and non-animated cells.
-
 00:22:04.256 --> 00:22:10.746 A:middle
 You can build an entire layout
 with Dynamics that works for,
@@ -1412,9 +1340,6 @@ like effect with that technique.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.736 --> 00:23:02.746 A:middle
-like effect with that technique.
-
 00:23:04.256 --> 00:23:11.196 A:middle
 Or you can create and
 add new items on the fly.
@@ -1476,10 +1401,6 @@ you can ask the animator itself
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.536 --> 00:24:05.006 A:middle
-for implementing your layout so
-you can ask the animator itself
-
 00:24:05.496 --> 00:24:08.296 A:middle
 for layout attribute
 for cell at index path
@@ -1539,10 +1460,6 @@ in the animator.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.446 --> 00:25:02.226 A:middle
-we have itemsInRect
-in the animator.
-
 00:25:02.936 --> 00:25:03.736 A:middle
 So that's really easy.
 
@@ -1601,10 +1518,6 @@ a little bit too much
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.546 --> 00:26:05.826 A:middle
-So the effect is maybe
-a little bit too much
-
 00:26:06.506 --> 00:26:08.526 A:middle
 but you get the idea.
 
@@ -1660,10 +1573,6 @@ rectangle and attached
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.616 --> 00:27:03.156 A:middle
-attached to a plane or
-rectangle and attached
 
 00:27:03.386 --> 00:27:04.406 A:middle
 to the center of this view.
@@ -1722,10 +1631,6 @@ with an array
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.456 --> 00:28:03.486 A:middle
-I can start the interaction
-with an array
 
 00:28:03.486 --> 00:28:04.966 A:middle
 of index paths from a point.
@@ -1792,10 +1697,6 @@ AttachmentBehavior
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.936 --> 00:29:02.386 A:middle
-I just create a spring
-AttachmentBehavior
-
 00:29:02.626 --> 00:29:07.036 A:middle
 for each point and I add
 these as children behaviors.
@@ -1853,10 +1754,6 @@ tell my low-level behavior
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.966 --> 00:30:02.386 A:middle
-I'm just going to basically
-tell my low-level behavior
 
 00:30:02.916 --> 00:30:04.356 A:middle
 to update to this point.
@@ -1924,10 +1821,6 @@ itself, "Why do I need to define
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:55.996 --> 00:31:01.116 A:middle
-The layout implementation
-itself, "Why do I need to define
-
 00:31:01.116 --> 00:31:04.736 A:middle
 which cells are in this
 layout for a given rect?"
@@ -1980,10 +1873,6 @@ Nilo to show you that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:55.556 --> 00:32:00.316 A:middle
-I'd like to ask Bruce
-Nilo to show you that.
 
 00:32:00.316 --> 00:32:02.116 A:middle
 [ Applause ]
@@ -2084,10 +1973,6 @@ compose with one another.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.776 --> 00:33:02.146 A:middle
-of how these different things
-compose with one another.
-
 00:33:02.146 --> 00:33:05.996 A:middle
 So let's do the quick review.
 
@@ -2153,9 +2038,6 @@ kind of pretty simple.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.416 --> 00:34:00.946 A:middle
-kind of pretty simple.
 
 00:34:01.796 --> 00:34:04.366 A:middle
 These two methods are passed
@@ -2409,10 +2291,6 @@ of the screen and I'm going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.106 --> 00:37:02.616 A:middle
-to pull down from the top
-of the screen and I'm going
-
 00:37:02.616 --> 00:37:04.786 A:middle
 to release it and either it's
 going to bounce up to the top
@@ -2489,10 +2367,6 @@ dynamic animator's elapsed time.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.006 --> 00:38:01.926 A:middle
-And we're also interested in the
-dynamic animator's elapsed time.
 
 00:38:02.046 --> 00:38:05.106 A:middle
 Now, the reason for this is that
@@ -2584,10 +2458,6 @@ presenting view controller.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.086 --> 00:39:01.626 A:middle
-and guess what, I can see the
-presenting view controller.
-
 00:39:02.036 --> 00:39:04.296 A:middle
 You couldn't do this
 really on the phone before.
@@ -2660,10 +2530,6 @@ is we slide off to the side
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.056 --> 00:40:00.596 A:middle
-Now the first thing that happens
-is we slide off to the side
 
 00:40:00.596 --> 00:40:02.876 A:middle
 and then we bounce
@@ -2749,10 +2615,6 @@ behaviors in the system.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:56.576 --> 00:41:00.926 A:middle
-for implementing certain
-behaviors in the system.
 
 00:41:01.056 --> 00:41:03.306 A:middle
 When you create this thing,
@@ -2840,10 +2702,6 @@ a little bit earlier.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.466 --> 00:42:01.236 A:middle
-as Olivier demonstrated
-a little bit earlier.
-
 00:42:01.396 --> 00:42:05.076 A:middle
 So, amazingly enough, I scrolled
 away in the corner of my office
@@ -2930,10 +2788,6 @@ where we set up an elasticity,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.546 --> 00:43:03.476 A:middle
-like the dynamic item behavior
-where we set up an elasticity,
-
 00:43:03.766 --> 00:43:06.926 A:middle
 we have the dynamic view
 to that primitive behavior.
@@ -3012,10 +2866,6 @@ then we add the duration
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.876 --> 00:44:02.716 A:middle
-we ask the elapsed time
-then we add the duration
-
 00:44:02.976 --> 00:44:05.706 A:middle
 that was scrolled away when we
 created the behavior object.
@@ -3085,10 +2935,6 @@ good to know button.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.386 --> 00:45:00.306 A:middle
-we're going to hit the
-good to know button.
 
 00:45:01.046 --> 00:45:03.456 A:middle
 And we're going to
@@ -3190,10 +3036,6 @@ of the duration not two-thirds
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:57.826 --> 00:46:00.696 A:middle
-It really should be two-thirds
-of the duration not two-thirds
-
 00:46:00.696 --> 00:46:03.046 A:middle
 of the elapsed time,
 but you get the drift.
@@ -3272,10 +3114,6 @@ behavior a little bit
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.026 --> 00:47:00.786 A:middle
-Now we're using the attach
-behavior a little bit
 
 00:47:00.786 --> 00:47:04.076 A:middle
 as a semaphore here because the
@@ -3362,9 +3200,6 @@ And I want to check
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.556 --> 00:48:01.156 A:middle
-And I want to check
-
 00:48:02.126 --> 00:48:04.566 A:middle
 that I actually bounce
 off the edge I care about.
@@ -3450,10 +3285,6 @@ the way it was implemented.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:58.366 --> 00:49:01.736 A:middle
-This one can actually be used
-the way it was implemented.
 
 00:49:01.736 --> 00:49:03.346 A:middle
 It's both the navigation
@@ -3609,10 +3440,6 @@ I can make this a full
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:56.246 --> 00:51:01.256 A:middle
-And just to prove my point,
-I can make this a full
-
 00:51:01.256 --> 00:51:02.986 A:middle
 on presentation if I want to.
 
@@ -3693,10 +3520,6 @@ controller,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.626 --> 00:52:01.276 A:middle
-vended in interaction
-controller,
 
 00:52:01.276 --> 00:52:03.036 A:middle
 and all those good
@@ -3780,10 +3603,6 @@ should cancel or not.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:59.646 --> 00:53:01.556 A:middle
-or not the gesture
-should cancel or not.
 
 00:53:01.956 --> 00:53:06.006 A:middle
 And then, we are going to create
@@ -3870,9 +3689,6 @@ on the transition context.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:59.846 --> 00:54:01.806 A:middle
-on the transition context.
-
 00:54:02.856 --> 00:54:04.726 A:middle
 So what did we learn here?
 
@@ -3953,10 +3769,6 @@ checks in place based
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:57.126 --> 00:55:00.566 A:middle
-So you want to put
-checks in place based
 
 00:55:00.566 --> 00:55:03.316 A:middle
 on your application logic

--- a/2013/222.srt
+++ b/2013/222.srt
@@ -70,9 +70,6 @@ It can be very frustrating.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.746 --> 00:01:01.016 A:middle
-It can be very frustrating.
-
 00:01:01.626 --> 00:01:05.566 A:middle
 But the good news is we've
 got some really nice APIs
@@ -146,10 +143,6 @@ to go over some of the tools
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.756 --> 00:02:01.276 A:middle
-And then finally, I'm going
-to go over some of the tools
 
 00:02:01.276 --> 00:02:06.216 A:middle
 that we have that can help you
@@ -230,10 +223,6 @@ you save and restore.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.546 --> 00:03:01.756 A:middle
-let that inform what
-you save and restore.
-
 00:03:02.306 --> 00:03:06.706 A:middle
 I'm going to give a
 short demo just to kind
@@ -312,10 +301,6 @@ going to force that here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.316 --> 00:04:01.216 A:middle
-for various reasons, so I'm
-going to force that here.
 
 00:04:02.116 --> 00:04:04.056 A:middle
 Now, I just want to
@@ -487,10 +472,6 @@ and the selected cell.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:56.936 --> 00:06:00.156 A:middle
-in our collection view
-and the selected cell.
-
 00:06:00.796 --> 00:06:05.006 A:middle
 And finally, we remembered
 what image we were showing,
@@ -568,10 +549,6 @@ prepare for segway that you use
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.426 --> 00:07:02.096 A:middle
-Well, we have a method called
-prepare for segway that you use
 
 00:07:02.096 --> 00:07:03.336 A:middle
 when you have storyboards.
@@ -658,10 +635,6 @@ image, also that title.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.236 --> 00:08:01.876 A:middle
-Well, we've got the
-image, also that title.
 
 00:08:01.956 --> 00:08:05.566 A:middle
 But we don't want to write
@@ -820,10 +793,6 @@ we save everything.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.886 --> 00:10:01.876 A:middle
-on all of them so that
-we save everything.
-
 00:10:02.436 --> 00:10:07.256 A:middle
 Okay. So how about
 when we restoreState?
@@ -892,10 +861,6 @@ for the objects
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.436 --> 00:11:01.626 A:middle
-to call the restorationMethods
-for the objects
 
 00:11:01.626 --> 00:11:02.576 A:middle
 that are participating.
@@ -1063,10 +1028,6 @@ sized up as it should have been.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.876 --> 00:13:03.376 A:middle
-And we also had that image
-sized up as it should have been.
-
 00:13:03.816 --> 00:13:06.316 A:middle
 Did you have to write any
 code to do any of that?
@@ -1146,10 +1107,6 @@ incorporating state restoration.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.066 --> 00:14:01.856 A:middle
-and some really nice apps
-incorporating state restoration.
-
 00:14:02.576 --> 00:14:06.816 A:middle
 And we felt that we had a nice
 starting point for all this,
@@ -1217,10 +1174,6 @@ little tricky sometimes is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.616 --> 00:15:01.266 A:middle
-Something that's a
-little tricky sometimes is
 
 00:15:01.266 --> 00:15:05.096 A:middle
 when your application restores
@@ -1309,10 +1262,6 @@ some state restoration
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.686 --> 00:16:02.126 A:middle
-I mentioned you can implement
-some state restoration
-
 00:16:02.126 --> 00:16:04.716 A:middle
 for your app and then
 enhance it or extend it
@@ -1390,10 +1339,6 @@ many, what their titles are,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.186 --> 00:17:01.466 A:middle
-of what images I have, how
-many, what their titles are,
 
 00:17:01.646 --> 00:17:03.606 A:middle
 and to get the image
@@ -1485,10 +1430,6 @@ and I'll also want to be able
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.446 --> 00:18:00.806 A:middle
-to save and restore state,
-and I'll also want to be able
-
 00:18:00.806 --> 00:18:02.286 A:middle
 to maintain those references.
 
@@ -1561,10 +1502,6 @@ for state restoration.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.476 --> 00:19:02.926 A:middle
-It's called RegisterObject
-for state restoration.
 
 00:19:04.686 --> 00:19:06.936 A:middle
 I'm glad we have code
@@ -1729,10 +1666,6 @@ the same effect objects,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.316 --> 00:21:01.906 A:middle
-And you might be using
-the same effect objects,
-
 00:21:01.906 --> 00:21:04.446 A:middle
 or the same filter
 objects, and you just want
@@ -1819,10 +1752,6 @@ create this because it existed
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:56.926 --> 00:22:00.276 A:middle
-and told the application, "hey,
-create this because it existed
-
 00:22:00.276 --> 00:22:01.526 A:middle
 when you saved state".
 
@@ -1904,10 +1833,6 @@ objects we're asking for,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.906 --> 00:23:02.606 A:middle
-about which one of these
-objects we're asking for,
 
 00:23:02.956 --> 00:23:04.276 A:middle
 you have that information.
@@ -1996,9 +1921,6 @@ and you'll all done.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.526 --> 00:24:01.036 A:middle
-and you'll all done.
-
 00:24:01.856 --> 00:24:04.656 A:middle
 So now let's look at when
 we launched the app before.
@@ -2079,10 +2001,6 @@ that way, it knows who to ask
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.236 --> 00:25:02.476 A:middle
-to the data source as well;
-that way, it knows who to ask
 
 00:25:02.676 --> 00:25:06.766 A:middle
 to get the actual image
@@ -2239,10 +2157,6 @@ put a cool sepia effect on it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.056 --> 00:27:01.966 A:middle
-So let's say that we want to
-put a cool sepia effect on it.
-
 00:27:02.516 --> 00:27:05.936 A:middle
 So here's that Inspector --
 you might recognize it from one
@@ -2316,10 +2230,6 @@ spend probably too long
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.946 --> 00:28:02.896 A:middle
-And then I usually
-spend probably too long
 
 00:28:02.896 --> 00:28:05.836 A:middle
 on the Internet, so the
@@ -2398,10 +2308,6 @@ okay, so we got everything back,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.776 --> 00:29:01.226 A:middle
-and all that good stuff --
-okay, so we got everything back,
 
 00:29:01.226 --> 00:29:03.246 A:middle
 no gasping, no flashing.
@@ -2483,10 +2389,6 @@ kind of a continuous
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.586 --> 00:30:01.356 A:middle
-so that it presents
-kind of a continuous
-
 00:30:01.356 --> 00:30:03.806 A:middle
 and seamless experience
 when the user navigates back
@@ -2558,9 +2460,6 @@ So what do we do?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.786 --> 00:31:00.046 A:middle
-So what do we do?
 
 00:31:00.396 --> 00:31:00.906 A:middle
 Again,
@@ -2642,9 +2541,6 @@ So when we wanted to save state,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.566 --> 00:32:01.426 A:middle
-So when we wanted to save state,
-
 00:32:01.646 --> 00:32:05.476 A:middle
 we needed to register the filter
 objects with state restoration.
@@ -2720,10 +2616,6 @@ the restoration class
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.206 --> 00:33:00.406 A:middle
-So we're going to consult
-the restoration class
 
 00:33:00.406 --> 00:33:02.386 A:middle
 to restore them only
@@ -2820,10 +2712,6 @@ on your picture,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.496 --> 00:34:00.676 A:middle
-that nice sepia look
-on your picture,
-
 00:34:01.416 --> 00:34:05.316 A:middle
 and we're back to where we were.
 
@@ -2909,9 +2797,6 @@ it's safe to go in the water.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.936 --> 00:35:00.246 A:middle
-it's safe to go in the water.
 
 00:35:00.556 --> 00:35:02.226 A:middle
 Go on, apply your filter.
@@ -3001,10 +2886,6 @@ a whole big bifurcated strategy
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.126 --> 00:36:01.376 A:middle
-so I don't have to go and write
-a whole big bifurcated strategy
-
 00:36:01.846 --> 00:36:04.776 A:middle
 for restoring the image and
 setting it up in this case
@@ -3088,10 +2969,6 @@ state restoration and we need
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.776 --> 00:37:02.116 A:middle
-So if they're going to be using
-state restoration and we need
 
 00:37:02.116 --> 00:37:04.776 A:middle
 to find them, you don't
@@ -3184,10 +3061,6 @@ restoration class comes in.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.866 --> 00:38:00.946 A:middle
-and that's where the
-restoration class comes in.
-
 00:38:02.276 --> 00:38:05.166 A:middle
 So you can use a restoration
 class for view controllers
@@ -3274,10 +3147,6 @@ so on until we get
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:57.626 --> 00:39:00.106 A:middle
-we'll go one back and
-so on until we get
-
 00:39:00.106 --> 00:39:02.136 A:middle
 to a view controller
 that still exists.
@@ -3360,9 +3229,6 @@ which recreated them on demand.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.106 --> 00:40:00.806 A:middle
-which recreated them on demand.
 
 00:40:01.066 --> 00:40:03.236 A:middle
 So when you think
@@ -3455,9 +3321,6 @@ so we give you some control.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.806 --> 00:41:01.426 A:middle
-so we give you some control.
-
 00:41:01.426 --> 00:41:02.656 A:middle
 We've added a new API.
 
@@ -3534,9 +3397,6 @@ they start the app up again.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.576 --> 00:42:01.136 A:middle
-they start the app up again.
 
 00:42:01.136 --> 00:42:04.736 A:middle
 And it would be kind of
@@ -3616,10 +3476,6 @@ we're going to assume, okay,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.466 --> 00:43:01.496 A:middle
-restoration identifier,
-we're going to assume, okay,
 
 00:43:01.496 --> 00:43:02.636 A:middle
 you're app's pretty awesome
@@ -3720,10 +3576,6 @@ to show a Snapshot
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.066 --> 00:44:01.006 A:middle
-So we don't want
-to show a Snapshot
-
 00:44:01.006 --> 00:44:01.946 A:middle
 if we know we're not going
 
@@ -3805,10 +3657,6 @@ activity view controller
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.626 --> 00:45:01.666 A:middle
-and they just see this
-activity view controller
-
 00:45:01.666 --> 00:45:04.176 A:middle
 and they're not really sure what
 it was they were trying to share
@@ -3886,10 +3734,6 @@ of fades right there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:56.766 --> 00:46:00.346 A:middle
-Nice. It just kind
-of fades right there.
 
 00:46:00.646 --> 00:46:03.656 A:middle
 So at least we're not
@@ -4062,10 +3906,6 @@ been inactive for awhile,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.006 --> 00:48:02.846 A:middle
-In some cases, after an app's
-been inactive for awhile,
-
 00:48:02.846 --> 00:48:03.876 A:middle
 you might actually want
 
@@ -4146,10 +3986,6 @@ the cell at index 3 tomorrow.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:58.736 --> 00:49:02.806 A:middle
-at index 3 today may not be
-the cell at index 3 tomorrow.
 
 00:49:02.806 --> 00:49:06.286 A:middle
 It may not even be the cell at
@@ -4238,10 +4074,6 @@ going to move.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.436 --> 00:50:00.576 A:middle
-when they're never
-going to move.
 
 00:50:01.326 --> 00:50:04.916 A:middle
 So now, if your data source
@@ -4397,10 +4229,6 @@ phone, managed to break
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:58.476 --> 00:52:01.026 A:middle
-even if somebody stole your
-phone, managed to break
-
 00:52:01.026 --> 00:52:02.996 A:middle
 into the file system
 and pulled that off,
@@ -4492,10 +4320,6 @@ protection for the application,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:57.576 --> 00:53:01.746 A:middle
-You may already be using data
-protection for the application,
-
 00:53:02.156 --> 00:53:04.686 A:middle
 and we don't want to be the
 weak link in that chain,
@@ -4579,10 +4403,6 @@ started up in the background
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:58.056 --> 00:54:00.996 A:middle
-that your application just gets
-started up in the background
-
 00:54:00.996 --> 00:54:03.686 A:middle
 and here's my little magic wand.
 
@@ -4658,10 +4478,6 @@ its current state is.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:59.616 --> 00:55:02.526 A:middle
-by saving whatever
-its current state is.
 
 00:55:02.736 --> 00:55:06.216 A:middle
 If the application is running
@@ -4746,10 +4562,6 @@ is built around the idea
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:59.176 --> 00:56:02.066 A:middle
-And state restoration
-is built around the idea
-
 00:56:02.066 --> 00:56:05.426 A:middle
 that you should be able to save
 state and then restore it even
@@ -4832,10 +4644,6 @@ you a little bit of that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:58.216 --> 00:57:00.456 A:middle
-I'm just going to show
-you a little bit of that.
 
 00:57:01.156 --> 00:57:04.466 A:middle
 Kind of looks like one of those
@@ -4925,10 +4733,6 @@ there highlighted in yellow,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:57:59.196 --> 00:58:01.926 A:middle
-So you can see on the top
-there highlighted in yellow,
-
 00:58:02.306 --> 00:58:05.336 A:middle
 we tell you the type of object
 it is, so you can kind of scan
@@ -5014,9 +4818,6 @@ you can learn quite a lot simply
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:58:58.546 --> 00:59:00.296 A:middle
-you can learn quite a lot simply
 
 00:59:00.296 --> 00:59:02.456 A:middle
 by taking a look
@@ -5109,10 +4910,6 @@ it saved a couple things,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:59:57.556 --> 01:00:01.036 A:middle
-We show the class of it, and
-it saved a couple things,
-
 01:00:01.156 --> 01:00:02.796 A:middle
 so we just keep track
 of all of that.
@@ -5203,10 +5000,6 @@ and you'll want to take a look
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:00:59.116 --> 01:01:02.536 A:middle
-in your app, and you'll go back
-and you'll want to take a look
 
 01:01:02.536 --> 01:01:03.906 A:middle
 at this and see what you can do.

--- a/2013/223.srt
+++ b/2013/223.srt
@@ -78,10 +78,6 @@ and modifying fallbacks,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:56.246 --> 00:01:00.316 A:middle
-in both iOS X and iOS 7,
-and modifying fallbacks,
-
 00:01:00.606 --> 00:01:03.826 A:middle
 also available on
 both platforms.
@@ -155,10 +151,6 @@ code layout engine available
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.926 --> 00:02:01.916 A:middle
-which is our low level unit
-code layout engine available
 
 00:02:02.186 --> 00:02:04.976 A:middle
 on both iOS and OS X.
@@ -235,10 +227,6 @@ content, there's really only one
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.406 --> 00:03:02.996 A:middle
-And when dealing with user
-content, there's really only one
-
 00:03:02.996 --> 00:03:05.006 A:middle
 of those variables
 that you have control
@@ -306,10 +294,6 @@ also going to talk about how
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.896 --> 00:04:00.226 A:middle
-And as I mentioned, we're
-also going to talk about how
 
 00:04:00.226 --> 00:04:05.586 A:middle
 to bring your own apps to your
@@ -380,10 +364,6 @@ very text heavy application.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.746 --> 00:05:01.486 A:middle
-So, as we can see, mail is a
-very text heavy application.
-
 00:05:02.486 --> 00:05:04.816 A:middle
 But it still has what
 we'd like to display
@@ -451,9 +431,6 @@ of the user's preference
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.606 --> 00:06:00.506 A:middle
-of the user's preference
-
 00:06:01.046 --> 00:06:05.116 A:middle
 and resizing the table
 view cells to match.
@@ -510,10 +487,6 @@ usage categories
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:56.876 --> 00:07:00.546 A:middle
-eight of these different
-usage categories
 
 00:07:00.726 --> 00:07:01.966 A:middle
 for use with text styles.
@@ -590,10 +563,6 @@ already seen Interface Builder
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:57.486 --> 00:08:00.416 A:middle
-And as I'm sure you've
-already seen Interface Builder
-
 00:08:00.416 --> 00:08:03.136 A:middle
 with Xcode 5 has a great
 support for these text styles,
@@ -662,9 +631,6 @@ very rich information hierarchy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.266 --> 00:09:01.316 A:middle
-very rich information hierarchy.
-
 00:09:02.426 --> 00:09:05.456 A:middle
 You'll also note that this
 particular text style --
@@ -732,10 +698,6 @@ which is hard to show
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.936 --> 00:10:01.156 A:middle
-and also the line spacing
-which is hard to show
 
 00:10:01.156 --> 00:10:01.976 A:middle
 on this particular example.
@@ -812,10 +774,6 @@ and we also have special traits
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.226 --> 00:11:00.546 A:middle
-to find useful are Bold, Italic,
-and we also have special traits
 
 00:11:00.616 --> 00:11:02.326 A:middle
 for adjusting the line spacing.
@@ -954,10 +912,6 @@ in OS X, you may be familiar
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.726 --> 00:13:03.186 A:middle
-who have done programming
-in OS X, you may be familiar
-
 00:13:03.186 --> 00:13:06.846 A:middle
 with the various NSFont class
 factory methods for getting
@@ -1028,10 +982,6 @@ it's not just
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.776 --> 00:14:01.656 A:middle
-to text styles because
-it's not just
-
 00:14:01.696 --> 00:14:04.296 A:middle
 that the font may be changing
 across releases, they're going
@@ -1101,10 +1051,6 @@ appropriate to drop down
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.666 --> 00:15:02.366 A:middle
-And never -- would it be
-appropriate to drop down
-
 00:15:02.836 --> 00:15:08.016 A:middle
 and grab a CD font and deal
 with that moving onwards.
@@ -1166,10 +1112,6 @@ fonts.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.546 --> 00:16:02.456 A:middle
-that we use for describing
-fonts.
 
 00:16:02.456 --> 00:16:04.766 A:middle
 It's a very, very
@@ -1248,10 +1190,6 @@ features might be enabled.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.086 --> 00:17:01.116 A:middle
-what typographic
-features might be enabled.
-
 00:17:01.886 --> 00:17:06.056 A:middle
 And you'll note that using
 a descriptor, it's very easy
@@ -1320,10 +1258,6 @@ explicit matching.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:59.746 --> 00:18:04.446 A:middle
-And the first is
-explicit matching.
 
 00:18:05.356 --> 00:18:07.456 A:middle
 You can invoke
@@ -1399,10 +1333,6 @@ because, of course, when we want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.966 --> 00:19:02.476 A:middle
-from a descriptor directly
-because, of course, when we want
 
 00:19:02.476 --> 00:19:04.836 A:middle
 to materialize that
@@ -1481,10 +1411,6 @@ consider certain attributes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.196 --> 00:20:03.556 A:middle
-But if you would like to only
-consider certain attributes
-
 00:20:03.786 --> 00:20:06.646 A:middle
 in the font descriptor, you
 can use the mandatory keys
@@ -1555,10 +1481,6 @@ font, so I'm going to start
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.816 --> 00:21:02.706 A:middle
-at a font -- just to get another
-font, so I'm going to start
 
 00:21:02.706 --> 00:21:05.946 A:middle
 by getting a UIFontDescriptor
@@ -1635,10 +1557,6 @@ style for use in bodies.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:56.426 --> 00:22:01.436 A:middle
-And now I have my Bold text
-style for use in bodies.
-
 00:22:03.016 --> 00:22:05.436 A:middle
 Descriptors are also
 the preferred mechanism
@@ -1711,10 +1629,6 @@ be able to reconstitute a font
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:55.726 --> 00:23:00.206 A:middle
-and assume that that's going to
-be able to reconstitute a font
 
 00:23:00.636 --> 00:23:02.916 A:middle
 on the other end, so
@@ -1792,10 +1706,6 @@ font, I get one appearance
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.776 --> 00:24:03.586 A:middle
-when I layout text using this
-font, I get one appearance
-
 00:24:03.876 --> 00:24:05.206 A:middle
 as you can see on the top here.
 
@@ -1867,10 +1777,6 @@ a time appearance to it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.556 --> 00:25:02.126 A:middle
-that allow me to apply
-a time appearance to it.
-
 00:25:02.126 --> 00:25:05.646 A:middle
 And one of those is one that I
 can use in other cases as well
@@ -1936,10 +1842,6 @@ typographic features
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.606 --> 00:26:01.836 A:middle
-the handles onto these
-typographic features
 
 00:26:01.996 --> 00:26:03.476 A:middle
 that can be implemented
@@ -2015,10 +1917,6 @@ predefined typographic features,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:55.476 --> 00:27:01.366 A:middle
-Well, so there are a number of
-predefined typographic features,
 
 00:27:01.846 --> 00:27:04.936 A:middle
 names that we've given
@@ -2108,9 +2006,6 @@ by adding attributes to it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.596 --> 00:28:02.166 A:middle
-by adding attributes to it.
-
 00:28:02.596 --> 00:28:04.366 A:middle
 In this case, there's
 just one attribute,
@@ -2197,10 +2092,6 @@ example of this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.166 --> 00:29:00.306 A:middle
-ligatures are a great
-example of this.
-
 00:29:01.756 --> 00:29:04.136 A:middle
 So another example,
 as I mentioned,
@@ -2279,10 +2170,6 @@ better right now.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.406 --> 00:30:01.966 A:middle
-Anything will be
-better right now.
-
 00:30:02.456 --> 00:30:04.706 A:middle
 So I mentioned earlier
 in passing
@@ -2360,10 +2247,6 @@ set which is exactly identical
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.376 --> 00:31:01.246 A:middle
-And so now we have a character
-set which is exactly identical
-
 00:31:01.246 --> 00:31:07.146 A:middle
 to the original font's character
 set minus that one character.
@@ -2427,10 +2310,6 @@ only for iOS but also
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.926 --> 00:32:02.886 A:middle
-and this goes not
-only for iOS but also
 
 00:32:03.096 --> 00:32:04.526 A:middle
 for OS X Mavericks as well.
@@ -2503,10 +2382,6 @@ resources are bundled.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.996 --> 00:33:03.216 A:middle
-because that's how your
-resources are bundled.
-
 00:33:04.856 --> 00:33:07.326 A:middle
 And then the system can
 automatically make those
@@ -2577,10 +2452,6 @@ you might want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.796 --> 00:34:02.236 A:middle
-And so in these cases,
-you might want
 
 00:34:02.236 --> 00:34:05.736 A:middle
 to have [inaudible] the font
@@ -2659,10 +2530,6 @@ names can never be matched.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:56.866 --> 00:35:00.416 A:middle
-In this case, the font's
-names can never be matched.
 
 00:35:01.646 --> 00:35:04.756 A:middle
 And you might say, "well,
@@ -2746,10 +2613,6 @@ use your own copy of one
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.016 --> 00:36:01.406 A:middle
-considerations and need to
-use your own copy of one
-
 00:36:01.406 --> 00:36:03.756 A:middle
 of our fonts, this is a great
 way to make that happen.
@@ -2821,10 +2684,6 @@ OS X as well as additional fonts
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.956 --> 00:37:01.466 A:middle
-all of the fonts installed in
-OS X as well as additional fonts
 
 00:37:01.666 --> 00:37:04.886 A:middle
 for particular support
@@ -2901,9 +2760,6 @@ of these downloadable fonts,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.106 --> 00:38:00.226 A:middle
-of these downloadable fonts,
 
 00:38:00.676 --> 00:38:04.316 A:middle
 your app will probably have the
@@ -2985,10 +2841,6 @@ your app is running.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:57.626 --> 00:39:00.976 A:middle
-on iOS can change while
-your app is running.
-
 00:39:01.436 --> 00:39:03.556 A:middle
 And so, if you'd like to react
 
@@ -3062,10 +2914,6 @@ does the very best job it can
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:54.866 --> 00:40:00.066 A:middle
-And so, the system by default
-does the very best job it can
 
 00:40:00.066 --> 00:40:01.976 A:middle
 in resolving these scenarios.
@@ -3146,9 +2994,6 @@ may not be a particularly useful
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:58.186 --> 00:41:00.036 A:middle
-may not be a particularly useful
 
 00:41:00.036 --> 00:41:01.886 A:middle
 because this relies
@@ -3234,10 +3079,6 @@ feature because it allows fonts
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.556 --> 00:42:06.036 A:middle
-And this is great as a
-feature because it allows fonts
-
 00:42:06.446 --> 00:42:10.876 A:middle
 to be more responsive
 to the user's languages.
@@ -3302,10 +3143,6 @@ behavior by defaults
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.106 --> 00:43:00.526 A:middle
-they'll get the correct
-behavior by defaults
 
 00:43:00.996 --> 00:43:03.726 A:middle
 but you may be writing
@@ -3378,10 +3215,6 @@ immediately trigger fallback
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.386 --> 00:44:01.796 A:middle
-and so this is going to
-immediately trigger fallback
 
 00:44:01.796 --> 00:44:03.336 A:middle
 which is the process
@@ -3461,10 +3294,6 @@ just that when we might want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:56.236 --> 00:45:00.516 A:middle
-but there are other cases beyond
-just that when we might want
-
 00:45:00.516 --> 00:45:02.546 A:middle
 to make a change to
 the fallback behavior.
@@ -3531,10 +3360,6 @@ falling back --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:57.206 --> 00:46:00.786 A:middle
-in that string, they're
-falling back --
 
 00:46:00.786 --> 00:46:02.066 A:middle
 the fallback font
@@ -3705,10 +3530,6 @@ particular example could be
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.796 --> 00:48:04.166 A:middle
-So, you may note also that this
-particular example could be
-
 00:48:04.166 --> 00:48:07.396 A:middle
 quite powerful when combined
 with a previous example
@@ -3788,10 +3609,6 @@ order to adapt dynamic type
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:56.456 --> 00:49:00.756 A:middle
-The first is to -- in
-order to adapt dynamic type
-
 00:49:01.006 --> 00:49:04.676 A:middle
 in your iOS 7 app, you'll
 do so using text styles.
@@ -3869,10 +3686,6 @@ available systemwide.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.056 --> 00:50:00.136 A:middle
-and those fonts are
-available systemwide.
 
 00:50:01.496 --> 00:50:05.006 A:middle
 So with that, I'd like to say

--- a/2013/224.srt
+++ b/2013/224.srt
@@ -96,9 +96,6 @@ in the App Store that they love.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.226 --> 00:01:00.176 A:middle
-in the App Store that they love.
-
 00:01:01.136 --> 00:01:03.126 A:middle
 However, across all these
 domains and different types
@@ -198,10 +195,6 @@ answer is always, right?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.956 --> 00:02:01.086 A:middle
-is it a trick question, the
-answer is always, right?
 
 00:02:01.086 --> 00:02:03.286 A:middle
 That's true to certain extent
@@ -318,9 +311,6 @@ Sometimes that's the case.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.106 --> 00:03:00.286 A:middle
-Sometimes that's the case.
 
 00:03:00.686 --> 00:03:03.166 A:middle
 But unfortunately, we usually
@@ -640,10 +630,6 @@ to talking about how
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.606 --> 00:06:01.256 A:middle
-OK. So now let's move
-to talking about how
-
 00:06:01.256 --> 00:06:02.406 A:middle
 to design for performance.
 
@@ -761,10 +747,6 @@ pay for an app in the store
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.716 --> 00:07:01.906 A:middle
-I don't mean how much you
-pay for an app in the store
-
 00:07:02.146 --> 00:07:05.506 A:middle
 or how much it cost to you
 to have people develop it.
@@ -868,10 +850,6 @@ complexity can often be analyzed
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.986 --> 00:08:02.856 A:middle
-OK. Fortunately, this kind of
-complexity can often be analyzed
-
 00:08:03.016 --> 00:08:04.036 A:middle
 without even running the code.
 
@@ -966,10 +944,6 @@ may be able to skip out early
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.156 --> 00:09:00.696 A:middle
-Ideally with an algorithm, you
-may be able to skip out early
 
 00:09:00.956 --> 00:09:03.406 A:middle
 and so on if you're doing
@@ -1082,10 +1056,6 @@ to by the name constant time,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.426 --> 00:10:00.266 A:middle
-You might also hear it referred
-to by the name constant time,
-
 00:10:00.266 --> 00:10:02.396 A:middle
 logarithmic time, linear
 time, quadratic time,
@@ -1187,9 +1157,6 @@ that it gets really complex
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.896 --> 00:11:01.206 A:middle
-that it gets really complex
 
 00:11:01.206 --> 00:11:02.426 A:middle
 and shoots its way
@@ -1302,10 +1269,6 @@ you can see I'm in query 1 index
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:57.516 --> 00:12:01.146 A:middle
-So if we have a sample array,
-you can see I'm in query 1 index
-
 00:12:01.146 --> 00:12:02.776 A:middle
 and say that that
 value is not there.
@@ -1416,10 +1379,6 @@ pairings of indexes in the array
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.606 --> 00:13:01.016 A:middle
-to compare every two possible
-pairings of indexes in the array
-
 00:13:01.016 --> 00:13:01.896 A:middle
 to see if they're equal.
 
@@ -1516,10 +1475,6 @@ and you eliminate half
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.186 --> 00:14:00.746 A:middle
-at i plus 1 for example
-and you eliminate half
 
 00:14:00.746 --> 00:14:01.606 A:middle
 of your comparisons.
@@ -1627,10 +1582,6 @@ trying to accomplish,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.726 --> 00:15:01.396 A:middle
-what kind of work it's
-trying to accomplish,
 
 00:15:01.586 --> 00:15:03.086 A:middle
 and another complimentary
@@ -1748,10 +1699,6 @@ these concurrently
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.906 --> 00:16:01.696 A:middle
-if I can enumerate
-these concurrently
-
 00:16:01.696 --> 00:16:02.616 A:middle
 and compare the objects?
 
@@ -1852,10 +1799,6 @@ storage as this NSDictionary.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:55.636 --> 00:17:00.756 A:middle
-So, NSSet uses a hash table for
-storage as this NSDictionary.
-
 00:17:02.156 --> 00:17:04.586 A:middle
 Every object has a
 deterministic hash value.
@@ -1951,10 +1894,6 @@ thousand objects, you may have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.076 --> 00:18:00.566 A:middle
-If you have an array that's a
-thousand objects, you may have
 
 00:18:00.566 --> 00:18:03.266 A:middle
 to check up to a thousand items
@@ -2176,10 +2115,6 @@ object is how you take part
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.246 --> 00:20:01.636 A:middle
-Defining your identity for your
-object is how you take part
-
 00:20:01.636 --> 00:20:03.416 A:middle
 of this hash-based identity.
 
@@ -2277,10 +2212,6 @@ same for both of these.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.516 --> 00:21:01.946 A:middle
-then the hash must be the
-same for both of these.
 
 00:21:02.386 --> 00:21:04.226 A:middle
 This is critical because
@@ -2389,10 +2320,6 @@ that when you have hash lookup,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:57.286 --> 00:22:00.336 A:middle
-One other key important thing is
-that when you have hash lookup,
 
 00:22:00.336 --> 00:22:02.356 A:middle
 your hashes really should
@@ -2504,10 +2431,6 @@ title and the time stamp.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:58.746 --> 00:23:00.976 A:middle
-and compare both the
-title and the time stamp.
 
 00:23:01.086 --> 00:23:02.716 A:middle
 Let me also check to see
@@ -2633,10 +2556,6 @@ it's not easy to look them
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.816 --> 00:24:01.326 A:middle
-over in your collection and
-it's not easy to look them
-
 00:24:01.326 --> 00:24:02.336 A:middle
 up when they're sorted
 by author.
@@ -2755,10 +2674,6 @@ you to always prefer
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.646 --> 00:25:01.236 A:middle
-And we encourage
-you to always prefer
-
 00:25:01.236 --> 00:25:03.236 A:middle
 to use the built-in
 API whenever possible.
@@ -2861,10 +2776,6 @@ to know what to expect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.306 --> 00:26:01.706 A:middle
-And the second thing is
-to know what to expect
 
 00:26:01.876 --> 00:26:03.606 A:middle
 from your collection, which
@@ -2978,10 +2889,6 @@ optimizations that are possible
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.556 --> 00:27:01.996 A:middle
-Also, there are memory and speed
-optimizations that are possible
-
 00:27:02.146 --> 00:27:03.276 A:middle
 with immutable collections
 
@@ -3083,10 +2990,6 @@ large capacity.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.936 --> 00:28:00.016 A:middle
-and ask for a really
-large capacity.
 
 00:28:00.266 --> 00:28:01.836 A:middle
 The collections are
@@ -3206,10 +3109,6 @@ inserting at the front,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.806 --> 00:29:00.666 A:middle
-even the guarantee that
-inserting at the front,
 
 00:29:00.816 --> 00:29:02.966 A:middle
 the very front of a mutable
@@ -3416,10 +3315,6 @@ can't store a set directly
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.546 --> 00:31:02.126 A:middle
-Related to this is that you
-can't store a set directly
-
 00:31:02.126 --> 00:31:04.216 A:middle
 in a property list or
 in JSON as we'll talk
@@ -3527,9 +3422,6 @@ it has unique key values,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.656 --> 00:32:01.146 A:middle
-it has unique key values,
-
 00:32:01.226 --> 00:32:03.066 A:middle
 and it uses hash lookup
 just a like a set.
@@ -3631,10 +3523,6 @@ going to be copied in.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.556 --> 00:33:01.926 A:middle
-to NSDictionary are
-going to be copied in.
-
 00:33:02.306 --> 00:33:05.556 A:middle
 They have to conform to
 the NSCopying Protocol.
@@ -3729,10 +3617,6 @@ we also have a set.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.556 --> 00:34:01.336 A:middle
-and no difficult objects,
-we also have a set.
 
 00:34:01.596 --> 00:34:03.086 A:middle
 So roughly double memory usage.
@@ -3834,10 +3718,6 @@ with storage.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.936 --> 00:35:00.316 A:middle
-So it's really efficient
-with storage.
 
 00:35:00.876 --> 00:35:03.906 A:middle
 It also supports set arithmetic
@@ -3950,10 +3830,6 @@ those go away then
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.776 --> 00:36:00.446 A:middle
-for example should
-those go away then
-
 00:36:00.446 --> 00:36:02.226 A:middle
 that entry would automatically
 be removed for you.
@@ -4048,10 +3924,6 @@ a few big benefits.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.726 --> 00:37:00.696 A:middle
-Primarily, there's
-a few big benefits.
 
 00:37:00.696 --> 00:37:03.446 A:middle
 First and foremost is that
@@ -4158,10 +4030,6 @@ example, convert to a string,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.446 --> 00:38:02.276 A:middle
-Any others that you can, for
-example, convert to a string,
-
 00:38:02.536 --> 00:38:05.146 A:middle
 you would have to use NSCoding
 and archive it into an NSData
@@ -4261,10 +4129,6 @@ Notation and originated
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.136 --> 00:39:00.556 A:middle
-This is JavaScript Object
-Notation and originated
-
 00:39:00.556 --> 00:39:01.886 A:middle
 in JavaScript but it's supported
 
@@ -4363,10 +4227,6 @@ out of JSON
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.266 --> 00:40:01.206 A:middle
-when you read objects
-out of JSON
 
 00:40:01.206 --> 00:40:02.896 A:middle
 which is different
@@ -4470,10 +4330,6 @@ of the applications.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.566 --> 00:41:00.996 A:middle
-in early versions
-of the applications.
 
 00:41:01.216 --> 00:41:02.506 A:middle
 At first we were
@@ -4593,10 +4449,6 @@ what work it has to do.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.066 --> 00:42:00.946 A:middle
-And let's think about
-what work it has to do.
 
 00:42:01.676 --> 00:42:04.146 A:middle
 Well, we're forming a predicate
@@ -4826,10 +4678,6 @@ for a different session ID.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.496 --> 00:44:01.886 A:middle
-through the same array just
-for a different session ID.
-
 00:44:02.536 --> 00:44:05.206 A:middle
 If there's a way that we can
 get that out of a loop and do
@@ -4930,10 +4778,6 @@ eliminate extra work, you know,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.456 --> 00:45:02.496 A:middle
-from the optimizations and
-eliminate extra work, you know,
-
 00:45:02.496 --> 00:45:04.026 A:middle
 that we're doing as fast
 as we can think to do it.
@@ -5030,10 +4874,6 @@ leave it there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.216 --> 00:46:00.316 A:middle
-and be faster, don't
-leave it there.
 
 00:46:00.846 --> 00:46:01.726 A:middle
 Take advantage of it.
@@ -5142,10 +4982,6 @@ your complexity grows over time,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.406 --> 00:47:02.286 A:middle
-If you have a lot of work and
-your complexity grows over time,
-
 00:47:02.526 --> 00:47:03.856 A:middle
 when you get to large
 amounts of data,
@@ -5250,9 +5086,6 @@ and being-- having common sense
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.406 --> 00:48:00.886 A:middle
-and being-- having common sense
 
 00:48:01.056 --> 00:48:02.696 A:middle
 about the performance

--- a/2013/225.srt
+++ b/2013/225.srt
@@ -60,10 +60,6 @@ apps at Apple.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.326 --> 00:01:00.616 A:middle
-and energy creating
-apps at Apple.
-
 00:01:00.916 --> 00:01:02.806 A:middle
 We focus on it, we
 want to make sure
@@ -122,10 +118,6 @@ or how many APIs you integrated
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:56.936 --> 00:02:01.956 A:middle
-on how many technologies you use
-or how many APIs you integrated
 
 00:02:02.336 --> 00:02:03.756 A:middle
 or how elegant your code is.
@@ -186,10 +178,6 @@ being designed for iOS,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.446 --> 00:03:01.156 A:middle
-There's so many great apps
-being designed for iOS,
 
 00:03:01.946 --> 00:03:03.576 A:middle
 many of them only for iOS.
@@ -257,10 +245,6 @@ is bad app icons.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:56.916 --> 00:04:00.226 A:middle
-And the first one
-is bad app icons.
 
 00:04:00.226 --> 00:04:04.566 A:middle
 So this is the first place
@@ -348,9 +332,6 @@ I mean, if an icon looks great
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.626 --> 00:05:01.556 A:middle
-I mean, if an icon looks great
-
 00:05:01.556 --> 00:05:04.806 A:middle
 and it obviously was carefully
 crafted, it's reasonable
@@ -430,10 +411,6 @@ to keep in mind.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.646 --> 00:06:00.696 A:middle
-out that are important
-to keep in mind.
-
 00:06:00.696 --> 00:06:04.196 A:middle
 I think they distinguish
 every great app icon.
@@ -512,10 +489,6 @@ choose a limited pallet,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:56.616 --> 00:07:00.936 A:middle
-The next step is to just
-choose a limited pallet,
 
 00:07:02.116 --> 00:07:03.936 A:middle
 one color, maybe two.
@@ -652,10 +625,6 @@ connect with the app name.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.476 --> 00:09:03.826 A:middle
-the mnemonic device to
-connect with the app name.
-
 00:09:04.036 --> 00:09:06.596 A:middle
 All right, so the next one
 is avoid a lot of text.
@@ -732,9 +701,6 @@ on your own preferences.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.346 --> 00:10:00.666 A:middle
-on your own preferences.
 
 00:10:00.666 --> 00:10:05.196 A:middle
 And they have a really fantastic
@@ -814,10 +780,6 @@ use that as their app icon,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.556 --> 00:11:02.916 A:middle
-with the down arrow and they
-use that as their app icon,
-
 00:11:02.916 --> 00:11:05.016 A:middle
 it works really well,
 or Pinterest
@@ -888,10 +850,6 @@ the product is Paper.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.936 --> 00:12:01.876 A:middle
-I mean, the name of
-the product is Paper.
 
 00:12:01.876 --> 00:12:05.426 A:middle
 So it would be sort of odd
@@ -969,10 +927,6 @@ it's easy to make this out.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.416 --> 00:13:02.276 A:middle
-so just it pops really well,
-it's easy to make this out.
-
 00:13:03.606 --> 00:13:05.656 A:middle
 If you're going to go
 for a texture like this,
@@ -1048,10 +1002,6 @@ then you have a team of people
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.196 --> 00:14:02.986 A:middle
-You set some personal goals and
-then you have a team of people
 
 00:14:03.396 --> 00:14:05.806 A:middle
 who are in your social
@@ -1129,10 +1079,6 @@ timetables and such.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.996 --> 00:15:02.226 A:middle
-about local Muni Transit
-timetables and such.
-
 00:15:02.766 --> 00:15:05.146 A:middle
 This looks like the
 old Muni Passes.
@@ -1208,10 +1154,6 @@ creative icons.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:57.166 --> 00:16:00.536 A:middle
-So these are really
-creative icons.
-
 00:16:01.816 --> 00:16:05.066 A:middle
 Now, we'd looked at a range
 of icons and I'm going
@@ -1283,10 +1225,6 @@ really a cool case study.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.986 --> 00:17:06.086 A:middle
-So, I'm going to show you
-really a cool case study.
 
 00:17:06.766 --> 00:17:09.266 A:middle
 This is for an app
@@ -1361,10 +1299,6 @@ demonstrate the beauty
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.166 --> 00:18:01.306 A:middle
-They knew they needed to
-demonstrate the beauty
 
 00:18:01.306 --> 00:18:03.426 A:middle
 of that turntable
@@ -1451,10 +1385,6 @@ from the platter
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.356 --> 00:19:00.076 A:middle
-or the dot pattern
-from the platter
-
 00:19:00.076 --> 00:19:02.466 A:middle
 to tell you what tempo you're
 playing your record at.
@@ -1531,10 +1461,6 @@ they got to this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:54.356 --> 00:20:01.256 A:middle
-to do and eventually,
-they got to this.
 
 00:20:01.476 --> 00:20:03.316 A:middle
 Really simple, right?
@@ -1613,10 +1539,6 @@ version, it really started
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.956 --> 00:21:02.766 A:middle
-With each successive
-version, it really started
-
 00:21:02.766 --> 00:21:04.196 A:middle
 to come together more and more.
 
@@ -1679,10 +1601,6 @@ but it still does.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.566 --> 00:22:01.486 A:middle
-that it still happens,
-but it still does.
 
 00:22:02.316 --> 00:22:03.576 A:middle
 So let's look at a case study.
@@ -1761,10 +1679,6 @@ allowed a third choice which was
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:55.816 --> 00:23:01.026 A:middle
-But even with that, they
-allowed a third choice which was
 
 00:23:01.066 --> 00:23:03.636 A:middle
 to continue forward
@@ -1847,10 +1761,6 @@ and the nav bar, but instead,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.746 --> 00:24:03.956 A:middle
-at the top, all the buttons
-and the nav bar, but instead,
-
 00:24:03.956 --> 00:24:05.206 A:middle
 this is what we actually
 shipped.
@@ -1923,10 +1833,6 @@ controls that we have.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:57.966 --> 00:25:00.726 A:middle
-and over again in the
-controls that we have.
-
 00:25:01.726 --> 00:25:07.726 A:middle
 Now, this number, 44 points,
 this goes back, this isn't new
@@ -1987,10 +1893,6 @@ it allows you track your ride
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.886 --> 00:26:02.676 A:middle
-This is a Cycling app by Strava,
-it allows you track your ride
 
 00:26:02.676 --> 00:26:06.476 A:middle
 through GPS, and you
@@ -2065,10 +1967,6 @@ pitfall is Hard-to-Read Text.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:56.456 --> 00:27:02.626 A:middle
-All right, the next common
-pitfall is Hard-to-Read Text.
-
 00:27:03.666 --> 00:27:06.996 A:middle
 Now, this is how our WWDC
 app could have looked
@@ -2137,10 +2035,6 @@ which is kind of a hard thing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.426 --> 00:28:03.556 A:middle
-maybe 60 percent in brightness
-which is kind of a hard thing
-
 00:28:03.556 --> 00:28:06.116 A:middle
 when you're talking about
 different colors like red
@@ -2206,9 +2100,6 @@ it's all the same typeface.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.716 --> 00:29:00.666 A:middle
-it's all the same typeface.
 
 00:29:01.556 --> 00:29:06.226 A:middle
 And that adds to a sense of
@@ -2288,10 +2179,6 @@ make it 15 points.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.256 --> 00:30:01.166 A:middle
-We can't just say
-make it 15 points.
 
 00:30:01.166 --> 00:30:03.026 A:middle
 Now, with dynamic type,
@@ -2380,10 +2267,6 @@ Brennen or Michelle Humphrey
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.746 --> 00:31:04.266 A:middle
-I'm looking for text from Paul
-Brennen or Michelle Humphrey
-
 00:31:04.386 --> 00:31:07.156 A:middle
 and you have to be able to
 see that even as it's moving.
@@ -2453,10 +2336,6 @@ lines of texts.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.216 --> 00:32:00.286 A:middle
-between different
-lines of texts.
 
 00:32:00.406 --> 00:32:04.166 A:middle
 And again, test on a device.
@@ -2605,9 +2484,6 @@ and you never want to do that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.396 --> 00:34:00.876 A:middle
-and you never want to do that.
-
 00:34:00.876 --> 00:34:02.106 A:middle
 You always want the affirmative,
 
@@ -2687,10 +2563,6 @@ device-- people are--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.116 --> 00:35:00.706 A:middle
-People are using your
-device-- people are--
 
 00:35:00.916 --> 00:35:04.236 A:middle
 we're all using these
@@ -2785,10 +2657,6 @@ are available to you and then
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.696 --> 00:36:03.386 A:middle
-or to look at what options
-are available to you and then
 
 00:36:03.386 --> 00:36:06.716 A:middle
 and only then do we show
@@ -2942,10 +2810,6 @@ terminology.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.206 --> 00:38:01.726 A:middle
-OK, next up, Out-Of-Place
-terminology.
-
 00:38:02.846 --> 00:38:05.826 A:middle
 Now, a big part of making
 apps, really easy to use,
@@ -3023,10 +2887,6 @@ talk about untitled.numbers
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.206 --> 00:39:02.936 A:middle
-So in Numbers, they don't
-talk about untitled.numbers
-
 00:39:02.936 --> 00:39:05.956 A:middle
 or Create a New File, it's
 Make a New Spreadsheet.
@@ -3102,10 +2962,6 @@ showing up and you get the sense
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.746 --> 00:40:00.166 A:middle
-Sometimes you see a logo
-showing up and you get the sense
 
 00:40:00.166 --> 00:40:01.036 A:middle
 that people are thinking
@@ -3341,10 +3197,6 @@ we're going to figure it's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:56.986 --> 00:43:00.286 A:middle
-So now, when it comes again,
-we're going to figure it's going
-
 00:43:00.286 --> 00:43:01.696 A:middle
 to come up from the
 bottom because that
@@ -3413,10 +3265,6 @@ on in the same way.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.126 --> 00:44:00.946 A:middle
-but it should have come
-on in the same way.
-
 00:44:01.496 --> 00:44:03.336 A:middle
 OK, it would have been a
 really bad idea no matter
@@ -3484,10 +3332,6 @@ appropriately starts
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.666 --> 00:45:02.296 A:middle
-to stylize your app
-appropriately starts
 
 00:45:02.296 --> 00:45:04.496 A:middle
 with understanding
@@ -3634,10 +3478,6 @@ used it as the style
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.846 --> 00:47:01.526 A:middle
-and they applied it and
-used it as the style
-
 00:47:01.526 --> 00:47:02.636 A:middle
 of everything in the UI.
 
@@ -3774,9 +3614,6 @@ but that's just the first step.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.826 --> 00:49:00.806 A:middle
-but that's just the first step.
-
 00:49:01.576 --> 00:49:06.466 A:middle
 So, the designers of ProCreate,
 they probably started saying,
@@ -3857,10 +3694,6 @@ these things, you're going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.146 --> 00:50:00.786 A:middle
-If you can avoid doing
-these things, you're going
-
 00:50:00.786 --> 00:50:01.826 A:middle
 to be in really good shape.
 
@@ -3932,10 +3765,6 @@ the WWDC app, we could have put
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:58.696 --> 00:51:04.146 A:middle
-Now, when we were designing
-the WWDC app, we could have put
 
 00:51:04.146 --> 00:51:07.486 A:middle
 in all sorts of great
@@ -4009,10 +3838,6 @@ really great at and it's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:57.996 --> 00:52:01.236 A:middle
-Figure out what your app can be
-really great at and it's going
-
 00:52:01.236 --> 00:52:05.876 A:middle
 to just be one thing or two
 things, and then devote all
@@ -4085,7 +3910,4 @@ Thank you very much.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:50.996 --> 00:53:05.640 A:middle
-[ Applause ]
 

--- a/2013/226.srt
+++ b/2013/226.srt
@@ -109,10 +109,6 @@ view photos in our application
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.926 --> 00:01:00.746 A:middle
-We can have the ability to
-view photos in our application
-
 00:01:00.746 --> 00:01:02.006 A:middle
 and delete ones that
 we don't like.
@@ -252,10 +248,6 @@ the demo and I'll get started.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.626 --> 00:02:00.596 A:middle
-&gt;&gt; So, why don't you go set up
-the demo and I'll get started.
-
 00:02:00.596 --> 00:02:01.376 A:middle
 &gt;&gt; All right, cool.
 
@@ -354,10 +346,6 @@ slides differently in the top
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.796 --> 00:03:01.886 A:middle
-And notice how the text
-slides differently in the top
 
 00:03:02.136 --> 00:03:04.276 A:middle
 and those two view controllers
@@ -552,10 +540,6 @@ you for AnimationController
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.866 --> 00:05:01.596 A:middle
-And we do that by asking
-you for AnimationController
-
 00:05:01.596 --> 00:05:02.766 A:middle
 for presented controller,
 
@@ -658,10 +642,6 @@ object, and that's an object
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.666 --> 00:06:02.406 A:middle
-We're going to create a new
-object, and that's an object
-
 00:06:02.406 --> 00:06:02.906 A:middle
 that responds
 
@@ -753,10 +733,6 @@ transitions.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.316 --> 00:07:00.176 A:middle
-to create interactive
-transitions.
 
 00:07:00.986 --> 00:07:02.456 A:middle
 It lets you update
@@ -859,10 +835,6 @@ we've taken from this run.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.036 --> 00:08:01.346 A:middle
-and show all the photos that
-we've taken from this run.
-
 00:08:01.476 --> 00:08:04.316 A:middle
 This is obviously around
 the campus and you can go
@@ -962,10 +934,6 @@ user hits the delete button
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.376 --> 00:09:01.826 A:middle
-to get called when that
-user hits the delete button
-
 00:09:02.426 --> 00:09:05.346 A:middle
 and that is to let us know
 that the user deleted the photo
@@ -1060,10 +1028,6 @@ is just two seconds.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.096 --> 00:10:01.586 A:middle
-Animation-- Transition-duration
-is just two seconds.
-
 00:10:01.586 --> 00:10:03.666 A:middle
 Like Brandon, this just lets
 the system know how long your
@@ -1151,10 +1115,6 @@ really care where the two view--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.646 --> 00:11:03.666 A:middle
-The first is that we don't
-really care where the two view--
 
 00:11:03.666 --> 00:11:04.806 A:middle
 we don't want to animate it in.
@@ -1252,10 +1212,6 @@ whole bunch of animation code,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.536 --> 00:12:01.146 A:middle
-Finally, going through a
-whole bunch of animation code,
 
 00:12:01.586 --> 00:12:02.766 A:middle
 it's this line right here.
@@ -1362,10 +1318,6 @@ some really interesting things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.176 --> 00:13:00.486 A:middle
-As you just saw, we can do
-some really interesting things
-
 00:13:00.726 --> 00:13:03.146 A:middle
 with custom transitions and
 the new snapshotting API.
@@ -1450,10 +1402,6 @@ important to note in Seed 1,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:57.496 --> 00:14:00.336 A:middle
-Now, as Jim mentioned, it's
-important to note in Seed 1,
-
 00:14:00.776 --> 00:14:03.406 A:middle
 these methods are snapshot
 and resizable snapshot,
@@ -1537,10 +1485,6 @@ we do across the system.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.726 --> 00:15:02.216 A:middle
-that look the same as what
-we do across the system.
 
 00:15:02.646 --> 00:15:03.516 A:middle
 So, how do you do that?
@@ -1631,10 +1575,6 @@ use it to apply light, dark,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.606 --> 00:16:03.196 A:middle
-into your own applications and
-use it to apply light, dark,
 
 00:16:03.196 --> 00:16:05.326 A:middle
 and very light effects
@@ -1734,10 +1674,6 @@ There's a new change in iOS
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.666 --> 00:17:03.076 A:middle
-There's a new change in iOS
-7 to the tintColor system
-
 00:17:03.376 --> 00:17:05.715 A:middle
 that makes this easy to
 set a unified tint color
@@ -1827,10 +1763,6 @@ to specify the tint color
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:59.776 --> 00:18:02.216 A:middle
-so that it's what you use
-to specify the tint color
 
 00:18:02.216 --> 00:18:05.756 A:middle
 of an entire bar on iOS 7 rather
@@ -1926,10 +1858,6 @@ rendering mode always template,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.746 --> 00:19:02.766 A:middle
-But if I switched it over to
-rendering mode always template,
-
 00:19:03.226 --> 00:19:05.946 A:middle
 we're only going to look at the
 alpha channel of that image.
@@ -2009,10 +1937,6 @@ cap insets for the left, bottom,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.856 --> 00:20:03.506 A:middle
-You do this by specifying your
-cap insets for the left, bottom,
 
 00:20:03.676 --> 00:20:07.436 A:middle
 right, and top to be how far
@@ -2101,10 +2025,6 @@ what it looks like now.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.666 --> 00:21:02.576 A:middle
-So, let's show you
-what it looks like now.
 
 00:21:03.276 --> 00:21:06.956 A:middle
 As you can see, we-- on
@@ -2199,10 +2119,6 @@ up the tint color.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.226 --> 00:22:00.536 A:middle
-So it will also pick
-up the tint color.
 
 00:22:01.136 --> 00:22:03.716 A:middle
 As we go back, now we see
@@ -2299,9 +2215,6 @@ And now, all of our buttons
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.766 --> 00:23:00.936 A:middle
-And now, all of our buttons
 
 00:23:00.936 --> 00:23:02.806 A:middle
 in our application
@@ -2403,10 +2316,6 @@ drawViewHierarchyInRect
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.756 --> 00:24:01.456 A:middle
-And it basically just calls
-drawViewHierarchyInRect
-
 00:24:01.546 --> 00:24:03.996 A:middle
 and makes the blur and applies
 it to the button background.
@@ -2495,10 +2404,6 @@ this is going to be
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.806 --> 00:25:01.776 A:middle
-And like Brandon mentioned,
-this is going to be
 
 00:25:01.776 --> 00:25:03.646 A:middle
 in this sample code as well
@@ -2595,10 +2500,6 @@ cool things with UIKit Dynamics.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.106 --> 00:26:01.426 A:middle
-Now, you can do a lot of really
-cool things with UIKit Dynamics.
-
 00:26:01.546 --> 00:26:03.986 A:middle
 You can do a lot of crazy
 things with UIKit Dynamics.
@@ -2685,9 +2586,6 @@ So, what do you need to do
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.986 --> 00:27:00.276 A:middle
-So, what do you need to do
 
 00:27:00.276 --> 00:27:02.426 A:middle
 to introduce dynamics
@@ -2783,10 +2681,6 @@ of talking about Dynamics
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.336 --> 00:28:01.316 A:middle
-&gt;&gt; Hey, Brandon, instead
-of talking about Dynamics
 
 00:28:01.316 --> 00:28:03.976 A:middle
 on slides anymore, how about
@@ -2899,10 +2793,6 @@ that we really wanted
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.836 --> 00:29:01.306 A:middle
-But the other place
-that we really wanted
-
 00:29:01.306 --> 00:29:05.376 A:middle
 to use Dynamics was in our
 flipbook in how we show photos
@@ -3000,10 +2890,6 @@ out to zero.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.366 --> 00:30:00.976 A:middle
-and animate its alpha
-out to zero.
 
 00:30:01.616 --> 00:30:04.376 A:middle
 Now, this is all fine
@@ -3106,10 +2992,6 @@ simple gravity behavior
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.576 --> 00:31:01.046 A:middle
-And then we create a
-simple gravity behavior
-
 00:31:01.046 --> 00:31:03.196 A:middle
 and we give it a little bit more
 gravity 'cause I want things
@@ -3192,10 +3074,6 @@ directly to our animator.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.386 --> 00:32:00.076 A:middle
-of those behaviors
-directly to our animator.
 
 00:32:03.096 --> 00:32:07.226 A:middle
 Then, as we iterate through
@@ -3292,10 +3170,6 @@ complete the second part
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.246 --> 00:33:02.326 A:middle
-And two, we needed to
-complete the second part
-
 00:33:02.326 --> 00:33:06.046 A:middle
 of our animation, the
 fading out of the view
@@ -3379,10 +3253,6 @@ with no animation at all.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.246 --> 00:34:00.296 A:middle
-of the view, that was done
-with no animation at all.
 
 00:34:00.576 --> 00:34:04.666 A:middle
 That was all just an
@@ -3472,10 +3342,6 @@ container from the superview.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.896 --> 00:35:01.476 A:middle
-and then we can remove the
-container from the superview.
 
 00:35:02.826 --> 00:35:03.476 A:middle
 Pretty cool, huh?
@@ -3581,10 +3447,6 @@ the entire system.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.396 --> 00:36:01.626 A:middle
-and so on and across
-the entire system.
-
 00:36:02.576 --> 00:36:05.646 A:middle
 Now you can think of these
 similarly to CAAnimations.
@@ -3679,9 +3541,6 @@ hovering above the screen
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.876 --> 00:37:00.176 A:middle
-hovering above the screen
-
 00:37:00.466 --> 00:37:02.096 A:middle
 and how you actually
 see different parts
@@ -3773,10 +3632,6 @@ group.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.766 --> 00:38:00.636 A:middle
-The first is UIMotionEffect
-group.
 
 00:38:01.146 --> 00:38:03.626 A:middle
 You want to group every motion
@@ -3875,10 +3730,6 @@ of interesting things.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.286 --> 00:39:01.406 A:middle
-in our app are a couple
-of interesting things.
 
 00:39:02.026 --> 00:39:03.576 A:middle
 The first thing our
@@ -3988,10 +3839,6 @@ subdued and much more brighter.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:57.756 --> 00:40:02.456 A:middle
-that the colors become much more
-subdued and much more brighter.
-
 00:40:02.456 --> 00:40:04.576 A:middle
 And then if I go in the
 wide axis, the buttons move
@@ -4090,9 +3937,6 @@ It's the exact same code.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.936 --> 00:41:00.966 A:middle
-It's the exact same code.
-
 00:41:01.016 --> 00:41:04.016 A:middle
 The only thing that's changed
 is the key path is now center.y
@@ -4181,10 +4025,6 @@ flare color motion effect.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.206 --> 00:42:01.326 A:middle
-of UIMotionEvent called lens
-flare color motion effect.
 
 00:42:01.326 --> 00:42:03.316 A:middle
 And it's a pretty simple class.
@@ -4278,10 +4118,6 @@ at both x and y, we just cared
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.066 --> 00:43:02.456 A:middle
-But what instead of looking
-at both x and y, we just cared
 
 00:43:02.456 --> 00:43:05.196 A:middle
 about the horizontal

--- a/2013/227.srt
+++ b/2013/227.srt
@@ -64,10 +64,6 @@ the talk is going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.366 --> 00:01:00.846 A:middle
-Then the bulk of
-the talk is going
-
 00:01:00.846 --> 00:01:03.966 A:middle
 to be spent covering
 several common tasks
@@ -128,10 +124,6 @@ NSDate, NSDateComponets,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:56.196 --> 00:02:01.486 A:middle
-to just these 4 classes here,
-NSDate, NSDateComponets,
 
 00:02:01.896 --> 00:02:04.156 A:middle
 NSCalendar and NSTimeZone.
@@ -207,10 +199,6 @@ talk, this is our timeline.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.996 --> 00:03:01.176 A:middle
-to use throughout the
-talk, this is our timeline.
 
 00:03:01.176 --> 00:03:04.856 A:middle
 Now, I'm going to add a
@@ -347,10 +335,6 @@ making the method call.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.216 --> 00:05:02.266 A:middle
-this very moment when I
-making the method call.
-
 00:05:02.756 --> 00:05:04.966 A:middle
 And I'll be using this
 a bunch in the talk
@@ -422,10 +406,6 @@ object I can set it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.806 --> 00:06:03.016 A:middle
-So, if I have NSDateComponents
-object I can set it
-
 00:06:03.016 --> 00:06:05.206 A:middle
 as month property
 to 6 for example
@@ -491,10 +471,6 @@ how to do calendar math on them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.906 --> 00:07:02.756 A:middle
-of world calendars and knows
-how to do calendar math on them.
 
 00:07:03.166 --> 00:07:06.906 A:middle
 It knows how to take an NSDate
@@ -563,10 +539,6 @@ how to convert between NSDates,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:56.826 --> 00:08:01.336 A:middle
-So, as I say, NSCalendar knows
-how to convert between NSDates,
-
 00:08:01.436 --> 00:08:05.936 A:middle
 these very large numbers
 which are not specific
@@ -633,10 +605,6 @@ their preferred calendar,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.616 --> 00:09:01.496 A:middle
-If the user changes
-their preferred calendar,
 
 00:09:01.716 --> 00:09:03.886 A:middle
 you may want your
@@ -791,10 +759,6 @@ might to ask is given
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.446 --> 00:11:01.466 A:middle
-So, one question I
-might to ask is given
-
 00:11:01.466 --> 00:11:03.306 A:middle
 that today is the 14th of June.
 
@@ -870,10 +834,6 @@ irregular region but, you know,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:57.916 --> 00:12:00.376 A:middle
-And you see it's a very
-irregular region but, you know,
-
 00:12:00.786 --> 00:12:03.376 A:middle
 I call it geo-political.
 
@@ -940,9 +900,6 @@ Now, very similar to NSCalendar,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.026 --> 00:13:00.246 A:middle
-Now, very similar to NSCalendar,
 
 00:13:01.486 --> 00:13:03.486 A:middle
 you can create an
@@ -1022,9 +979,6 @@ as a default "don't care" time.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.036 --> 00:14:02.196 A:middle
-as a default "don't care" time.
-
 00:14:02.746 --> 00:14:06.166 A:middle
 It is-- they may want
 to use an NSDate object
@@ -1098,10 +1052,6 @@ about the time use noon instead.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:56.406 --> 00:15:01.066 A:middle
-So, if you really don't care
-about the time use noon instead.
-
 00:15:01.736 --> 00:15:05.166 A:middle
 The other main reason
 that people want to it
@@ -1164,9 +1114,6 @@ So, and then, of course,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.046 --> 00:16:00.816 A:middle
-So, and then, of course,
 
 00:16:00.816 --> 00:16:03.966 A:middle
 if the reverse happens
@@ -1239,10 +1186,6 @@ of course today's start date.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:56.996 --> 00:17:00.876 A:middle
-For-- and that would give me
-of course today's start date.
-
 00:17:01.146 --> 00:17:05.286 A:middle
 For tomorrow's start date,
 we need to do some more work.
@@ -1309,10 +1252,6 @@ that tomorrow
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.466 --> 00:18:03.116 A:middle
-to be the same moment
-that tomorrow
-
 00:18:03.116 --> 00:18:05.316 A:middle
 because of the daylight
 saving time transition.
@@ -1374,10 +1313,6 @@ called when the day changes.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:55.866 --> 00:19:00.666 A:middle
-And you'll-- your code will get
-called when the day changes.
 
 00:19:00.666 --> 00:19:04.066 A:middle
 When midnight or, you
@@ -1456,10 +1391,6 @@ in this case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.716 --> 00:20:01.906 A:middle
-of NSNotificationCenter
-in this case.
-
 00:20:04.546 --> 00:20:07.746 A:middle
 Now, midnight of course
 is a specific example
@@ -1531,10 +1462,6 @@ we're after 11:30
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.746 --> 00:21:02.766 A:middle
-Well, right now,
-we're after 11:30
-
 00:21:02.766 --> 00:21:04.706 A:middle
 so we're more like
 at point B here.
@@ -1599,10 +1526,6 @@ just add one method here,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.176 --> 00:22:01.836 A:middle
-Now, of course, we didn't
-just add one method here,
-
 00:22:01.976 --> 00:22:05.726 A:middle
 it's also interesting to know
 about yesterday and tomorrow.
@@ -1664,10 +1587,6 @@ is very literal when you talk
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.536 --> 00:23:01.586 A:middle
-The compare method of NSDate
-is very literal when you talk
 
 00:23:01.586 --> 00:23:05.286 A:middle
 about wanting to know is
@@ -1742,10 +1661,6 @@ NSCalendarConstants for the unit
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.936 --> 00:24:03.646 A:middle
-you pass in one of the
-NSCalendarConstants for the unit
-
 00:24:03.686 --> 00:24:04.636 A:middle
 that you're interested in.
 
@@ -1810,10 +1725,6 @@ another, but rather if they're
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.736 --> 00:25:05.136 A:middle
-if toDates are close to one
-another, but rather if they're
-
 00:25:05.136 --> 00:25:08.416 A:middle
 on the same-- within
 the same calendar unit
@@ -1869,9 +1780,6 @@ NSDateComponents object.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.176 --> 00:26:00.696 A:middle
-NSDateComponents object.
 
 00:26:01.256 --> 00:26:04.736 A:middle
 An NSDateComponents object as I
@@ -1945,10 +1853,6 @@ of the context of a calendar.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.556 --> 00:27:05.346 A:middle
-They have no meaning outside
-of the context of a calendar.
-
 00:27:05.466 --> 00:27:07.656 A:middle
 You know, what calendar
 is that year in?
@@ -2008,10 +1912,6 @@ the Japanese Imperial calendar."
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.376 --> 00:28:00.806 A:middle
-or these are always dates in
-the Japanese Imperial calendar."
 
 00:28:02.606 --> 00:28:07.836 A:middle
 But when you do that, remember;
@@ -2082,10 +1982,6 @@ NSDate objects or try
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:57.666 --> 00:29:00.936 A:middle
-Sometimes people use
-NSDate objects or try
-
 00:29:00.936 --> 00:29:04.466 A:middle
 to use NSDate objects
 to represent times
@@ -2153,10 +2049,6 @@ new API for that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.266 --> 00:30:01.806 A:middle
-So, we've added a
-new API for that.
 
 00:30:01.806 --> 00:30:04.216 A:middle
 And this is perhaps
@@ -2379,10 +2271,6 @@ them here on my slides.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.716 --> 00:33:02.616 A:middle
-and just literally expose
-them here on my slides.
-
 00:33:03.146 --> 00:33:06.856 A:middle
 So, then I call the
 method nextDateAfterDate.
@@ -2456,10 +2344,6 @@ is the smaller components
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:57.306 --> 00:34:00.696 A:middle
-For the lower components that
-is the smaller components
-
 00:34:00.696 --> 00:34:01.186 A:middle
 if you will.
 
@@ -2523,10 +2407,6 @@ component and we look for either
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.036 --> 00:35:02.846 A:middle
-We take its value of that
-component and we look for either
 
 00:35:02.896 --> 00:35:07.716 A:middle
 that same value or the next
@@ -2595,9 +2475,6 @@ that is of course the week.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.486 --> 00:36:00.726 A:middle
-that is of course the week.
-
 00:36:01.106 --> 00:36:05.296 A:middle
 The weekday cycle around
 repeat one after the other
@@ -2662,10 +2539,6 @@ clear why we do this
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.396 --> 00:37:01.196 A:middle
-which will make this
-clear why we do this
 
 00:37:01.256 --> 00:37:04.366 A:middle
 but this the default
@@ -2741,10 +2614,6 @@ get back to those.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.566 --> 00:38:00.836 A:middle
-but I promise I will
-get back to those.
-
 00:38:01.386 --> 00:38:05.306 A:middle
 Now, it's possible that
 there's no possible results.
@@ -2816,10 +2685,6 @@ wanted to find the next leap day
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.556 --> 00:39:03.086 A:middle
-An example would be suppose you
-wanted to find the next leap day
 
 00:39:03.156 --> 00:39:04.376 A:middle
 in the Gregorian calendar.
@@ -2967,9 +2832,6 @@ or will raise an exception.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.786 --> 00:41:00.416 A:middle
-or will raise an exception.
-
 00:41:00.846 --> 00:41:06.066 A:middle
 You either need to ask for
 strict matching or you need
@@ -3036,10 +2898,6 @@ a.m. is actually 3:00 a.m.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.226 --> 00:42:02.146 A:middle
-So, one hour after 1:00
-a.m. is actually 3:00 a.m.
-
 00:42:02.256 --> 00:42:05.126 A:middle
 in the United States on
 the date of the transition.
@@ -3099,10 +2957,6 @@ said is you want us
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:56.406 --> 00:43:00.166 A:middle
-So, what this has
-said is you want us
 
 00:43:00.166 --> 00:43:05.326 A:middle
 to give you the best
@@ -3170,10 +3024,6 @@ international flights takeoff
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:56.336 --> 00:44:00.826 A:middle
-in the morning before the first
-international flights takeoff
 
 00:44:00.826 --> 00:44:02.616 A:middle
 and before the first
@@ -3250,10 +3100,6 @@ warning to get to work.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.296 --> 00:45:00.086 A:middle
-and he'll have no
-warning to get to work.
-
 00:45:00.086 --> 00:45:04.776 A:middle
 On the other hand, if it passes
 in the PreviousTimePreserving
@@ -3326,10 +3172,6 @@ to begin searching.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.656 --> 00:46:00.286 A:middle
-at which you want
-to begin searching.
 
 00:46:00.586 --> 00:46:04.306 A:middle
 Of course even nicer might be
@@ -3489,10 +3331,6 @@ you pass in MatchNextTime
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.136 --> 00:48:04.426 A:middle
-On the other hand, if
-you pass in MatchNextTime
-
 00:48:04.796 --> 00:48:08.656 A:middle
 PreservingSmallerUnits,
 you get a 24-hour period
@@ -3550,10 +3388,6 @@ do some work for each match,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:56.236 --> 00:49:00.446 A:middle
-and enumerate them all and
-do some work for each match,
 
 00:49:01.076 --> 00:49:02.436 A:middle
 then you should use this method.
@@ -3630,10 +3464,6 @@ other enumerate methods,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.806 --> 00:50:01.756 A:middle
-So, we've used this in
-other enumerate methods,
 
 00:50:01.756 --> 00:50:02.976 A:middle
 it's the same kind of pattern.
@@ -3783,10 +3613,6 @@ the Era is really important
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:59.336 --> 00:52:04.356 A:middle
-In some cases, some calendars,
-the Era is really important
-
 00:52:05.336 --> 00:52:08.646 A:middle
 to also test for
 and keep in mind.
@@ -3863,10 +3689,6 @@ Islamic Calendar year?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:57.776 --> 00:53:00.016 A:middle
-What is the current
-Islamic Calendar year?
-
 00:53:00.256 --> 00:53:00.786 A:middle
 For example.
 
@@ -3941,10 +3763,6 @@ have some people that you ask
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:58.336 --> 00:54:02.636 A:middle
-So, if, you know, assuming you
-have some people that you ask
 
 00:54:02.716 --> 00:54:08.406 A:middle
 to beta test your application,
@@ -4024,10 +3842,6 @@ go try it out."
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.536 --> 00:55:01.176 A:middle
-here's a new version,
-go try it out."
 
 00:55:01.816 --> 00:55:06.196 A:middle
 So, I've talked about various

--- a/2013/228.srt
+++ b/2013/228.srt
@@ -88,10 +88,6 @@ themselves sort
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.256 --> 00:01:00.726 A:middle
-So-- And who considers
-themselves sort
-
 00:01:00.726 --> 00:01:01.306 A:middle
 of like intermediate,
 
@@ -190,10 +186,6 @@ been doing this for a while,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.256 --> 00:02:01.956 A:middle
-So, what Mattt does, he's
-been doing this for a while,
 
 00:02:01.956 --> 00:02:04.836 A:middle
 he goes out and digs up
@@ -307,10 +299,6 @@ we're going to focus on editing
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.226 --> 00:03:02.316 A:middle
-So let's start with Xcode and
-we're going to focus on editing
 
 00:03:02.316 --> 00:03:03.166 A:middle
 and debugging to start.
@@ -437,10 +425,6 @@ I've typed coretextctpar,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.476 --> 00:04:02.916 A:middle
-So, in this example on screen,
-I've typed coretextctpar,
-
 00:04:02.916 --> 00:04:04.966 A:middle
 and Open Quickly is
 smart to say, "You know,
@@ -538,10 +522,6 @@ cluster you're currently working
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.816 --> 00:05:01.316 A:middle
-that are related to the
-cluster you're currently working
 
 00:05:01.316 --> 00:05:03.806 A:middle
 on which is a great thing for--
@@ -650,10 +630,6 @@ with this just pop over,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.826 --> 00:06:00.696 A:middle
-You can do a bunch of things
-with this just pop over,
 
 00:06:00.696 --> 00:06:02.216 A:middle
 but the one thing I just
@@ -767,10 +743,6 @@ visual view and I do a po
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.126 --> 00:07:01.526 A:middle
-just in the Xcode
-visual view and I do a po
-
 00:07:01.526 --> 00:07:04.606 A:middle
 on self.rootViewController here,
 I get that really long string.
@@ -855,9 +827,6 @@ I don't-- I think most
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.976 --> 00:08:00.836 A:middle
-I don't-- I think most
 
 00:08:00.836 --> 00:08:02.426 A:middle
 of you are probably
@@ -973,10 +942,6 @@ setObject:atIndexedSubscript,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.216 --> 00:09:00.176 A:middle
-you implement
-setObject:atIndexedSubscript,
-
 00:09:00.736 --> 00:09:02.376 A:middle
 and then I'll just close
 up the class like that.
@@ -1088,10 +1053,6 @@ subscript instead of index,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.486 --> 00:10:01.946 A:middle
-objectKeyed [assumed spelling]
-subscript instead of index,
-
 00:10:02.316 --> 00:10:03.976 A:middle
 and setObject:
 forKeyedSubscript.
@@ -1186,9 +1147,6 @@ Set because it's inappropriate.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.816 --> 00:11:00.066 A:middle
-Set because it's inappropriate.
 
 00:11:00.276 --> 00:11:03.586 A:middle
 So, I've got indexedValues
@@ -1289,10 +1247,6 @@ that out, so that's good.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.186 --> 00:12:02.206 A:middle
-The compiler will figure
-that out, so that's good.
-
 00:12:02.396 --> 00:12:04.726 A:middle
 And this is-- maybe more of
 you are familiar with this,
@@ -1387,9 +1341,6 @@ So, let's switch over to this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.726 --> 00:13:01.106 A:middle
-So, let's switch over to this.
 
 00:13:03.276 --> 00:13:04.396 A:middle
 All right, you can see code.
@@ -1567,10 +1518,6 @@ a powerful man now as a manager.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.016 --> 00:15:02.886 A:middle
-because I have subordinates, I'm
-a powerful man now as a manager.
-
 00:15:03.006 --> 00:15:05.456 A:middle
 So-- And again, we
 don't have to, you know,
@@ -1657,10 +1604,6 @@ to fill out our implementation
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.096 --> 00:16:02.126 A:middle
-So, if we go back and make sure
-to fill out our implementation
 
 00:16:02.126 --> 00:16:09.436 A:middle
 as well and then back to
@@ -1753,10 +1696,6 @@ to both iOS and OS X.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.296 --> 00:17:01.316 A:middle
-about so far applies
-to both iOS and OS X.
 
 00:17:01.316 --> 00:17:04.506 A:middle
 So everything for iOS 7,
@@ -1856,10 +1795,6 @@ out there and you say Cancel
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.336 --> 00:18:00.126 A:middle
-So, you can have stuff running
-out there and you say Cancel
 
 00:18:00.126 --> 00:18:01.526 A:middle
 and it will stop running.
@@ -1961,10 +1896,6 @@ anticipate.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.556 --> 00:19:00.356 A:middle
-where you may actually
-anticipate.
 
 00:19:00.356 --> 00:19:03.586 A:middle
 So we use the Dependencies
@@ -2167,10 +2098,6 @@ parse mathematical expressions.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.326 --> 00:21:01.686 A:middle
-So, NSExpression can actually
-parse mathematical expressions.
-
 00:21:02.466 --> 00:21:06.406 A:middle
 So here, I've got 3
 plus 5 times 4e10.
@@ -2264,10 +2191,6 @@ our friends, NSArray
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.116 --> 00:22:01.136 A:middle
-OK. So, in addition to
-our friends, NSArray
 
 00:22:01.136 --> 00:22:02.786 A:middle
 and NSDictionary that
@@ -2370,10 +2293,6 @@ interesting you can do
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.036 --> 00:23:01.696 A:middle
-And there's also something
-interesting you can do
 
 00:23:01.696 --> 00:23:03.776 A:middle
 with set calculations
@@ -2490,10 +2409,6 @@ you should catch on video
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.246 --> 00:24:00.916 A:middle
-if you were in the room, but
-you should catch on video
-
 00:24:00.916 --> 00:24:02.416 A:middle
 if you didn't see
 it, Designing Code
@@ -2601,10 +2516,6 @@ mutable copy a nil,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.626 --> 00:25:00.506 A:middle
-because if you call
-mutable copy a nil,
-
 00:25:00.506 --> 00:25:01.746 A:middle
 you're going to get nil back.
 
@@ -2709,10 +2620,6 @@ the implementation is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.676 --> 00:26:00.766 A:middle
-And it turns out that
-the implementation is
-
 00:26:00.766 --> 00:26:01.496 A:middle
 incredibly simple.
 
@@ -2801,10 +2708,6 @@ has a few tricks up its sleeve.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.026 --> 00:27:01.986 A:middle
-But NSValue, you know, still
-has a few tricks up its sleeve.
 
 00:27:01.986 --> 00:27:03.966 A:middle
 For instance, it can store
@@ -2897,10 +2800,6 @@ type using the @encode
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.246 --> 00:28:02.016 A:middle
-and then Objective-C
-type using the @encode
 
 00:28:02.366 --> 00:28:05.076 A:middle
 and then the type of the struct.
@@ -3005,10 +2904,6 @@ manager.name, that's equivalent
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.936 --> 00:29:03.246 A:middle
-So, valueForKeyPath,
-manager.name, that's equivalent
-
 00:29:03.246 --> 00:29:05.216 A:middle
 to employee.manager.name.
 
@@ -3096,10 +2991,6 @@ API and maybe encoding,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.636 --> 00:30:00.596 A:middle
-with some sort of web service
-API and maybe encoding,
 
 00:30:00.766 --> 00:30:03.516 A:middle
 you know, serializing values
@@ -3209,10 +3100,6 @@ of collection operators
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.626 --> 00:31:01.426 A:middle
-So there are three kinds
-of collection operators
-
 00:31:01.426 --> 00:31:03.146 A:middle
 and they are kind of
 distinguished based
@@ -3311,10 +3198,6 @@ it'll give you the, you know,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.806 --> 00:32:01.256 A:middle
-So for collections of NSNumbers,
-it'll give you the, you know,
-
 00:32:01.256 --> 00:32:05.366 A:middle
 arithmetic sum and average of
 the numbers in that collection.
@@ -3400,10 +3283,6 @@ Array and Set Operators.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.696 --> 00:33:03.056 A:middle
-So, finally, we have
-Array and Set Operators.
 
 00:33:03.456 --> 00:33:05.786 A:middle
 You have unionOfArrays,
@@ -3498,10 +3377,6 @@ a date to your calendar.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.626 --> 00:34:02.426 A:middle
-to your address book or
-a date to your calendar.
-
 00:34:02.556 --> 00:34:03.416 A:middle
 Very convenient.
 
@@ -3593,9 +3468,6 @@ more processing.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.576 --> 00:35:00.386 A:middle
-more processing.
 
 00:35:00.496 --> 00:35:01.956 A:middle
 So in this case, we're
@@ -3697,10 +3569,6 @@ a CFMutableStringRef
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.446 --> 00:36:02.426 A:middle
-The first argument is
-a CFMutableStringRef
 
 00:36:02.426 --> 00:36:03.166 A:middle
 which you remember
@@ -3808,10 +3676,6 @@ two is sort of academic.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.346 --> 00:37:00.626 A:middle
-The difference between the
-two is sort of academic.
-
 00:37:00.626 --> 00:37:02.266 A:middle
 In this case, it just
 noted all the squiggly bits
@@ -3904,9 +3768,6 @@ really, really cool stuff.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.556 --> 00:38:00.526 A:middle
-really, really cool stuff.
-
 00:38:00.526 --> 00:38:02.836 A:middle
 Translating between writing
 system or Orthographies.
@@ -3996,10 +3857,6 @@ systems of Japanese.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.116 --> 00:39:01.546 A:middle
-the two phonetic writing
-systems of Japanese.
 
 00:39:01.546 --> 00:39:03.586 A:middle
 You can convert between the
@@ -4097,10 +3954,6 @@ you might use this in action.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.366 --> 00:40:01.236 A:middle
-[inaudible] actually show how
-you might use this in action.
-
 00:40:01.496 --> 00:40:03.106 A:middle
 Let's say you've
 taken Apple's advice
@@ -4195,10 +4048,6 @@ enumerateLinguisticTagsInRange
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.206 --> 00:41:01.966 A:middle
-we're going to use our friend
-enumerateLinguisticTagsInRange
 
 00:41:02.176 --> 00:41:05.136 A:middle
 which, again, really
@@ -4312,10 +4161,6 @@ you're not super familiar
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.606 --> 00:42:03.226 A:middle
-And real quickly, if
-you're not super familiar
-
 00:42:03.226 --> 00:42:04.996 A:middle
 with Core Animation, I'm sure
 most of you have heard of it.
@@ -4401,10 +4246,6 @@ will actually animate
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.556 --> 00:43:00.566 A:middle
-So CAGradientLayer
-will actually animate
 
 00:43:00.566 --> 00:43:02.146 A:middle
 between different gradients.
@@ -4501,10 +4342,6 @@ and take that layer and add it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:57.996 --> 00:44:01.416 A:middle
-and then I can just go ahead
-and take that layer and add it
-
 00:44:01.416 --> 00:44:03.476 A:middle
 to any view that that has
 a layer already on it.
@@ -4593,10 +4430,6 @@ so it's pretty cool.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.486 --> 00:45:01.926 A:middle
-And it looks like that,
-so it's pretty cool.
 
 00:45:03.216 --> 00:45:04.756 A:middle
 Now, what would be really cool?
@@ -4690,10 +4523,6 @@ actually change the time offset
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:57.466 --> 00:46:00.316 A:middle
-So instead what you can do is
-actually change the time offset
 
 00:46:00.316 --> 00:46:03.056 A:middle
 of the layer itself and that
@@ -4798,10 +4627,6 @@ X developers as a way
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.586 --> 00:47:00.696 A:middle
-for both iOS and OS
-X developers as a way
 
 00:47:00.696 --> 00:47:02.126 A:middle
 to persist your data
@@ -4911,10 +4736,6 @@ just any work you want to do
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:57.806 --> 00:48:00.486 A:middle
-You say performBlock with
-just any work you want to do
 
 00:48:00.766 --> 00:48:02.346 A:middle
 and you don't even have
@@ -5027,10 +4848,6 @@ it will go and fetch more.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.496 --> 00:49:01.186 A:middle
-of run through that array,
-it will go and fetch more.
-
 00:49:01.886 --> 00:49:04.066 A:middle
 And also if you're doing
 cross relationship fetching,
@@ -5125,10 +4942,6 @@ something?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.026 --> 00:50:04.436 A:middle
-Has anyone not learned
-something?
 
 00:50:05.686 --> 00:50:08.136 A:middle
 OK, yeah, because I was going
@@ -5236,10 +5049,6 @@ about UICollectionView,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.716 --> 00:51:01.716 A:middle
-But here's the great news
-about UICollectionView,
-
 00:51:02.086 --> 00:51:04.806 A:middle
 the API is incredibly
 similar to UITableView.
@@ -5330,10 +5139,6 @@ the past you're used to working
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:56.966 --> 00:52:00.326 A:middle
-So one thing to know is if in
-the past you're used to working
 
 00:52:00.326 --> 00:52:03.876 A:middle
 with UITableView and then
@@ -5441,10 +5246,6 @@ class that's NSTableCellView
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:59.636 --> 00:53:04.776 A:middle
-is there's an existing
-class that's NSTableCellView
 
 00:53:05.136 --> 00:53:06.446 A:middle
 which you can use generically.

--- a/2013/300.srt
+++ b/2013/300.srt
@@ -79,10 +79,6 @@ well for a long time,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.276 --> 00:01:00.736 A:middle
-This model worked reasonably
-well for a long time,
-
 00:01:01.666 --> 00:01:04.426 A:middle
 but times have changed
 and we here
@@ -172,10 +168,6 @@ and distributing apps
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:57.926 --> 00:02:00.636 A:middle
-enforcing security policies
-and distributing apps
-
 00:02:00.636 --> 00:02:02.376 A:middle
 and other content out
 to their end users.
@@ -252,10 +244,6 @@ that enable organizations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.876 --> 00:03:01.036 A:middle
-and added new capabilities
-that enable organizations
 
 00:03:01.556 --> 00:03:05.026 A:middle
 to get more control over their
@@ -336,10 +324,6 @@ new capabilities we're offering
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.346 --> 00:04:00.796 A:middle
-to fully take advantage of these
-new capabilities we're offering
 
 00:04:00.796 --> 00:04:02.786 A:middle
 to you to make the experience
@@ -428,10 +412,6 @@ profiles.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.976 --> 00:05:01.806 A:middle
-as installing configuration
-profiles.
 
 00:05:02.506 --> 00:05:05.036 A:middle
 Now, configuration profiles were
@@ -525,10 +505,6 @@ work and we're looking forward
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.286 --> 00:06:01.736 A:middle
-But this is a huge amount of
-work and we're looking forward
-
 00:06:01.736 --> 00:06:04.386 A:middle
 to you integrating
 these new capabilities
@@ -604,10 +580,6 @@ company's device with access
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.406 --> 00:07:01.476 A:middle
-or they're using it as their
-company's device with access
 
 00:07:01.476 --> 00:07:02.546 A:middle
 to the corporate secure data.
@@ -689,10 +661,6 @@ data leaking out in ways
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.446 --> 00:08:00.556 A:middle
-to prevent their secure
-data leaking out in ways
-
 00:08:00.556 --> 00:08:03.506 A:middle
 that they don't want including
 being able to delete that app
@@ -768,10 +736,6 @@ to the organization [applause].
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.166 --> 00:09:00.416 A:middle
-to the MDM server to provide
-to the organization [applause].
 
 00:09:04.486 --> 00:09:07.236 A:middle
 And then finally, this one
@@ -940,10 +904,6 @@ through that private network,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.826 --> 00:11:00.216 A:middle
-and have all data go
-through that private network,
-
 00:11:00.646 --> 00:11:02.416 A:middle
 only the corporate
 secure data will go
@@ -1025,10 +985,6 @@ key is generated
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.456 --> 00:12:00.216 A:middle
-an individual recovery
-key is generated
 
 00:12:00.216 --> 00:12:01.306 A:middle
 and provided to the user.
@@ -1123,10 +1079,6 @@ locked down but still not have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.956 --> 00:13:03.726 A:middle
-And you can have the Apple TVs
-locked down but still not have
 
 00:13:03.726 --> 00:13:06.256 A:middle
 to have each end user
@@ -1285,10 +1237,6 @@ and the corporate secure data.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.416 --> 00:15:02.146 A:middle
-between the users personal data
-and the corporate secure data.
 
 00:15:03.346 --> 00:15:06.346 A:middle
 There's also a new restriction
@@ -1468,10 +1416,6 @@ kind of settings would you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.306 --> 00:17:00.006 A:middle
-you want to think of what
-kind of settings would you
 
 00:17:00.006 --> 00:17:01.686 A:middle
 like to implement
@@ -1658,10 +1602,6 @@ account or whatnot.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.336 --> 00:19:02.126 A:middle
-that has a Dropbox
-account or whatnot.
-
 00:19:02.126 --> 00:19:03.496 A:middle
 But that's not necessarily
 ideal.
@@ -1830,10 +1770,6 @@ that are revocable
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.006 --> 00:21:00.416 A:middle
-to purchase licenses
-that are revocable
-
 00:21:00.416 --> 00:21:08.306 A:middle
 for apps instead of codes.
 
@@ -1918,10 +1854,6 @@ to tell the device to install
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.636 --> 00:22:02.526 A:middle
-that allows the organization
-to tell the device to install
 
 00:22:02.566 --> 00:22:04.656 A:middle
 that app, which will
@@ -2099,10 +2031,6 @@ to be able to revoke them
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:57.906 --> 00:24:00.766 A:middle
-being able to assign licenses,
-to be able to revoke them
-
 00:24:00.976 --> 00:24:02.566 A:middle
 and then assign into
 some other user.
@@ -2191,10 +2119,6 @@ system and then be able to use
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:56.666 --> 00:25:00.736 A:middle
-that they are tracking in their
-system and then be able to use
-
 00:25:00.736 --> 00:25:02.446 A:middle
 that URL to construct
 an invitation
@@ -2279,10 +2203,6 @@ transfer of ownership.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.536 --> 00:26:02.226 A:middle
-it's still permanent, a
-transfer of ownership.
-
 00:26:02.616 --> 00:26:04.706 A:middle
 We decide to add that
 to the new system
@@ -2366,10 +2286,6 @@ to download particular book
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:56.466 --> 00:27:00.396 A:middle
-down to the device to tell it
-to download particular book
-
 00:27:00.396 --> 00:27:03.006 A:middle
 or books-- sorry,
 particular app or apps.
@@ -2452,10 +2368,6 @@ and user readable ErrorMessage
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.566 --> 00:28:00.716 A:middle
-you'll get both an ErrorNumber
-and user readable ErrorMessage
 
 00:28:00.716 --> 00:28:04.716 A:middle
 that you can provide
@@ -2801,10 +2713,6 @@ one client user ID string
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.276 --> 00:32:01.386 A:middle
-it's always tied to exactly
-one client user ID string
-
 00:32:01.656 --> 00:32:05.216 A:middle
 but that reference can
 change, and in fact can change
@@ -2960,10 +2868,6 @@ but they will not get
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.576 --> 00:34:02.476 A:middle
-for an app perhaps
-but they will not get
-
 00:34:02.476 --> 00:34:03.576 A:middle
 to two different Apple IDs,
 
@@ -3045,10 +2949,6 @@ are the first to adopt this API
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.826 --> 00:35:02.766 A:middle
-of the engineers on my team who
-are the first to adopt this API
-
 00:35:02.766 --> 00:35:04.706 A:middle
 and they have some
 things that they'd
@@ -3128,10 +3028,6 @@ to get VPP user service
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:56.936 --> 00:36:02.856 A:middle
-to get VPP user service
-'cause users may unenroll
-
 00:36:02.856 --> 00:36:04.956 A:middle
 from the service,
 you may retire them.
@@ -3208,10 +3104,6 @@ license to the user
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.096 --> 00:37:00.066 A:middle
-between assigning a
-license to the user
 
 00:37:00.516 --> 00:37:02.676 A:middle
 and actually sending
@@ -3295,10 +3187,6 @@ to separate the assignment
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.916 --> 00:38:02.346 A:middle
-you've probably in the UI want
-to separate the assignment
 
 00:38:02.346 --> 00:38:03.466 A:middle
 from the installation.
@@ -3482,10 +3370,6 @@ complete that initial step.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.556 --> 00:40:02.196 A:middle
-like Apple Configurator to
-complete that initial step.
-
 00:40:03.396 --> 00:40:05.786 A:middle
 But wouldn't it be easier
 if we gave you this.
@@ -3567,10 +3451,6 @@ order lots and lots
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.886 --> 00:41:01.826 A:middle
-Well, they hopefully
-order lots and lots
 
 00:41:01.826 --> 00:41:03.666 A:middle
 of Apple devices from us.
@@ -3655,10 +3535,6 @@ of critical settings,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.766 --> 00:42:00.326 A:middle
-There are a couple
-of critical settings,
 
 00:42:00.326 --> 00:42:03.176 A:middle
 the most important one
@@ -3838,10 +3714,6 @@ back to Apple.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:56.636 --> 00:44:01.166 A:middle
-to send diagnostics
-back to Apple.
-
 00:44:01.166 --> 00:44:03.726 A:middle
 So again, let's turn from
 the way the feature--
@@ -3928,10 +3800,6 @@ which can then manage them
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.886 --> 00:45:02.486 A:middle
-and enroll in your MDM Server
-which can then manage them
-
 00:45:02.486 --> 00:45:03.546 A:middle
 in all of the ways we've talked
 
@@ -4016,10 +3884,6 @@ their Mac to work or learn.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.526 --> 00:46:02.336 A:middle
-to be which is that user-- using
-their Mac to work or learn.
 
 00:46:03.456 --> 00:46:04.886 A:middle
 Now I know you want
@@ -4116,10 +3980,6 @@ set my keyboard
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.656 --> 00:47:02.096 A:middle
-So I set my country,
-set my keyboard
-
 00:47:02.516 --> 00:47:03.546 A:middle
 and the first thing that's--
 
@@ -4201,10 +4061,6 @@ server that will be hosted
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.176 --> 00:48:01.146 A:middle
-This now talking to an MDM
-server that will be hosted
 
 00:48:01.146 --> 00:48:03.986 A:middle
 by the organization would
@@ -4291,9 +4147,6 @@ Here we go.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.716 --> 00:49:00.636 A:middle
-Here we go.
-
 00:49:00.636 --> 00:49:01.466 A:middle
 Let's go surfing.
 
@@ -4376,9 +4229,6 @@ Let's go set this up.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.126 --> 00:50:00.666 A:middle
-Let's go set this up.
 
 00:50:01.316 --> 00:50:02.156 A:middle
 Here we go.
@@ -4539,9 +4389,6 @@ and if they restore the phone,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:59.796 --> 00:52:02.576 A:middle
-and if they restore the phone,
-
 00:52:02.576 --> 00:52:04.296 A:middle
 basically erase/install
 the phone,
@@ -4614,9 +4461,6 @@ And now log out.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.416 --> 00:53:02.826 A:middle
-And now log out.
 
 00:53:03.016 --> 00:53:07.726 A:middle
 So we have an Apple ID and
@@ -4707,10 +4551,6 @@ is going to send.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:59.996 --> 00:54:01.806 A:middle
-that the MDM console
-is going to send.
-
 00:54:01.806 --> 00:54:06.046 A:middle
 And that'll show up in
 the device momentarily.
@@ -4793,10 +4633,6 @@ three pushes.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:57.986 --> 00:55:00.586 A:middle
-And yes, now we got
-three pushes.
 
 00:55:00.886 --> 00:55:02.906 A:middle
 So yes, I will allow apps
@@ -4882,9 +4718,6 @@ without me doing anything.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:54.516 --> 00:56:00.096 A:middle
-[ Applause ]
 
 00:56:00.596 --> 00:56:01.726 A:middle
 So-- and that is the demo.
@@ -4982,10 +4815,6 @@ to working together with all
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:56:59.626 --> 00:57:02.396 A:middle
-And I'm really looking forward
-to working together with all
-
 00:57:02.396 --> 00:57:04.716 A:middle
 of you to get these
 systems integrated
@@ -5081,10 +4910,6 @@ features in their apps including
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:57:59.896 --> 00:58:03.276 A:middle
-of these new management
-features in their apps including
 
 00:58:03.276 --> 00:58:05.606 A:middle
 that receipt session I

--- a/2013/301.srt
+++ b/2013/301.srt
@@ -131,10 +131,6 @@ networking,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.426 --> 00:02:02.616 A:start
-They are: authentication,
-networking,
-
 00:02:03.736 --> 00:02:06.326 A:start
 data security, and management.
 
@@ -211,10 +207,6 @@ a suite of apps
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.276 --> 00:03:01.176 A:start
-that has developed
-a suite of apps
 
 00:03:01.176 --> 00:03:03.166 A:start
 and we call that
@@ -304,10 +296,6 @@ introducing Single Sign-On.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.626 --> 00:04:06.706 A:start
-So, new in iOS 7, we are
-introducing Single Sign-On.
-
 00:04:07.206 --> 00:04:10.266 A:start
 [ Applause ]
 
@@ -370,10 +358,6 @@ what iOS brings to the table.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.176 --> 00:05:01.696 A:start
-I'm going to present to you
-what iOS brings to the table.
 
 00:05:02.256 --> 00:05:04.846 A:start
 And then, I'm going to talk
@@ -456,10 +440,6 @@ will see as a developer is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.796 --> 00:06:02.416 A:start
-So, the only change that you
-will see as a developer is
-
 00:06:03.036 --> 00:06:05.986 A:start
 when you access a resource
 that has been configured it
@@ -539,10 +519,6 @@ that you are going to allow
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.616 --> 00:07:03.366 A:start
-And define the app bundle IDs
-that you are going to allow
-
 00:07:03.366 --> 00:07:05.616 A:start
 into this system, into the
 Single Sign On account,
@@ -608,10 +584,6 @@ Wi-Fi 802.1X, WPA, WPA2,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:56.086 --> 00:08:01.636 A:start
-and we support enterprise
-Wi-Fi 802.1X, WPA, WPA2,
 
 00:08:02.096 --> 00:08:04.566 A:start
 and we support virtual
@@ -693,10 +665,6 @@ to only the apps
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.396 --> 00:09:01.776 A:start
-This limits VPN access
-to only the apps
-
 00:09:01.776 --> 00:09:04.536 A:start
 that the enterprise has
 installed, specific Apps.
@@ -756,10 +724,6 @@ have to do to install this--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.116 --> 00:10:01.596 A:start
-For IT integrators, what do you
-have to do to install this--
 
 00:10:01.596 --> 00:10:03.686 A:start
 to configure this feature?
@@ -920,10 +884,6 @@ of cellular data.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.126 --> 00:12:00.246 A:start
-and limit the consumption
-of cellular data.
-
 00:12:01.236 --> 00:12:05.026 A:start
 And the way you do that is
 you tag your URL request
@@ -1065,9 +1025,6 @@ remain unencrypted.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.966 --> 00:14:00.996 A:start
-remain unencrypted.
-
 00:14:01.356 --> 00:14:04.996 A:start
 So, keep that in mind, this is
 the model that you can choose
@@ -1147,9 +1104,6 @@ in iOS 7 than it did in iOS 6.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.056 --> 00:15:01.546 A:start
-in iOS 7 than it did in iOS 6.
 
 00:15:01.686 --> 00:15:03.056 A:start
 And we do this across the board
@@ -1304,10 +1258,6 @@ need to do an update
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.416 --> 00:17:00.796 A:start
-that you are-- that you
-need to do an update
-
 00:17:00.796 --> 00:17:03.066 A:start
 when the app comes back
 to foreground and do it
@@ -1460,10 +1410,6 @@ folder instead
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.656 --> 00:19:00.856 A:start
-in your local documents
-folder instead
-
 00:19:00.856 --> 00:19:02.416 A:start
 of the iCloud document folder
 
@@ -1538,10 +1484,6 @@ including email, calendar, VPN,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:57.436 --> 00:20:03.426 A:start
-It can install accounts
-including email, calendar, VPN,
 
 00:20:03.426 --> 00:20:06.776 A:start
 you know, Wi-Fi accounts,
@@ -1689,10 +1631,6 @@ with both apps and accounts.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:55.216 --> 00:23:01.706 A:start
-So, Managed Open In works
-with both apps and accounts.
-
 00:23:02.116 --> 00:23:05.566 A:start
 So, when you tap an
 attachment and there's an--
@@ -1762,10 +1700,6 @@ you push down appears
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.266 --> 00:24:02.016 A:start
-Now, the dictionary that
-you push down appears
 
 00:24:02.166 --> 00:24:05.816 A:start
 in the NSUserDefaults of that
@@ -1837,10 +1771,6 @@ com.apple.feedback.managed.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.906 --> 00:25:02.336 A:start
-NSUserDefaults key
-com.apple.feedback.managed.
 
 00:25:02.716 --> 00:25:05.216 A:start
 And when the MDM
@@ -1927,10 +1857,6 @@ values that were tracking.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.306 --> 00:26:02.226 A:start
-we've got a success and failure
-values that were tracking.
 
 00:26:02.466 --> 00:26:04.446 A:start
 And in the center,
@@ -2028,10 +1954,6 @@ and push down that change,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.496 --> 00:27:02.016 A:start
-So, I'm going to go ahead
-and push down that change,
-
 00:27:02.846 --> 00:27:05.066 A:start
 give it a moment for the
 device to receive it.
@@ -2112,10 +2034,6 @@ were pulled out of the app,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.086 --> 00:28:01.136 A:start
-but the success values
-were pulled out of the app,
 
 00:28:01.136 --> 00:28:04.046 A:start
 sent back to the MDM Server
@@ -2204,10 +2122,6 @@ what's going on under the--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.766 --> 00:29:03.846 A:start
-Let's take a closer look at
-what's going on under the--
-
 00:29:03.846 --> 00:29:04.606 A:start
 under the covers here.
 
@@ -2277,10 +2191,6 @@ then it picks apart the keys
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.696 --> 00:30:02.306 A:start
-configuration.managed, and
-then it picks apart the keys
 
 00:30:02.356 --> 00:30:03.776 A:start
 and the values from
@@ -2357,10 +2267,6 @@ com.apple.feedback.managed.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:56.986 --> 00:31:01.256 A:start
-under that magic key
-com.apple.feedback.managed.
 
 00:31:01.836 --> 00:31:06.346 A:start
 We then write the value of the
@@ -2441,10 +2347,6 @@ configuration, it is stored
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.816 --> 00:32:01.956 A:start
-Some things to note about this
-configuration, it is stored
 
 00:32:01.956 --> 00:32:04.266 A:start
 as file protection
@@ -2606,10 +2508,6 @@ things like that,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.106 --> 00:34:02.116 A:start
-things like location,
-things like that,
-
 00:34:02.116 --> 00:34:05.546 A:start
 be sure that you are legally
 allowed to do this and,
@@ -2680,9 +2578,6 @@ Next, fonts.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.926 --> 00:35:02.466 A:start
-Next, fonts.
 
 00:35:03.286 --> 00:35:05.386 A:start
 We can now install
@@ -2764,10 +2659,6 @@ in the enterprise
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.796 --> 00:36:01.646 A:start
-in certain industries
-in the enterprise
-
 00:36:02.176 --> 00:36:05.006 A:start
 and that's single app mode.
 
@@ -2833,10 +2724,6 @@ mode allows an MDM Server
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.356 --> 00:37:02.556 A:start
-So, app-requested single app
-mode allows an MDM Server
 
 00:37:02.556 --> 00:37:05.206 A:start
 to pre-authorize a
@@ -2985,10 +2872,6 @@ app may be installed
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.736 --> 00:39:04.316 A:start
-So, what happens is your
-app may be installed
-
 00:39:04.316 --> 00:39:07.726 A:start
 on some user's device and
 then, the right to run
@@ -3070,10 +2953,6 @@ recommended you go to that one
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.976 --> 00:40:02.596 A:start
-I recommend it-- I
-recommended you go to that one
-
 00:40:02.596 --> 00:40:05.556 A:start
 and we'll cite that at the
 end of the presentation.
@@ -3141,10 +3020,6 @@ you to do something different,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.576 --> 00:41:05.726 A:start
-And we don't-- we encourage
-you to do something different,
-
 00:41:07.396 --> 00:41:11.966 A:start
 we encourage you to
 build the next generation
@@ -3197,10 +3072,6 @@ tacked on at the end.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:57.676 --> 00:42:00.036 A:start
-natively and not just
-tacked on at the end.
 
 00:42:00.546 --> 00:42:02.236 A:start
 These are the apps
@@ -3258,10 +3129,6 @@ the first time, all right?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.206 --> 00:43:02.416 A:start
-and have it work correctly
-the first time, all right?
 
 00:43:02.416 --> 00:43:03.606 A:start
 I know in some cases, you can't,
@@ -3332,10 +3199,6 @@ they are prevalent here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:57.646 --> 00:44:00.346 A:start
-to be interested in because
-they are prevalent here.
 
 00:44:01.186 --> 00:44:04.106 A:start
 The first is already

--- a/2013/302.srt
+++ b/2013/302.srt
@@ -84,10 +84,6 @@ pass, and that kind of thing,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.526 --> 00:01:01.036 A:middle
-how to build your first
-pass, and that kind of thing,
-
 00:01:01.036 --> 00:01:03.056 A:middle
 I'll still be covering some
 high level concepts just
@@ -163,10 +159,6 @@ something, to do something.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.076 --> 00:02:00.546 A:middle
-to get into something, to buy
-something, to do something.
 
 00:02:01.406 --> 00:02:05.396 A:middle
 So how does a pass get
@@ -258,10 +250,6 @@ and it's built on top
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.696 --> 00:03:01.436 A:middle
-So we have a better system,
-and it's built on top
-
 00:03:01.436 --> 00:03:03.136 A:middle
 of the Apple Push
 Notification Service.
@@ -348,10 +336,6 @@ whose balance you're updating,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.346 --> 00:04:01.266 A:middle
-or if you have a store card
-whose balance you're updating,
-
 00:04:02.286 --> 00:04:03.666 A:middle
 your server might
 take that opportunity
@@ -429,10 +413,6 @@ some really cool new
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.786 --> 00:05:01.626 A:middle
-both via APIs and via
-some really cool new
-
 00:05:01.746 --> 00:05:02.866 A:middle
 user-facing features.
 
@@ -507,10 +487,6 @@ zipped, and there's your pass.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:56.686 --> 00:06:01.316 A:middle
-All of that is signed and
-zipped, and there's your pass.
 
 00:06:01.836 --> 00:06:05.246 A:middle
 So you may have noticed that
@@ -604,10 +580,6 @@ the full width of the screen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.216 --> 00:07:01.456 A:middle
-and that's that passes are now
-the full width of the screen.
-
 00:07:01.456 --> 00:07:04.806 A:middle
 They're 320 points, up from 312,
 
@@ -687,10 +659,6 @@ ready for your passes to end
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.916 --> 00:08:03.146 A:middle
-on iOS 7 this fall, be
-ready for your passes to end
 
 00:08:03.146 --> 00:08:03.916 A:middle
 up pretty much anywhere.
@@ -780,10 +748,6 @@ or a multi-day event.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.156 --> 00:09:00.676 A:middle
-that involves an itinerary
-or a multi-day event.
-
 00:09:01.936 --> 00:09:03.756 A:middle
 So, if you need that, use it.
 
@@ -861,10 +825,6 @@ that it occurs in in
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.456 --> 00:10:02.226 A:middle
-that it occurs in in
-12 p.m. Pacific time,
 
 00:10:02.626 --> 00:10:04.326 A:middle
 then the user will
@@ -953,10 +913,6 @@ that time zone adjustment.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.236 --> 00:11:02.226 A:middle
-So we now allow you to disable
-that time zone adjustment.
-
 00:11:02.726 --> 00:11:05.486 A:middle
 It's just a key on date fields.
 
@@ -1032,9 +988,6 @@ It shows your app icon.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.606 --> 00:12:00.686 A:middle
-It shows your app icon.
 
 00:12:00.686 --> 00:12:03.206 A:middle
 It shows a button that
@@ -1205,9 +1158,6 @@ It can even do it in conditions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.886 --> 00:14:00.976 A:middle
-It can even do it in conditions
-
 00:14:00.976 --> 00:14:03.066 A:middle
 where there's no network access
 -- on an iPod, for instance.
@@ -1305,10 +1255,6 @@ confirmation number that's being
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.226 --> 00:15:01.396 A:middle
-You can see here I have a
-confirmation number that's being
-
 00:15:01.396 --> 00:15:03.876 A:middle
 confused as a phone number,
 and an address that --
@@ -1394,9 +1340,6 @@ If you don't provide this key,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.866 --> 00:16:00.806 A:middle
-If you don't provide this key,
 
 00:16:00.806 --> 00:16:02.596 A:middle
 then we just do our
@@ -1485,10 +1428,6 @@ explanatory text,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.936 --> 00:17:01.146 A:middle
-with more information,
-explanatory text,
-
 00:17:01.276 --> 00:17:04.576 A:middle
 and I've also included
 a much shorter --
@@ -1565,10 +1504,6 @@ style by making your own gloss
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:56.976 --> 00:18:00.836 A:middle
-If you've been matching the old
-style by making your own gloss
 
 00:18:00.836 --> 00:18:03.676 A:middle
 or shadows or fitting
@@ -1738,10 +1673,6 @@ run it and see how it looks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.526 --> 00:20:06.456 A:middle
-and let's just go ahead and
-run it and see how it looks.
 
 00:20:06.456 --> 00:20:06.646 A:middle
 [ Pause ]
@@ -1926,10 +1857,6 @@ third status to determine
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.936 --> 00:22:00.436 A:middle
-we will be adding a
-third status to determine
-
 00:22:00.436 --> 00:22:02.866 A:middle
 if the user cancelled
 adding those passes.
@@ -2026,10 +1953,6 @@ just going to tap "add all",
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.626 --> 00:23:02.056 A:middle
-And when we do that we're
-just going to tap "add all",
-
 00:23:02.056 --> 00:23:06.636 A:middle
 they look pretty good to me,
 and nicely animate those out.
@@ -2120,10 +2043,6 @@ one of the passes then they have
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.506 --> 00:24:02.676 A:middle
-If the user doesn't want to have
-one of the passes then they have
-
 00:24:02.676 --> 00:24:05.156 A:middle
 to cancel the whole thing or
 go back and delete it later,
@@ -2202,10 +2121,6 @@ friends, I went to Store,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.166 --> 00:25:02.076 A:middle
-They just say, you know, "hey,
-friends, I went to Store,
 
 00:25:02.076 --> 00:25:04.146 A:middle
 I got Thing, Thing is cool,
@@ -2297,10 +2212,6 @@ that's what it's for.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.096 --> 00:26:01.746 A:middle
-Check the barcode:
-that's what it's for.
 
 00:26:01.806 --> 00:26:03.106 A:middle
 So that's sharing.
@@ -2398,10 +2309,6 @@ to a website, you don't have
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.776 --> 00:27:01.246 A:middle
-You don't have to send them
-to a website, you don't have
-
 00:27:01.246 --> 00:27:02.926 A:middle
 to get their email address,
 you don't have to get them
@@ -2485,10 +2392,6 @@ single code that's going to end
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.396 --> 00:28:03.426 A:middle
-But even if you are printing a
-single code that's going to end
 
 00:28:03.426 --> 00:28:05.876 A:middle
 up in a lot of places, in a
@@ -2668,10 +2571,6 @@ to point out is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.316 --> 00:30:00.366 A:middle
-One thing we do want
-to point out is
-
 00:30:00.366 --> 00:30:02.276 A:middle
 that if you are running
 a generation service,
@@ -2763,9 +2662,6 @@ sorry, this is not a pass.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.786 --> 00:31:02.106 A:middle
-sorry, this is not a pass.
-
 00:31:02.106 --> 00:31:05.826 A:middle
 So the URL has to be HTTPS
 just like your web services.
@@ -2853,10 +2749,6 @@ you're doing that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.406 --> 00:32:02.976 A:middle
-Just make sure that
-you're doing that.
-
 00:32:04.126 --> 00:32:06.676 A:middle
 And, let's see.
 
@@ -2941,10 +2833,6 @@ to use your passes.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.956 --> 00:33:01.756 A:middle
-to get your users
-to use your passes.
-
 00:33:01.886 --> 00:33:03.946 A:middle
 If your pass is relevant
 where they're ready to use it,
@@ -3023,10 +2911,6 @@ any of those locations,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.996 --> 00:34:02.166 A:middle
-And if you wanted to change
-any of those locations,
 
 00:34:02.166 --> 00:34:05.456 A:middle
 if you had a bunch of them,
@@ -3108,10 +2992,6 @@ ton of extra flexibility.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.025 --> 00:35:00.786 A:middle
-And that allows you a
-ton of extra flexibility.
 
 00:35:01.266 --> 00:35:05.136 A:middle
 It means that you can have any
@@ -3211,10 +3091,6 @@ for different beacons
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.616 --> 00:36:01.316 A:middle
-different relevant text
-for different beacons
-
 00:36:01.576 --> 00:36:02.856 A:middle
 in a department store,
 for instance,
@@ -3312,10 +3188,6 @@ be, of course,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.156 --> 00:37:00.906 A:middle
-And the reason would
-be, of course,
-
 00:37:00.906 --> 00:37:03.796 A:middle
 that we size boarding-pass
 relevance for an airport or so.
@@ -3397,9 +3269,6 @@ So that's relevance.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.126 --> 00:38:00.606 A:middle
-So that's relevance.
 
 00:38:00.916 --> 00:38:02.016 A:middle
 Let's talk about updates.
@@ -3486,10 +3355,6 @@ this other thing in our store",
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.226 --> 00:39:00.026 A:middle
-in our store, hey, check out
-this other thing in our store",
 
 00:39:00.556 --> 00:39:01.936 A:middle
 they're eventually going
@@ -3579,10 +3444,6 @@ and now it can scan the passes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.096 --> 00:40:02.546 A:middle
-It can make the passes relevant,
-and now it can scan the passes
-
 00:40:02.546 --> 00:40:06.156 A:middle
 for you, and you can
 then do whatever you need
@@ -3652,10 +3513,6 @@ say, "hey, don't bother trying
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.046 --> 00:41:00.356 A:middle
-that you can cue your users and
-say, "hey, don't bother trying
 
 00:41:00.356 --> 00:41:01.856 A:middle
 to use this pass: it's
@@ -3752,10 +3609,6 @@ them as expired in the UI.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.246 --> 00:42:01.986 A:middle
-to expire your passes, to mark
-them as expired in the UI.
-
 00:42:02.916 --> 00:42:06.296 A:middle
 And, again, if it matters
 to you your pass being
@@ -3845,10 +3698,6 @@ without any validation
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.546 --> 00:43:02.096 A:middle
-at some local server
-without any validation
 
 00:43:02.096 --> 00:43:04.786 A:middle
 and it will just work.
@@ -3944,10 +3793,6 @@ about all of these is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.976 --> 00:44:01.476 A:middle
-Something to note
-about all of these is
-
 00:44:01.476 --> 00:44:03.446 A:middle
 that they're only available
 on development devices.
@@ -4027,10 +3872,6 @@ this URL with logs on the end,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:56.396 --> 00:45:00.146 A:middle
-We will send a message to
-this URL with logs on the end,
 
 00:45:00.146 --> 00:45:03.566 A:middle
 and that will let you know
@@ -4122,10 +3963,6 @@ server resources.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.026 --> 00:46:01.616 A:middle
-and it saves your
-server resources.
-
 00:46:01.766 --> 00:46:03.216 A:middle
 So: use that.
 
@@ -4209,10 +4046,6 @@ your errors in production
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:57.476 --> 00:47:00.286 A:middle
-because it will help you catch
-your errors in production
 
 00:47:00.356 --> 00:47:01.536 A:middle
 which is super useful.
@@ -4298,10 +4131,6 @@ can watch the video later.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.826 --> 00:48:01.036 A:middle
-so you are too late, but you
-can watch the video later.
 
 00:48:01.736 --> 00:48:05.286 A:middle
 That talks about the new

--- a/2013/303.srt
+++ b/2013/303.srt
@@ -54,10 +54,6 @@ Store Gift Card in Passbook.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.216 --> 00:01:03.006 A:middle
-So, very quickly came Apple
-Store Gift Card in Passbook.
-
 00:01:04.396 --> 00:01:07.496 A:middle
 Now, I'm not from
 the Passbook Team.
@@ -126,10 +122,6 @@ to my Ecosystem?"
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.146 --> 00:02:00.546 A:middle
-"Can I bring Passbook
-to my Ecosystem?"
-
 00:02:01.226 --> 00:02:05.936 A:middle
 You have ASP downstream, how
 many weeks do I have to prepare
@@ -194,10 +186,6 @@ about giving the people you care
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.076 --> 00:03:03.156 A:middle
-Apple Store Gift Card is all
-about giving the people you care
 
 00:03:03.156 --> 00:03:05.246 A:middle
 about the products
@@ -269,10 +257,6 @@ have a value left,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.946 --> 00:04:01.636 A:middle
-Of course if they
-have a value left,
-
 00:04:01.926 --> 00:04:03.796 A:middle
 they can continue
 that cycle again.
@@ -342,9 +326,6 @@ How many of you don't?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:57.836 --> 00:05:00.476 A:middle
-How many of you don't?
 
 00:05:00.476 --> 00:05:02.816 A:middle
 You guys, OK.
@@ -424,10 +405,6 @@ this is so great."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.446 --> 00:06:00.386 A:middle
-I got an apple TV,
-this is so great."
-
 00:06:00.386 --> 00:06:01.326 A:middle
 She's going to open it up.
 
@@ -498,10 +475,6 @@ I would do way
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.926 --> 00:07:01.446 A:middle
-if I had a choice,
-I would do way
-
 00:07:01.446 --> 00:07:03.096 A:middle
 with the paper gift
 card entirely.
@@ -567,10 +540,6 @@ actually have access
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.156 --> 00:08:00.456 A:middle
-of a companion app, you
-actually have access
 
 00:08:01.026 --> 00:08:03.356 A:middle
 to much larger user base, right?
@@ -655,10 +624,6 @@ up her Apple TV or her--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.376 --> 00:09:00.946 A:middle
-So, she goes in, she picks
-up her Apple TV or her--
-
 00:09:00.946 --> 00:09:03.396 A:middle
 she picks up her Apple TV and
 picks up her pass and says,
@@ -734,10 +699,6 @@ you'll see this kind of theme
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:55.946 --> 00:10:00.366 A:middle
-OK. So, using the pass,
-you'll see this kind of theme
 
 00:10:00.366 --> 00:10:03.336 A:middle
 or reusing and leveraging
@@ -824,10 +785,6 @@ agents use to make sure
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.756 --> 00:11:02.516 A:middle
-that only our sales
-agents use to make sure
-
 00:11:02.516 --> 00:11:05.906 A:middle
 that it's almost impossible
 for them to make a mistake.
@@ -904,10 +861,6 @@ do out of a button there
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.126 --> 00:12:00.666 A:middle
-that the sales agent should
-do out of a button there
 
 00:12:00.666 --> 00:12:03.586 A:middle
 that says check out with
@@ -1056,10 +1009,6 @@ there are a lot of boxes there.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.576 --> 00:14:01.416 A:middle
-and I would agree with you,
-there are a lot of boxes there.
-
 00:14:02.576 --> 00:14:08.006 A:middle
 So, the goal is to identify all
 those boxes that do not matter.
@@ -1126,10 +1075,6 @@ primarily represents.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.736 --> 00:15:02.646 A:middle
-It's what your pass
-primarily represents.
 
 00:15:04.236 --> 00:15:07.626 A:middle
 Number three, redeeming
@@ -1198,10 +1143,6 @@ currencies for you guys?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.356 --> 00:16:01.436 A:middle
-OK, what are some common
-currencies for you guys?
-
 00:16:02.916 --> 00:16:04.196 A:middle
 So, we use gift card number.
 
@@ -1268,10 +1209,6 @@ to your system.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.726 --> 00:17:01.076 A:middle
-to bringing a pass
-to your system.
 
 00:17:01.616 --> 00:17:08.006 A:middle
 I've identified five facets that
@@ -1347,10 +1284,6 @@ through the snow
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.676 --> 00:18:00.186 A:middle
-you're kind of parsing
-through the snow
-
 00:18:00.186 --> 00:18:01.986 A:middle
 and you know exactly
 what's going on.
@@ -1424,10 +1357,6 @@ be the end of the world.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.506 --> 00:19:01.076 A:middle
-it wouldn't-- it wouldn't
-be the end of the world.
 
 00:19:02.196 --> 00:19:06.436 A:middle
 And finally, you kind of have
@@ -1574,10 +1503,6 @@ some things away for free.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.236 --> 00:21:01.206 A:middle
-but unless you want to give
-some things away for free.
-
 00:21:01.636 --> 00:21:03.826 A:middle
 So, as a uniqueness increases--
 
@@ -1662,10 +1587,6 @@ number of balls
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.646 --> 00:22:01.036 A:middle
-you're counting the
-number of balls
 
 00:22:01.036 --> 00:22:03.466 A:middle
 or you're counting the
@@ -1752,10 +1673,6 @@ if you're using that pass
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.816 --> 00:23:02.816 A:middle
-they're buying a shirt,
-if you're using that pass
-
 00:23:03.106 --> 00:23:07.336 A:middle
 in both places you need to
 make sure that data is correct
@@ -1828,10 +1745,6 @@ gift cards to support you have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:56.916 --> 00:24:01.196 A:middle
-when you still have the physical
-gift cards to support you have
 
 00:24:01.416 --> 00:24:04.066 A:middle
 to make sure you keep
@@ -1906,9 +1819,6 @@ Web services tips and tricks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:54.866 --> 00:25:01.156 A:middle
-Web services tips and tricks.
 
 00:25:01.266 --> 00:25:09.476 A:middle
 OK, reviewing the
@@ -2105,10 +2015,6 @@ pass, he slips that pass
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:57.956 --> 00:28:01.216 A:middle
-And then five minutes
-pass, he slips that pass
-
 00:28:01.216 --> 00:28:02.476 A:middle
 over and he pulls it down.
 
@@ -2180,10 +2086,6 @@ make sure you've implemented
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:57.386 --> 00:29:01.166 A:middle
-But I highly recommend that you
-make sure you've implemented
-
 00:29:02.056 --> 00:29:02.586 A:middle
 the log.
 
@@ -2252,10 +2154,6 @@ called Location Services.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:55.716 --> 00:30:00.976 A:middle
-For us, we talk to something
-called Location Services.
 
 00:30:01.056 --> 00:30:07.716 A:middle
 Location Services is-- it gives
@@ -2333,10 +2231,6 @@ the time of launch.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.446 --> 00:31:00.976 A:middle
-that Apple had at
-the time of launch.
-
 00:31:01.316 --> 00:31:04.986 A:middle
 At least we were able to serve
 the user with something, right?
@@ -2402,10 +2296,6 @@ request, simply test, "Hey,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.356 --> 00:32:02.336 A:middle
-and we could just for every
-request, simply test, "Hey,
 
 00:32:02.336 --> 00:32:05.266 A:middle
 is this gift card number valid?
@@ -2487,10 +2377,6 @@ like 10 percent, 15 percent.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:57.896 --> 00:33:00.806 A:middle
-A few of you, oh, that's
-like 10 percent, 15 percent.
-
 00:33:00.806 --> 00:33:02.656 A:middle
 OK, authentication token.
 
@@ -2547,9 +2433,6 @@ HMAC is super easy to do.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.416 --> 00:34:00.196 A:middle
-HMAC is super easy to do.
 
 00:34:00.196 --> 00:34:03.036 A:middle
 It's available on practically
@@ -2615,10 +2498,6 @@ information as possible.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:56.025 --> 00:35:00.636 A:middle
-cache as much downstream
-information as possible.
 
 00:35:01.736 --> 00:35:03.576 A:middle
 We talked about Location
@@ -2702,10 +2581,6 @@ yes, yes, OK."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.966 --> 00:36:00.286 A:middle
-at a queue listed,
-yes, yes, OK."
-
 00:36:00.816 --> 00:36:04.396 A:middle
 Forming out the WWDC party
 pass and all of them are going
@@ -2770,10 +2645,6 @@ everything.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.016 --> 00:37:02.086 A:middle
-and you can configure
-everything.
 
 00:37:02.086 --> 00:37:04.896 A:middle
 You can configure the post,
@@ -2849,10 +2720,6 @@ get top 10 logs.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.096 --> 00:38:00.416 A:middle
-of the logs, you
-get top 10 logs.
-
 00:38:00.896 --> 00:38:03.686 A:middle
 This will help you monitor
 and keep your systems healthy
@@ -2916,10 +2783,6 @@ these invalid requests.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.176 --> 00:39:00.546 A:middle
-attempting to serve all
-these invalid requests.
 
 00:39:01.026 --> 00:39:04.086 A:middle
 It protects you from a
@@ -2998,9 +2861,6 @@ So, for example like I said,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.626 --> 00:40:02.286 A:middle
-So, for example like I said,
 
 00:40:02.286 --> 00:40:04.096 A:middle
 gift cards can be
@@ -3081,10 +2941,6 @@ notifications and this is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:56.736 --> 00:41:00.146 A:middle
-Using a queue for push
-notifications and this is
-
 00:41:00.146 --> 00:41:04.196 A:middle
 that callback update, so when
 you find out that the pass needs
@@ -3157,10 +3013,6 @@ Store pass services needs
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.476 --> 00:42:01.586 A:middle
-On our request, Apple
-Store pass services needs
-
 00:42:01.586 --> 00:42:04.236 A:middle
 to take the serial number I
 got from the pass and I need
@@ -3232,10 +3084,6 @@ what is associated
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.236 --> 00:43:03.186 A:middle
-to ask your database
-what is associated
 
 00:43:03.186 --> 00:43:04.016 A:middle
 with that serial number.
@@ -3319,10 +3167,6 @@ my Location Services again
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.376 --> 00:44:01.876 A:middle
-for a pass, I never check
-my Location Services again
-
 00:44:02.406 --> 00:44:06.256 A:middle
 because I have it there.
 
@@ -3400,10 +3244,6 @@ identifier, will make it so that
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:57.986 --> 00:45:02.546 A:middle
-but keeping the pass type
-identifier, will make it so that
 
 00:45:02.546 --> 00:45:05.276 A:middle
 if somebody walks into your
@@ -3560,9 +3400,6 @@ He helps us prepare.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.866 --> 00:48:01.526 A:middle
-He helps us prepare.
-
 00:48:01.686 --> 00:48:03.976 A:middle
 He's our evangelist,
 great access
@@ -3634,7 +3471,4 @@ for joining us.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:50.656 --> 00:49:04.850 A:middle
-[Applause]
 

--- a/2013/304.srt
+++ b/2013/304.srt
@@ -154,10 +154,6 @@ talk about Map Kit for OS X.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:57.576 --> 00:02:04.996 A:middle
-So, with that outlined let's
-talk about Map Kit for OS X.
-
 00:02:05.226 --> 00:02:06.996 A:middle
 Here it is.
 
@@ -244,10 +240,6 @@ can use these to interact
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.586 --> 00:03:01.606 A:middle
-and a compass control so you
-can use these to interact
 
 00:03:01.606 --> 00:03:04.166 A:middle
 with the Map via a
@@ -343,10 +335,6 @@ on stage to do this demo.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.676 --> 00:04:02.726 A:middle
-up Alexander Carlhian up
-on stage to do this demo.
-
 00:04:03.296 --> 00:04:04.966 A:middle
 And you should give him
 a big round of applause
@@ -418,10 +406,6 @@ view, resize, simple right?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:54.726 --> 00:05:02.496 A:middle
-I can just drag it into my
-view, resize, simple right?
-
 00:05:02.796 --> 00:05:07.096 A:middle
 Just, let's just
 run-- here it is.
@@ -488,9 +472,6 @@ So you can see Paris.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.366 --> 00:06:02.566 A:middle
-So you can see Paris.
 
 00:06:02.566 --> 00:06:03.716 A:middle
 You can see the compass.
@@ -564,10 +545,6 @@ an image to my project.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.616 --> 00:07:00.956 A:middle
-So, I'm going to add
-an image to my project.
-
 00:07:01.456 --> 00:07:05.536 A:middle
 [ Silence ]
 
@@ -635,10 +612,6 @@ will be to add a callout.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.766 --> 00:08:01.876 A:middle
-Alright, so the next step
-will be to add a callout.
 
 00:08:02.016 --> 00:08:04.996 A:middle
 A callout is like a popover that
@@ -709,10 +682,6 @@ so I'm going to use that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:56.566 --> 00:09:01.696 A:middle
-and left accessory views
-so I'm going to use that.
 
 00:09:01.906 --> 00:09:07.216 A:middle
 I'm creating a left button,
@@ -862,10 +831,6 @@ title here and address
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:53.746 --> 00:11:02.256 A:middle
-I will show you my annotation
-title here and address
-
 00:11:03.036 --> 00:11:05.456 A:middle
 and just add a button.
 
@@ -942,10 +907,6 @@ So, we need to override the
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.076 --> 00:12:00.996 A:middle
-So, we need to override the
--hitTest: method to correct that
 
 00:12:01.496 --> 00:12:05.316 A:middle
 and to allow click
@@ -1025,10 +986,6 @@ MKPin annotation view
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.766 --> 00:13:02.246 A:middle
-to the map both the built-in
-MKPin annotation view
 
 00:13:02.246 --> 00:13:04.586 A:middle
 with the red pins and then
@@ -1127,10 +1084,6 @@ look a little bit different.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:57.326 --> 00:14:02.756 A:middle
-And we've changed the pins; they
-look a little bit different.
-
 00:14:02.756 --> 00:14:04.036 A:middle
 They're a little-- they've
 lost a little weight.
@@ -1219,10 +1172,6 @@ programmatically via API.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.276 --> 00:15:01.246 A:middle
-And you can also do this
-programmatically via API.
 
 00:15:01.776 --> 00:15:04.096 A:middle
 So, just to look at the code
@@ -1320,10 +1269,6 @@ showed on the slide earlier.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.036 --> 00:16:01.576 A:middle
-and so that's the screenshot
-showed on the slide earlier.
 
 00:16:02.226 --> 00:16:03.636 A:middle
 The other thing you might
@@ -1528,9 +1473,6 @@ We've got a geodesic polyline.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.676 --> 00:18:01.086 A:middle
-We've got a geodesic polyline.
-
 00:18:01.086 --> 00:18:03.946 A:middle
 A geodesic is the shortest path
 
@@ -1730,10 +1672,6 @@ then just go ahead and push
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.366 --> 00:20:01.776 A:middle
-This is AboveLabels and
-then just go ahead and push
-
 00:20:01.776 --> 00:20:03.656 A:middle
 that underneath and it improves
 the readability of the map.
@@ -1816,10 +1754,6 @@ to 2D and add an annotation view
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.946 --> 00:21:01.296 A:middle
-And then finally we'll come back
-to 2D and add an annotation view
 
 00:21:01.586 --> 00:21:03.296 A:middle
 and an annotation view
@@ -2023,10 +1957,6 @@ in order to display.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.106 --> 00:23:00.416 A:middle
-from your web server
-in order to display.
-
 00:23:00.916 --> 00:23:03.456 A:middle
 We can set this property
 canReplaceMapContent to Yes
@@ -2131,10 +2061,6 @@ tiles in the X direction
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.776 --> 00:24:01.726 A:middle
-We have two to the twelve
-tiles in the X direction
 
 00:24:01.726 --> 00:24:03.346 A:middle
 to the twelve tiles
@@ -2243,10 +2169,6 @@ if you don't want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.906 --> 00:25:01.146 A:middle
-So, you can make--
-if you don't want
-
 00:25:01.146 --> 00:25:03.456 A:middle
 to use MKTileOverlay you
 can just use any MKOverlay,
@@ -2349,10 +2271,6 @@ let's bring up a new demo.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.676 --> 00:26:11.166 A:middle
-&gt;&gt; Let's shut this down and
-let's bring up a new demo.
-
 00:26:11.166 --> 00:26:11.666 A:middle
 [ Silence ]
 
@@ -2416,10 +2334,6 @@ just goes ahead and loads them
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.926 --> 00:27:01.176 A:middle
-and what this thing does it
-just goes ahead and loads them
 
 00:27:01.176 --> 00:27:03.046 A:middle
 and displays them in
@@ -2511,10 +2425,6 @@ I don't have that many.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.756 --> 00:28:01.296 A:middle
-It works for me because
-I don't have that many.
-
 00:28:01.496 --> 00:28:03.736 A:middle
 I'm not going to put
 them on web server here,
@@ -2590,10 +2500,6 @@ a smaller number of tiles
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.536 --> 00:29:00.306 A:middle
-So, in this case we had
-a smaller number of tiles
 
 00:29:00.306 --> 00:29:01.626 A:middle
 and we wanted to put
@@ -2690,10 +2596,6 @@ Geocoder a few years ago.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.616 --> 00:30:00.706 A:middle
-So, we introduced CL
-Geocoder a few years ago.
 
 00:30:01.036 --> 00:30:03.636 A:middle
 And Geocoding is useful
@@ -2995,10 +2897,6 @@ directions and how do we use it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.616 --> 00:33:02.036 A:middle
-So, that's the features of
-directions and how do we use it.
-
 00:33:02.436 --> 00:33:03.746 A:middle
 So, suppose we have this
 method here and we want
@@ -3101,10 +2999,6 @@ to have a name to it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.196 --> 00:34:01.486 A:middle
-so each route is going
-to have a name to it.
 
 00:34:01.616 --> 00:34:03.886 A:middle
 So, this is sort of the
@@ -3221,10 +3115,6 @@ from San Franciso
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.296 --> 00:35:00.686 A:middle
-Here's the routes
-from San Franciso
-
 00:35:01.126 --> 00:35:02.646 A:middle
 down to Cupertino,
 three ways to do it.
@@ -3315,10 +3205,6 @@ that and we'll go ahead and use
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:55.436 --> 00:36:01.206 A:middle
-Cool. I'm glad you guys liked
-that and we'll go ahead and use
-
 00:36:01.206 --> 00:36:03.746 A:middle
 that distance formatter and
 we'll use NS data formatter,
@@ -3395,9 +3281,6 @@ from you know how do we get
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.246 --> 00:37:00.046 A:middle
-from you know how do we get
 
 00:37:00.136 --> 00:37:01.706 A:middle
 to the train station
@@ -3496,10 +3379,6 @@ route let's also clear our
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.106 --> 00:38:02.486 A:middle
-So, if we clear that Caltrain
-route let's also clear our
 
 00:38:02.486 --> 00:38:03.746 A:middle
 walking route.
@@ -3654,10 +3533,6 @@ type to walking and we're going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:56.306 --> 00:40:00.026 A:middle
-We're going to set the transport
-type to walking and we're going
-
 00:40:00.026 --> 00:40:01.196 A:middle
 to set the source
 and the destination
@@ -3764,9 +3639,6 @@ And the other thing I would say
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.776 --> 00:41:01.566 A:middle
-And the other thing I would say
-
 00:41:01.566 --> 00:41:04.036 A:middle
 about this is I actually
 cheated a little bit and I went
@@ -3844,10 +3716,6 @@ more you could do with it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.136 --> 00:42:00.856 A:middle
-There's obviously a lot
-more you could do with it.
 
 00:42:00.856 --> 00:42:02.326 A:middle
 This just sort of
@@ -3964,10 +3832,6 @@ wide usage limits.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.676 --> 00:43:00.566 A:middle
-or developer identifier
-wide usage limits.
-
 00:43:00.776 --> 00:43:03.576 A:middle
 So, if you have a app that has
 a lot of users and you want
@@ -4076,9 +3940,6 @@ There's the updates to iOS 7 UI.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.836 --> 00:44:02.256 A:middle
-There's the updates to iOS 7 UI.
-
 00:44:02.486 --> 00:44:04.046 A:middle
 So, there's a new UI in iOS 7
 
@@ -4180,10 +4041,6 @@ which I try to read occasionally
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.866 --> 00:45:03.116 A:middle
-And there's the Developer Forum
-which I try to read occasionally
 
 00:45:03.186 --> 00:45:04.596 A:middle
 and so I may see you in there.

--- a/2013/305.srt
+++ b/2013/305.srt
@@ -77,10 +77,6 @@ review the In-App purchase
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.776 --> 00:01:02.496 A:middle
-to StoreKit and then we'll
-review the In-App purchase
-
 00:01:02.496 --> 00:01:05.226 A:middle
 process and highlight the
 changes that you might want
@@ -172,10 +168,6 @@ details you want to get right.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.686 --> 00:02:01.226 A:middle
-but there's a bunch of
-details you want to get right.
 
 00:02:01.816 --> 00:02:04.676 A:middle
 So we spun off a separate
@@ -348,10 +340,6 @@ at some point in time,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.576 --> 00:04:00.896 A:middle
-as a paid application and
-at some point in time,
-
 00:04:01.016 --> 00:04:03.486 A:middle
 you want to make this
 application a free application.
@@ -439,10 +427,6 @@ the users having updated
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.666 --> 00:05:02.316 A:middle
-of the applications, of
-the users having updated
-
 00:05:02.316 --> 00:05:03.596 A:middle
 to the latest version
 of the iOS.
@@ -523,10 +507,6 @@ new batch of students.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.556 --> 00:06:00.976 A:middle
-and assign them to the
-new batch of students.
 
 00:06:01.446 --> 00:06:03.276 A:middle
 So that really unlocks
@@ -619,10 +599,6 @@ is in the receipt.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.506 --> 00:07:00.396 A:middle
-But again, the security
-is in the receipt.
-
 00:07:00.816 --> 00:07:03.996 A:middle
 So in both cases, it is the
 application's responsibility
@@ -709,10 +685,6 @@ server and Apple will host this,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.996 --> 00:08:02.156 A:middle
-You can upload this to the Apple
-server and Apple will host this,
 
 00:08:02.256 --> 00:08:04.516 A:middle
 Apple will serve it, and
@@ -808,9 +780,6 @@ because you're managing it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.076 --> 00:09:00.986 A:middle
-because you're managing it.
 
 00:09:01.306 --> 00:09:02.876 A:middle
 Now on the other
@@ -983,10 +952,6 @@ consumables and non-consumables.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.746 --> 00:11:02.886 A:middle
-OS X supports only
-consumables and non-consumables.
-
 00:11:03.666 --> 00:11:07.056 A:middle
 And as you've probably
 guessed, today we're excited
@@ -1060,10 +1025,6 @@ that you already know the basics
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:56.186 --> 00:12:00.386 A:middle
-So I'm going to assume here
-that you already know the basics
 
 00:12:00.386 --> 00:12:03.216 A:middle
 of StoreKit and that you
@@ -1151,10 +1112,6 @@ purchases like game options,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.206 --> 00:13:01.916 A:middle
-If you have In-App
-purchases like game options,
 
 00:13:02.006 --> 00:13:03.336 A:middle
 things just unlocking the game,
@@ -1245,10 +1202,6 @@ receive response."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:57.696 --> 00:14:01.076 A:middle
-you will get, "Did
-receive response."
-
 00:14:01.676 --> 00:14:04.336 A:middle
 And the response will
 contain two things.
@@ -1332,10 +1285,6 @@ size and the content version.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.946 --> 00:15:03.346 A:middle
-well you'll also get the content
-size and the content version.
 
 00:15:03.826 --> 00:15:05.546 A:middle
 And you can use this
@@ -1422,10 +1371,6 @@ store gives you is what we will
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.246 --> 00:16:02.916 A:middle
-and the price currency that the
-store gives you is what we will
-
 00:16:02.916 --> 00:16:03.766 A:middle
 charge to the user.
 
@@ -1509,10 +1454,6 @@ a 99 cent specials.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:56.586 --> 00:17:00.366 A:middle
-Look at that, it has
-a 99 cent specials.
 
 00:17:00.516 --> 00:17:01.596 A:middle
 It has [inaudible] Sprint.
@@ -1777,10 +1718,6 @@ your account names or users.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.846 --> 00:20:01.976 A:middle
-That means we don't want to know
-your account names or users.
-
 00:20:02.046 --> 00:20:04.106 A:middle
 We really don't want
 to know about this.
@@ -1864,10 +1801,6 @@ it, and it will come back
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:56.526 --> 00:21:00.616 A:middle
-and the store will be processing
-it, and it will come back
-
 00:21:00.716 --> 00:21:02.286 A:middle
 to the device as a transaction.
 
@@ -1949,9 +1882,6 @@ And again, you choose the level
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.876 --> 00:22:01.236 A:middle
-And again, you choose the level
 
 00:22:01.236 --> 00:22:02.756 A:middle
 of security you want
@@ -2221,10 +2151,6 @@ it across a connection
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.796 --> 00:25:01.436 A:middle
-And you want to send
-it across a connection
-
 00:25:01.436 --> 00:25:02.606 A:middle
 that you really know
 you can trust.
@@ -2396,10 +2322,6 @@ future, when you get --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:57.966 --> 00:27:00.096 A:middle
-to look for in the
-future, when you get --
-
 00:27:00.516 --> 00:27:04.296 A:middle
 when you're payment of
 server fires with updates
@@ -2486,10 +2408,6 @@ in the background
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.386 --> 00:28:02.516 A:middle
-to your application
-in the background
 
 00:28:02.666 --> 00:28:04.526 A:middle
 and gives you a fine-grain
@@ -2580,9 +2498,6 @@ or finishes downloading.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.576 --> 00:29:00.346 A:middle
-or finishes downloading.
-
 00:29:02.376 --> 00:29:06.136 A:middle
 So we mentioned that
 Newsstand Kits was downloading
@@ -2672,10 +2587,6 @@ is its power efficient.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.076 --> 00:30:01.756 A:middle
-And an added benefit
-is its power efficient.
 
 00:30:02.046 --> 00:30:04.036 A:middle
 So as long as the application
@@ -2773,10 +2684,6 @@ URL into a URL request object
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.276 --> 00:31:01.626 A:middle
-So again, you want to wrap your
-URL into a URL request object
-
 00:31:02.296 --> 00:31:06.206 A:middle
 and you want to create an
 NSURL session download task.
@@ -2856,10 +2763,6 @@ background URL session.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.816 --> 00:32:00.226 A:middle
-with handle events with
-background URL session.
 
 00:32:00.946 --> 00:32:02.576 A:middle
 This will give you the
@@ -2948,9 +2851,6 @@ but it's not a good idea,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.416 --> 00:33:00.476 A:middle
-but it's not a good idea,
-
 00:33:00.476 --> 00:33:04.436 A:middle
 actually because when the
 application gets backgrounded,
@@ -3037,10 +2937,6 @@ finish this transaction.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.446 --> 00:34:00.186 A:middle
-and the final step is to
-finish this transaction.
 
 00:34:00.386 --> 00:34:01.206 A:middle
 Again, not change here.
@@ -3129,10 +3025,6 @@ doing this, but don't wait
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.516 --> 00:35:01.086 A:middle
-And you guys are already
-doing this, but don't wait
 
 00:35:01.326 --> 00:35:03.046 A:middle
 to make a purchase
@@ -3231,10 +3123,6 @@ the API you call
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.626 --> 00:36:01.336 A:middle
-nothing changes except
-the API you call
-
 00:36:01.336 --> 00:36:02.926 A:middle
 to get the receipt
 so no change here.
@@ -3313,10 +3201,6 @@ application it is signed
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.276 --> 00:37:00.276 A:middle
-So when you develop your
-application it is signed
 
 00:37:00.276 --> 00:37:01.456 A:middle
 with the development
@@ -3401,10 +3285,6 @@ to use the SendBox.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.946 --> 00:38:00.576 A:middle
-So you can feel free
-to use the SendBox.
-
 00:38:00.646 --> 00:38:02.366 A:middle
 These receipts will not
 validate against production.
@@ -3482,10 +3362,6 @@ you have to first log
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:57.096 --> 00:39:01.976 A:middle
-So in practice, that means
-you have to first log
 
 00:39:01.976 --> 00:39:04.276 A:middle
 into Access Connect,
@@ -3677,10 +3553,6 @@ don't want this to fail
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.906 --> 00:41:02.476 A:middle
-it will fail, and you
-don't want this to fail
-
 00:41:02.476 --> 00:41:03.546 A:middle
 because this will
 fail at review.
@@ -3768,10 +3640,6 @@ do is have a restore button.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:56.726 --> 00:42:01.366 A:middle
-So the first thing you have to
-do is have a restore button.
 
 00:42:02.036 --> 00:42:05.226 A:middle
 If you have non-consumables, you
@@ -3868,10 +3736,6 @@ connects.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.376 --> 00:43:00.616 A:middle
-to feel your [inaudible]
-connects.
-
 00:43:01.396 --> 00:43:03.096 A:middle
 Otherwise, this is an
 automatic rejection.
@@ -3966,10 +3830,6 @@ totally okay, in fact it's great
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:55.996 --> 00:44:00.606 A:middle
-And in Newsstand, it is
-totally okay, in fact it's great
 
 00:44:00.606 --> 00:44:02.516 A:middle
 if you offer the
@@ -4074,9 +3934,6 @@ You can't ask the user to pay
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.096 --> 00:45:00.606 A:middle
-You can't ask the user to pay
-
 00:45:00.646 --> 00:45:02.256 A:middle
 for things he could
 get for free otherwise.
@@ -4167,10 +4024,6 @@ and read reviews and loyalty.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.736 --> 00:46:01.916 A:middle
-way to get good user feedback
-and read reviews and loyalty.
 
 00:46:02.506 --> 00:46:05.246 A:middle
 And it's also the best

--- a/2013/306.srt
+++ b/2013/306.srt
@@ -83,9 +83,6 @@ What about Harry Potter.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.526 --> 00:01:02.906 A:middle
-What about Harry Potter.
-
 00:01:03.026 --> 00:01:06.276 A:middle
 Let's see here, this is the
 number of studs collected,
@@ -166,10 +163,6 @@ Game Center leaderboards.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.616 --> 00:02:00.636 A:middle
-then we don't post it to the
-Game Center leaderboards.
 
 00:02:01.036 --> 00:02:03.646 A:middle
 New this year is score signing
@@ -256,10 +249,6 @@ are affected by this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:55.696 --> 00:03:01.296 A:middle
-No other leaderboards
-are affected by this.
 
 00:03:01.506 --> 00:03:02.226 A:middle
 Blocking a user.
@@ -449,10 +438,6 @@ name localization.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.246 --> 00:05:00.726 A:middle
-Talk about display
-name localization.
-
 00:05:01.766 --> 00:05:03.676 A:middle
 Again, we have these
 four leaderboards.
@@ -542,10 +527,6 @@ to turn the time
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.166 --> 00:06:01.636 A:middle
-With that, I'd like
-to turn the time
-
 00:06:01.636 --> 00:06:03.426 A:middle
 over to Daniel Miao
 [phonetic] to give us a demo
@@ -630,9 +611,6 @@ into Sets, right here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.646 --> 00:07:00.036 A:middle
-into Sets, right here.
 
 00:07:00.036 --> 00:07:04.476 A:middle
 And this page is asking us what
@@ -768,9 +746,6 @@ Hit Save to create it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.816 --> 00:09:00.456 A:middle
-Hit Save to create it.
-
 00:09:00.456 --> 00:09:02.566 A:middle
 And we'll see up here that
 now we have both Level 1
@@ -846,9 +821,6 @@ Choose an English display name.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.656 --> 00:10:00.266 A:middle
-Choose an English display name.
 
 00:10:01.076 --> 00:10:02.106 A:middle
 Call it Fastest Time.
@@ -927,10 +899,6 @@ click this button right here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.786 --> 00:11:00.656 A:middle
-In order to do that, we
-click this button right here.
 
 00:11:00.656 --> 00:11:05.446 A:middle
 And this brings up a list
@@ -1021,9 +989,6 @@ but this one's not his fault.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.156 --> 00:12:00.346 A:middle
-but this one's not his fault.
-
 00:12:00.866 --> 00:12:02.326 A:middle
 This one's due to the
 fact that we had a bug
@@ -1113,9 +1078,6 @@ It's on the App Store.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.826 --> 00:13:00.016 A:middle
-It's on the App Store.
 
 00:13:00.796 --> 00:13:03.726 A:middle
 It's doing very well and now
@@ -1297,10 +1259,6 @@ transfer contract on their end.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.716 --> 00:15:00.456 A:middle
-as they will need to sign an app
-transfer contract on their end.
-
 00:15:01.926 --> 00:15:04.186 A:middle
 Once they do that, we begin
 to process the app transfer.
@@ -1477,10 +1435,6 @@ phone number, email,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:57.336 --> 00:17:00.106 A:middle
-about the app: Name,
-phone number, email,
-
 00:17:00.206 --> 00:17:01.446 A:middle
 those fields you see
 in iTunes Connect.
@@ -1568,9 +1522,6 @@ That is App Transfer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:59.056 --> 00:18:00.486 A:middle
-That is App Transfer.
 
 00:18:01.056 --> 00:18:03.096 A:middle
 It's available today,
@@ -1664,10 +1615,6 @@ gain, you'll be able to reinvest
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:56.326 --> 00:19:00.316 A:middle
-And the time savings that you
-gain, you'll be able to reinvest
-
 00:19:00.436 --> 00:19:03.136 A:middle
 into making your
 apps even better.
@@ -1748,10 +1695,6 @@ most effectively
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.816 --> 00:20:02.096 A:middle
-so in order to appeal
-most effectively
-
 00:20:02.096 --> 00:20:05.286 A:middle
 to your customers worldwide, it
 pays to provide that information
@@ -1830,10 +1773,6 @@ the Web GUI effectively.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.116 --> 00:21:01.716 A:middle
-because you can't script
-the Web GUI effectively.
-
 00:21:04.016 --> 00:21:06.236 A:middle
 You've been telling us about
 it; you've been filing a lot
@@ -1910,10 +1849,6 @@ current metadata for your app.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.386 --> 00:22:01.636 A:middle
-up the current state, the
-current metadata for your app.
-
 00:22:02.876 --> 00:22:05.226 A:middle
 When you do that, it gets
 downloaded as a package,
@@ -1986,10 +1921,6 @@ overall: download the package;
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:55.406 --> 00:23:00.346 A:middle
-This is the lifecycle, the flow
-overall: download the package;
 
 00:23:00.806 --> 00:23:05.706 A:middle
 modify XML; add screenshots and
@@ -2069,10 +2000,6 @@ app in there, from scratch.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.006 --> 00:24:00.166 A:middle
-with everything about your
-app in there, from scratch.
 
 00:24:00.736 --> 00:24:03.556 A:middle
 You could use this as a skeleton
@@ -2234,10 +2161,6 @@ to be a few minutes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.686 --> 00:26:01.416 A:middle
-You could expect there
-to be a few minutes
-
 00:26:01.416 --> 00:26:04.636 A:middle
 of delay before your data
 is actually reflected
@@ -2398,9 +2321,6 @@ which is the app's SKU.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.396 --> 00:28:00.306 A:middle
-which is the app's SKU.
-
 00:28:01.056 --> 00:28:04.276 A:middle
 And within it the metadata.
 
@@ -2485,10 +2405,6 @@ you have to identify,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.426 --> 00:29:02.596 A:middle
-And in the software section,
-you have to identify,
-
 00:29:02.596 --> 00:29:03.736 A:middle
 well, what app is it for?
 
@@ -2562,10 +2478,6 @@ locale element
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.626 --> 00:30:00.866 A:middle
-In the feed, that's
-locale element
 
 00:30:01.376 --> 00:30:04.306 A:middle
 with the language
@@ -2723,10 +2635,6 @@ entire section.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.686 --> 00:32:00.286 A:middle
-please supply the
-entire section.
-
 00:32:01.076 --> 00:32:02.676 A:middle
 Here's why.
 
@@ -2805,10 +2713,6 @@ corresponds to iTunes Connect,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:57.426 --> 00:33:01.826 A:middle
-What you'll see there
-corresponds to iTunes Connect,
-
 00:33:01.826 --> 00:33:06.606 A:middle
 in that most of the settings are
 applicable worldwide, globally.
@@ -2884,10 +2788,6 @@ iTunes Connect.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.156 --> 00:34:00.466 A:middle
-same concept as in
-iTunes Connect.
 
 00:34:00.466 --> 00:34:02.646 A:middle
 And the tier end
@@ -2969,10 +2869,6 @@ available for sale there or not,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.736 --> 00:35:00.006 A:middle
-to state whether your app is
-available for sale there or not,
 
 00:35:00.006 --> 00:35:01.756 A:middle
 and there are two
@@ -3064,10 +2960,6 @@ that territory settings.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:56.656 --> 00:36:00.346 A:middle
-So, two ways of going about
-that territory settings.
-
 00:36:01.576 --> 00:36:03.496 A:middle
 So, these were rights
 and pricing for your app.
@@ -3154,10 +3046,6 @@ to host it and provide it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.546 --> 00:37:00.596 A:middle
-that you would like Apple
-to host it and provide it
 
 00:37:00.596 --> 00:37:06.526 A:middle
 as an asset in the
@@ -3333,10 +3221,6 @@ output for each report type
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:57.846 --> 00:39:01.756 A:middle
-and you get a status
-output for each report type
-
 00:39:01.756 --> 00:39:02.706 A:middle
 that you've requested.
 
@@ -3487,10 +3371,6 @@ they suit your processes.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.486 --> 00:41:03.386 A:middle
-They suit your flows;
-they suit your processes.
 
 00:41:04.026 --> 00:41:07.466 A:middle
 What we're providing is the
@@ -3657,10 +3537,6 @@ and because this is all meant
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.836 --> 00:43:05.316 A:middle
-So, we'll invoke a script,
-and because this is all meant
-
 00:43:05.316 --> 00:43:08.646 A:middle
 to show case command line
 ways of automating your stuff,
@@ -3751,9 +3627,6 @@ and PASSWORD, uppercase.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.126 --> 00:44:00.126 A:middle
-and PASSWORD, uppercase.
-
 00:44:01.306 --> 00:44:03.986 A:middle
 And finally, the "destination"
 parameter tells Transporter
@@ -3832,10 +3705,6 @@ identifiers are provided to you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.446 --> 00:45:02.216 A:middle
-you get the metadata and these
-identifiers are provided to you.
 
 00:45:02.856 --> 00:45:04.346 A:middle
 When you're ready to
@@ -3922,10 +3791,6 @@ document is ...
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.606 --> 00:46:00.286 A:middle
-for opening a CSV
-document is ...
-
 00:46:01.106 --> 00:46:06.686 A:middle
 Numbers. So, we hit return and
 open the document in Numbers.
@@ -4006,10 +3871,6 @@ in the United States.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.906 --> 00:47:02.096 A:middle
-and it's available only
-in the United States.
-
 00:47:03.096 --> 00:47:06.986 A:middle
 So, this is the data we saw on
 iTunes Connect, we were able
@@ -4086,10 +3947,6 @@ we looking at here?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.066 --> 00:48:02.476 A:middle
-Alright, so what are
-we looking at here?
-
 00:48:02.716 --> 00:48:04.816 A:middle
 It's practically, the same
 document we saw earlier.
@@ -4163,10 +4020,6 @@ upload it to iTunes Connect.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.306 --> 00:49:00.536 A:middle
-transform it to XML and then
-upload it to iTunes Connect.
 
 00:49:01.576 --> 00:49:05.826 A:middle
 I invoke a script called
@@ -4259,10 +4112,6 @@ validations.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.226 --> 00:50:00.476 A:middle
-we do some additional
-validations.
-
 00:50:01.286 --> 00:50:05.056 A:middle
 In this case, it turns
 out, version 2.0,
@@ -4340,9 +4189,6 @@ But we're not done yet.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:59.236 --> 00:51:00.406 A:middle
-But we're not done yet.
 
 00:51:01.866 --> 00:51:04.356 A:middle
 The upload is done, but,
@@ -4596,10 +4442,6 @@ providing a demo account,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:57.446 --> 00:54:01.506 A:middle
-On the metadata side, if you're
-providing a demo account,
 
 00:54:01.506 --> 00:54:03.236 A:middle
 make sure it's full

--- a/2013/307.srt
+++ b/2013/307.srt
@@ -82,10 +82,6 @@ online you might want to pause
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.966 --> 00:01:01.996 A:middle
-If you're watching this
-online you might want to pause
-
 00:01:01.996 --> 00:01:03.646 A:middle
 and go back to last year's
 video, which is going
@@ -180,10 +176,6 @@ provide for a period of time
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.686 --> 00:02:02.146 A:middle
-that your application
-provide for a period of time
-
 00:02:02.316 --> 00:02:04.356 A:middle
 and they'll manually
 launch their application
@@ -271,10 +263,6 @@ specifying NS Location usage
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.276 --> 00:03:00.776 A:middle
-These goes beyond just
-specifying NS Location usage
 
 00:03:00.776 --> 00:03:02.406 A:middle
 description key inside
@@ -371,10 +359,6 @@ fetching proactively understand
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.416 --> 00:04:00.586 A:middle
-And especially when you're
-fetching proactively understand
 
 00:04:00.586 --> 00:04:02.726 A:middle
 that the location that
@@ -559,10 +543,6 @@ however, it's possible
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.916 --> 00:06:02.656 A:middle
-With these changes
-however, it's possible
-
 00:06:02.656 --> 00:06:05.146 A:middle
 that the user could
 tell you that hey,
@@ -649,10 +629,6 @@ and this is restricted.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.966 --> 00:07:02.656 A:middle
-Now, there's one other option
-and this is restricted.
-
 00:07:03.086 --> 00:07:05.276 A:middle
 And this is if parental controls
 
@@ -738,9 +714,6 @@ As many of you already know
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.236 --> 00:08:00.366 A:middle
-As many of you already know
 
 00:08:00.366 --> 00:08:02.646 A:middle
 because we've gotten many
@@ -835,10 +808,6 @@ to a freeway if you tell us
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.456 --> 00:09:00.966 A:middle
-and less likely to snap you
-to a freeway if you tell us
-
 00:09:00.966 --> 00:09:02.046 A:middle
 that you're a fitness
 application.
@@ -922,10 +891,6 @@ consumed by the chip itself,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.666 --> 00:10:00.716 A:middle
-Beyond just the battery that's
-consumed by the chip itself,
-
 00:10:01.596 --> 00:10:03.006 A:middle
 the phone stays awake.
 
@@ -1007,10 +972,6 @@ fitness application looks like.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.746 --> 00:11:02.306 A:middle
-up with what an idealized
-fitness application looks like.
 
 00:11:03.106 --> 00:11:06.596 A:middle
 And so for us, and we model this
@@ -1094,9 +1055,6 @@ So, if we could do this
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.476 --> 00:12:01.126 A:middle
-So, if we could do this
 
 00:12:01.396 --> 00:12:04.866 A:middle
 and if we could defer location
@@ -1192,10 +1150,6 @@ locationManager
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.966 --> 00:13:02.276 A:middle
-Now if you tell your
-locationManager
-
 00:13:02.676 --> 00:13:05.206 A:middle
 that I'm allowing you to
 defer location updates
@@ -1288,10 +1242,6 @@ that you could run
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.956 --> 00:14:01.576 A:middle
-So, the first error
-that you could run
-
 00:14:01.576 --> 00:14:04.136 A:middle
 into is NotUpdatingLocation.
 
@@ -1370,10 +1320,6 @@ of them is it really beneficial.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.526 --> 00:15:00.406 A:middle
-If you're not interested in most
-of them is it really beneficial.
 
 00:15:00.606 --> 00:15:03.416 A:middle
 So, to use this API
@@ -1467,10 +1413,6 @@ currently updating we give you a
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.126 --> 00:16:03.056 A:middle
-and if this happens while we're
-currently updating we give you a
-
 00:16:03.056 --> 00:16:07.426 A:middle
 callback saying hey we're done
 because you told us we're done.
@@ -1551,10 +1493,6 @@ at the sample
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.936 --> 00:17:00.686 A:middle
-So, if you look back
-at the sample
 
 00:17:00.686 --> 00:17:03.306 A:middle
 that I provided earlier this
@@ -1649,10 +1587,6 @@ save you again spurious errors.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.616 --> 00:18:01.396 A:middle
-or not it's available this will
-save you again spurious errors.
 
 00:18:02.536 --> 00:18:04.696 A:middle
 This can actually happen
@@ -1751,10 +1685,6 @@ reason why we defer location
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.906 --> 00:19:02.416 A:middle
-at the sample code this is the
-reason why we defer location
-
 00:19:02.416 --> 00:19:04.496 A:middle
 updates from within
 the location,
@@ -1851,10 +1781,6 @@ background we'll gladly try
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.516 --> 00:20:03.266 A:middle
-And when you back into the
-background we'll gladly try
-
 00:20:03.356 --> 00:20:06.346 A:middle
 to sleep.
 
@@ -1949,10 +1875,6 @@ actually weren't able
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.476 --> 00:21:01.536 A:middle
-And this is why we
-actually weren't able
-
 00:21:01.536 --> 00:21:02.676 A:middle
 to talk about this last year.
 
@@ -2040,10 +1962,6 @@ then go back to sleep.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.566 --> 00:22:01.216 A:middle
-relevant to me and
-then go back to sleep.
-
 00:22:02.456 --> 00:22:07.126 A:middle
 So, it would be nice if we could
 save that step and allow you
@@ -2123,10 +2041,6 @@ temporary reminder saying hey,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.016 --> 00:23:00.826 A:middle
-Let's say you want a
-temporary reminder saying hey,
 
 00:23:01.056 --> 00:23:01.946 A:middle
 remember your car keys.
@@ -2297,10 +2211,6 @@ happens when your--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.636 --> 00:25:02.896 A:middle
-And usually this
-happens when your--
-
 00:25:03.046 --> 00:25:05.866 A:middle
 you've just installed the fence
 and so we haven't had a chance
@@ -2393,10 +2303,6 @@ couple of seconds we're going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.026 --> 00:26:02.256 A:middle
-and outside the fence every
-couple of seconds we're going
 
 00:26:02.256 --> 00:26:03.466 A:middle
 to coalesce those updates
@@ -2491,10 +2397,6 @@ know something about iOS
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.826 --> 00:27:01.646 A:middle
-It helps that I actually
-know something about iOS
-
 00:27:01.646 --> 00:27:04.426 A:middle
 and I can familiar with
 this so it's not that hard.
@@ -2588,10 +2490,6 @@ this is both tedious
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.216 --> 00:28:01.466 A:middle
-and quite frankly
-this is both tedious
-
 00:28:01.866 --> 00:28:04.486 A:middle
 and at some point we hit a wall
 and we can't actually monitor
@@ -2678,10 +2576,6 @@ on their phone to pick up
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.226 --> 00:29:01.936 A:middle
-and for your application
-on their phone to pick up
-
 00:29:02.336 --> 00:29:04.316 A:middle
 and give them an
 immersive experience.
@@ -2749,10 +2643,6 @@ based on that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.356 --> 00:30:00.016 A:middle
-and change its behaviors
-based on that.
 
 00:30:01.256 --> 00:30:02.706 A:middle
 And similarly when
@@ -2842,10 +2732,6 @@ maliciously copy my identifier
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.026 --> 00:31:02.186 A:middle
-Now obviously somebody could
-maliciously copy my identifier
-
 00:31:02.686 --> 00:31:07.196 A:middle
 but in general this is a unique
 way for me to see my stores.
@@ -2929,10 +2815,6 @@ identifies it to your instance
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.826 --> 00:32:02.806 A:middle
-This identifier is what uniquely
-identifies it to your instance
 
 00:32:02.806 --> 00:32:05.306 A:middle
 of core location such
@@ -3021,9 +2903,6 @@ that my phone starts vibrating
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.576 --> 00:33:00.926 A:middle
-that my phone starts vibrating
 
 00:33:00.926 --> 00:33:02.436 A:middle
 because I go by Jay's
@@ -3117,10 +2996,6 @@ leave the notification
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.216 --> 00:34:00.796 A:middle
-And we're going to
-leave the notification
 
 00:34:01.136 --> 00:34:03.976 A:middle
 on exit around in a second.
@@ -3221,10 +3096,6 @@ good idea to then--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.126 --> 00:35:00.506 A:middle
-And it I might be a
-good idea to then--
 
 00:35:00.506 --> 00:35:03.296 A:middle
 track when you leave the
@@ -3328,10 +3199,6 @@ cash register and it's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.396 --> 00:36:01.936 A:middle
-to know that I'm at the
-cash register and it's going
-
 00:36:01.936 --> 00:36:05.286 A:middle
 to present me a notification
 saying, hey now's a good time
@@ -3418,10 +3285,6 @@ store more broadly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.586 --> 00:37:00.176 A:middle
-and not just the
-store more broadly.
-
 00:37:01.256 --> 00:37:04.086 A:middle
 So, going back to my region
 monitoring example when I know
@@ -3497,10 +3360,6 @@ Jay's Donut Shop there's only
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.996 --> 00:38:00.516 A:middle
-And more importantly in
-Jay's Donut Shop there's only
 
 00:38:00.516 --> 00:38:00.976 A:middle
 one anyway.
@@ -3587,10 +3446,6 @@ beacon that matches it,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.156 --> 00:39:00.096 A:middle
-And when we find the
-beacon that matches it,
 
 00:39:00.096 --> 00:39:01.476 A:middle
 this is the beacon
@@ -3685,9 +3540,6 @@ where the store was--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.716 --> 00:40:00.816 A:middle
-where the store was--
-
 00:40:01.026 --> 00:40:03.066 A:middle
 which store was involved
 in the purchase,
@@ -3779,10 +3631,6 @@ corresponds with apple fritter.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.396 --> 00:41:00.236 A:middle
-and say hey look this number
-corresponds with apple fritter.
 
 00:41:00.526 --> 00:41:01.976 A:middle
 Tell the user that if you're
@@ -3876,10 +3724,6 @@ menswear section they could
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.866 --> 00:42:01.126 A:middle
-Or if they walk into the
-menswear section they could
-
 00:42:01.126 --> 00:42:03.356 A:middle
 realize Father's Day
 is coming up in a week.
@@ -3965,10 +3809,6 @@ with than route names.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.446 --> 00:43:00.886 A:middle
-sometimes easier to deal
-with than route names.
 
 00:43:01.756 --> 00:43:04.066 A:middle
 But there's an added
@@ -4058,10 +3898,6 @@ major value and minor value
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.836 --> 00:44:02.126 A:middle
-with the same proximity uuid
-major value and minor value
 
 00:44:02.126 --> 00:44:06.406 A:middle
 that you'd like to scan for,
@@ -4155,10 +3991,6 @@ into the CLRegion API.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.546 --> 00:45:04.736 A:middle
-So, tying beacons back
-into the CLRegion API.
-
 00:45:05.716 --> 00:45:08.056 A:middle
 Previously we had
 a CLRegionObject.
@@ -4238,10 +4070,6 @@ If you're targeting 6 and
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.156 --> 00:46:01.416 A:middle
-If you're targeting 6 and
-7 and you need to be able
 
 00:46:01.416 --> 00:46:03.206 A:middle
 to be backwards compatible
@@ -4325,10 +4153,6 @@ is kind of the upper bound
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:55.186 --> 00:47:00.196 A:middle
-and 40 percent battery savings
-is kind of the upper bound
 
 00:47:00.196 --> 00:47:01.746 A:middle
 of what you can achieve
@@ -4430,10 +4254,6 @@ check the Air Locate project
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.276 --> 00:48:02.576 A:middle
-of iBeacons then go ahead and
-check the Air Locate project
 
 00:48:02.576 --> 00:48:05.666 A:middle
 and also review the

--- a/2013/308.srt
+++ b/2013/308.srt
@@ -137,10 +137,6 @@ about validating these receipts
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:57.926 --> 00:02:00.876 A:middle
-as to how you actually go
-about validating these receipts
-
 00:02:01.166 --> 00:02:04.626 A:middle
 and getting the purchase
 information out of them.
@@ -223,10 +219,6 @@ Store, the receipt is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.556 --> 00:03:02.176 A:middle
-Likewise in the App
-Store, the receipt is
-
 00:03:02.176 --> 00:03:03.326 A:middle
 that digital equivalent.
 
@@ -303,10 +295,6 @@ know exactly what the user has
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.826 --> 00:04:01.836 A:middle
-Using the receipt is how you
-know exactly what the user has
 
 00:04:01.896 --> 00:04:02.376 A:middle
 paid for.
@@ -472,10 +460,6 @@ paid for your app.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.966 --> 00:06:01.476 A:middle
-that have already
-paid for your app.
 
 00:06:04.726 --> 00:06:04.946 A:middle
 [Applause] Right.
@@ -643,10 +627,6 @@ out there that need
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.956 --> 00:08:00.446 A:middle
-if you have servers
-out there that need
 
 00:08:00.446 --> 00:08:02.186 A:middle
 to validate these
@@ -894,10 +874,6 @@ unlock features and content
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.566 --> 00:11:01.886 A:middle
-you know then not too
-unlock features and content
-
 00:11:02.256 --> 00:11:05.246 A:middle
 until they make the purchase
 and you verify that transaction
@@ -974,10 +950,6 @@ to work in iOS 7.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:56.976 --> 00:12:00.296 A:middle
-on iOS 6 will continue
-to work in iOS 7.
-
 00:12:00.806 --> 00:12:05.386 A:middle
 iOS 7 is binary compatible with
 the receipt checking methods
@@ -1046,10 +1018,6 @@ if I lose any of you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:54.746 --> 00:13:00.046 A:middle
-to the iOS 7 APIs, and
-if I lose any of you
 
 00:13:00.046 --> 00:13:02.916 A:middle
 when I said Weak
@@ -1211,10 +1179,6 @@ file that has purchased data
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:56.696 --> 00:15:00.096 A:middle
-of it, and it's a single
-file that has purchased data
-
 00:15:00.096 --> 00:15:01.916 A:middle
 and signatures to
 check authenticity.
@@ -1299,10 +1263,6 @@ a receipt that's not really
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.816 --> 00:16:01.276 A:middle
-No one's tried to doctor up
-a receipt that's not really
-
 00:16:01.276 --> 00:16:02.426 A:middle
 for an app that they purchased.
 
@@ -1385,9 +1345,6 @@ for us on both iOS and OS X.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.306 --> 00:17:00.336 A:middle
-for us on both iOS and OS X.
-
 00:17:00.836 --> 00:17:02.636 A:middle
 It keeps the receipt
 file there for you.
@@ -1468,10 +1425,6 @@ verify this signature.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.716 --> 00:18:01.736 A:middle
-of deciding how you
-verify this signature.
-
 00:18:02.956 --> 00:18:06.626 A:middle
 At one end of the extreme,
 there are third party libraries
@@ -1550,10 +1503,6 @@ do the verification for us,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.976 --> 00:19:02.086 A:middle
-and if we used Open SSL to
-do the verification for us,
 
 00:19:02.576 --> 00:19:03.456 A:middle
 here's what it would look like.
@@ -1635,9 +1584,6 @@ We check the result.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.986 --> 00:20:00.856 A:middle
-We check the result.
-
 00:20:01.886 --> 00:20:04.716 A:middle
 If result's one, the
 receipt is valid.
@@ -1706,10 +1652,6 @@ standard called ASN.1.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.736 --> 00:21:00.276 A:middle
-We encode these using a
-standard called ASN.1.
-
 00:21:01.286 --> 00:21:04.066 A:middle
 ASN.1 again, I know I sound like
 I'm repeating myself, but again,
@@ -1776,10 +1718,6 @@ decision point as a developer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.156 --> 00:22:01.346 A:middle
-of ASN.1, and here's your second
-decision point as a developer.
 
 00:22:02.366 --> 00:22:05.216 A:middle
 You need to decide what
@@ -1858,10 +1796,6 @@ ground of finding examples
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.426 --> 00:23:01.426 A:middle
-and all the middle
-ground of finding examples
 
 00:23:01.426 --> 00:23:02.636 A:middle
 and making informed decisions
@@ -1944,10 +1878,6 @@ itself, the actual payload
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:57.216 --> 00:24:00.326 A:middle
-takes in my receipt bytes
-itself, the actual payload
-
 00:24:00.326 --> 00:24:03.456 A:middle
 of data we got, and it gives
 me a data structure back
@@ -2028,10 +1958,6 @@ that it's the bundle version.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.746 --> 00:25:02.056 A:middle
-We'd look for Type 3 and know
-that it's the bundle version.
 
 00:25:02.856 --> 00:25:05.746 A:middle
 We can take these and compare
@@ -2116,10 +2042,6 @@ bit of information.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.306 --> 00:26:00.946 A:middle
-So that's the first
-bit of information.
-
 00:26:01.406 --> 00:26:05.576 A:middle
 A sequence of bytes that
 uniquely identifies this device
@@ -2201,10 +2123,6 @@ successfully confirmed it's
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.086 --> 00:27:01.256 A:middle
-and it matches, you've
-successfully confirmed it's
-
 00:27:01.256 --> 00:27:03.436 A:middle
 for your app on this device.
 
@@ -2280,10 +2198,6 @@ attributes within the receipt
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.546 --> 00:28:00.846 A:middle
-When you're iterating over those
-attributes within the receipt
 
 00:28:00.916 --> 00:28:02.776 A:middle
 and you've got those
@@ -2362,10 +2276,6 @@ Firstly, it's a PKCS
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:59.856 --> 00:29:02.916 A:middle
-Firstly, it's a PKCS
-#7 container.
 
 00:29:03.606 --> 00:29:06.316 A:middle
 I guarantee if you Google
@@ -2517,10 +2427,6 @@ you know, Game Levels, assets,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:56.636 --> 00:31:00.136 A:middle
-that issue these -- these,
-you know, Game Levels, assets,
-
 00:31:00.306 --> 00:31:03.576 A:middle
 contents, periodicals,
 whatever it might be,
@@ -2612,10 +2518,6 @@ is authentic and unaltered,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.306 --> 00:32:00.416 A:middle
-confirm that the receipt
-is authentic and unaltered,
-
 00:32:01.126 --> 00:32:04.536 A:middle
 and we return back to you a
 JSON code, coded block of data,
@@ -2691,10 +2593,6 @@ that at the device level.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.886 --> 00:33:01.776 A:middle
-You still want to do
-that at the device level.
-
 00:33:06.836 --> 00:33:10.316 A:middle
 So now let's look at some
 platform specific implementation
@@ -2769,9 +2667,6 @@ and most up-to-date receipt.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.016 --> 00:34:00.186 A:middle
-and most up-to-date receipt.
 
 00:34:00.696 --> 00:34:04.996 A:middle
 Use what's there first,
@@ -2861,10 +2756,6 @@ exists with a Code 173.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.706 --> 00:35:03.286 A:middle
-to another, then your app
-exists with a Code 173.
-
 00:35:03.836 --> 00:35:07.666 A:middle
 This special Exit Code
 tells OS X in the App Store
@@ -2938,10 +2829,6 @@ through an In-App Purchase.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.896 --> 00:36:02.866 A:middle
-to purchase 500 gallons of gas
-through an In-App Purchase.
 
 00:36:03.806 --> 00:36:07.166 A:middle
 You would expect that that 500
@@ -3021,10 +2908,6 @@ state you need.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.996 --> 00:37:01.466 A:middle
-and then set whatever
-state you need.
 
 00:37:02.966 --> 00:37:04.366 A:middle
 Now non-consumables
@@ -3181,10 +3064,6 @@ make the app read only,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.216 --> 00:39:00.926 A:middle
-You might decide to
-make the app read only,
-
 00:39:01.126 --> 00:39:03.456 A:middle
 block parts of the UI,
 whatever you want to do,
@@ -3276,10 +3155,6 @@ always just Exit 173.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:56.836 --> 00:40:00.666 A:middle
-let us drive the UI,
-always just Exit 173.
-
 00:40:01.516 --> 00:40:05.936 A:middle
 [ Pause ]
 
@@ -3352,10 +3227,6 @@ transactions, get receipts,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.096 --> 00:41:02.416 A:middle
-that you can use to make
-transactions, get receipts,
 
 00:41:02.416 --> 00:41:05.816 A:middle
 use In-App Purchases, without
@@ -3520,10 +3391,6 @@ with your production account,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.856 --> 00:43:02.206 A:middle
-sign-out of the App Store
-with your production account,
-
 00:43:03.236 --> 00:43:05.436 A:middle
 because that production account
 that you use, your Apple ID
@@ -3611,10 +3478,6 @@ testing your production site,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.856 --> 00:44:03.966 A:middle
-The app reviewers are actually
-testing your production site,
-
 00:44:04.236 --> 00:44:05.876 A:middle
 ready to go into
 the store binary,
@@ -3691,10 +3554,6 @@ are issuing content.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.876 --> 00:45:00.316 A:middle
-for servers that
-are issuing content.
 
 00:45:01.136 --> 00:45:02.746 A:middle
 But choose a model
@@ -3777,10 +3636,6 @@ your test environment accounts.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.146 --> 00:46:03.536 A:middle
-to be development signed, using
-your test environment accounts.
 
 00:46:05.456 --> 00:46:06.756 A:middle
 Now for more information,

--- a/2013/309.srt
+++ b/2013/309.srt
@@ -72,10 +72,6 @@ to take static map snapshots.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.986 --> 00:01:03.706 A:middle
-in Maps we added the ability
-to take static map snapshots.
-
 00:01:06.496 --> 00:01:09.226 A:middle
 Now we had hundreds of millions
 of users using the Maps.app
@@ -156,10 +152,6 @@ use the Snapshot API
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.666 --> 00:02:01.466 A:middle
-about how you can
-use the Snapshot API
 
 00:02:01.466 --> 00:02:04.596 A:middle
 that we've introduced to create
@@ -331,10 +323,6 @@ recompile with iOS 7 SDK.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.856 --> 00:04:01.396 A:middle
-The first one is just
-recompile with iOS 7 SDK.
-
 00:04:01.396 --> 00:04:04.846 A:middle
 You're going to find that
 pitching and rotation just work.
@@ -432,10 +420,6 @@ that's looking straight
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.166 --> 00:05:00.676 A:middle
-It results in a 2D map
-that's looking straight
-
 00:05:00.676 --> 00:05:02.546 A:middle
 down at the map with
 no rotation.
@@ -524,10 +508,6 @@ you can read from
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.706 --> 00:06:02.756 A:middle
-Now the same two APIs
-you can read from
 
 00:06:02.756 --> 00:06:03.846 A:middle
 and they'll turn a rectangle
@@ -630,10 +610,6 @@ data on the map.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.786 --> 00:07:00.926 A:middle
-to show a lot of
-data on the map.
-
 00:07:01.336 --> 00:07:04.086 A:middle
 So you should continue
 using this API to do that.
@@ -718,10 +694,6 @@ using will never be distorted
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.136 --> 00:08:01.296 A:middle
-To the artwork that you're
-using will never be distorted
 
 00:08:01.296 --> 00:08:03.636 A:middle
 and you don't have to
@@ -813,10 +785,6 @@ changes to overlays.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.406 --> 00:09:00.046 A:middle
-There's a few small
-changes to overlays.
-
 00:09:01.726 --> 00:09:04.146 A:middle
 Overlays now take the
 shortest path across the maps.
@@ -904,10 +872,6 @@ pins going to drop.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.516 --> 00:10:00.416 A:middle
-on the map a purple
-pins going to drop.
 
 00:10:01.026 --> 00:10:02.716 A:middle
 And that's really
@@ -1007,10 +971,6 @@ involved check for CGRectNull.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.006 --> 00:11:00.636 A:middle
-And if there's a rectangle
-involved check for CGRectNull.
-
 00:11:01.036 --> 00:11:03.436 A:middle
 It's an indication that we
 just couldn't do the conversion
@@ -1097,9 +1057,6 @@ So that's the existing API.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:54.966 --> 00:12:01.006 A:middle
-So that's the existing API.
 
 00:12:01.006 --> 00:12:05.626 A:middle
 Now I want to talk about a new
@@ -1276,10 +1233,6 @@ code of the four properties
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.506 --> 00:14:05.226 A:middle
-So here's the interfacing
-code of the four properties
-
 00:14:05.226 --> 00:14:06.676 A:middle
 that I just described;
 center coordinate,
@@ -1374,10 +1327,6 @@ coordinate give it the
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.916 --> 00:15:00.956 A:middle
-Camera looking at center
-coordinate give it the
-
 00:15:00.956 --> 00:15:01.426 A:middle
 ground point.
 
@@ -1469,10 +1418,6 @@ one line of code again.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:56.996 --> 00:16:00.116 A:middle
-And then to restore it its
-one line of code again.
 
 00:16:01.276 --> 00:16:03.646 A:middle
 Use unarchiveObjectFromFile:
@@ -1574,10 +1519,6 @@ want just get the description
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.426 --> 00:17:01.496 A:middle
-and it's not showing what you
-want just get the description
-
 00:17:01.496 --> 00:17:02.436 A:middle
 from the camera and it's going
 
@@ -1665,10 +1606,6 @@ to 180 degrees.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.416 --> 00:18:01.166 A:middle
-it's getting closer
-to 180 degrees.
-
 00:18:01.166 --> 00:18:04.486 A:middle
 Now I'm going to use
 these zoom controls here.
@@ -1752,10 +1689,6 @@ called Golden Gate Park,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.166 --> 00:19:00.966 A:middle
-Let's go to a park nearby
-called Golden Gate Park,
 
 00:19:02.686 --> 00:19:04.746 A:middle
 search for that and great.
@@ -1852,10 +1785,6 @@ add a little bit of pitch too
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.256 --> 00:20:00.266 A:middle
-And you know what, I want to
-add a little bit of pitch too
-
 00:20:00.266 --> 00:20:03.116 A:middle
 because I want the user to
 see 3D buildings and want them
@@ -1940,10 +1869,6 @@ on our platform --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.246 --> 00:21:01.086 A:middle
-in animation APIs
-on our platform --
 
 00:21:01.086 --> 00:21:03.416 A:middle
 on OS X that's
@@ -2044,9 +1969,6 @@ I know it will.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.706 --> 00:22:00.236 A:middle
-I know it will.
-
 00:22:00.916 --> 00:22:02.326 A:middle
 Don't use that completion
 handler.
@@ -2137,10 +2059,6 @@ a coordinate and we just want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.736 --> 00:23:00.416 A:middle
-and that search result lives at
-a coordinate and we just want
 
 00:23:00.416 --> 00:23:01.396 A:middle
 to go look at that coordinate.
@@ -2398,10 +2316,6 @@ thing to figure
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.976 --> 00:26:03.476 A:middle
-All right, the first
-thing to figure
-
 00:26:03.476 --> 00:26:05.646 A:middle
 out is how do we build a filter?
 
@@ -2493,10 +2407,6 @@ console, switch back to our app.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.356 --> 00:27:05.746 A:middle
-And let's go bring up our
-console, switch back to our app.
-
 00:27:06.266 --> 00:27:08.396 A:middle
 Let's go to Golden Gate Park.
 
@@ -2585,10 +2495,6 @@ out how we can filter this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.606 --> 00:28:01.316 A:middle
-So let's go back and figure
-out how we can filter this.
 
 00:28:01.316 --> 00:28:05.626 A:middle
 well right now our animation is
@@ -2684,10 +2590,6 @@ point just like we were using
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.526 --> 00:29:01.646 A:middle
-Now we have a start and end
-point just like we were using
-
 00:29:01.646 --> 00:29:03.146 A:middle
 to inspect the distance
 we were traveling.
@@ -2774,9 +2676,6 @@ to pan over to our destination.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.906 --> 00:30:00.386 A:middle
-to pan over to our destination.
 
 00:30:00.386 --> 00:30:02.206 A:middle
 So now I have a second
@@ -2874,10 +2773,6 @@ and I think I want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.166 --> 00:31:00.386 A:middle
-that pretty long
-and I think I want
-
 00:31:00.386 --> 00:31:02.796 A:middle
 to use our multi-stage
 transition
@@ -2958,9 +2853,6 @@ That's really far away.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.616 --> 00:32:00.466 A:middle
-That's really far away.
 
 00:32:03.126 --> 00:32:04.876 A:middle
 Boom, all over the
@@ -3060,9 +2952,6 @@ in animation framework.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.746 --> 00:33:00.616 A:middle
-in animation framework.
-
 00:33:01.116 --> 00:33:04.596 A:middle
 And lastly we saw
 that it's pretty clear
@@ -3147,10 +3036,6 @@ doing the same thing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.976 --> 00:34:00.956 A:middle
-and in iOS 7 we're
-doing the same thing.
-
 00:34:00.956 --> 00:34:02.996 A:middle
 We've introduced rotate
 enabled and pitch enabled
@@ -3233,9 +3118,6 @@ doesn't make sense.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.756 --> 00:35:00.626 A:middle
-doesn't make sense.
 
 00:35:01.006 --> 00:35:04.196 A:middle
 You may have seen an app like
@@ -3321,10 +3203,6 @@ a few properties on it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.056 --> 00:36:02.936 A:middle
-The options object has
-a few properties on it
 
 00:36:02.936 --> 00:36:03.796 A:middle
 that you need to configure.
@@ -3419,10 +3297,6 @@ a size of 512 points
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.926 --> 00:37:02.346 A:middle
-Here I'm setting it to
-a size of 512 points
 
 00:37:02.346 --> 00:37:04.286 A:middle
 by 512 points, a square image.
@@ -3520,10 +3394,6 @@ something you can show your user
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.636 --> 00:38:01.116 A:middle
-Have a placeholder image or
-something you can show your user
-
 00:38:01.116 --> 00:38:02.606 A:middle
 in case the map wasn't
 able to load.
@@ -3615,9 +3485,6 @@ like you normally would.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.206 --> 00:39:00.196 A:middle
-like you normally would.
 
 00:39:01.056 --> 00:39:02.726 A:middle
 Create a snapshot just
@@ -3725,9 +3592,6 @@ All right, into the differences.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.276 --> 00:40:02.196 A:middle
-All right, into the differences.
 
 00:40:02.676 --> 00:40:05.576 A:middle
 The first step we're doing here
@@ -3918,10 +3782,6 @@ Paris, two coordinates.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.286 --> 00:42:02.486 A:middle
-So I have London, I have
-Paris, two coordinates.
-
 00:42:02.486 --> 00:42:04.756 A:middle
 I also have a little
 helper method I wrote
@@ -4002,10 +3862,6 @@ relatively large.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.446 --> 00:43:00.956 A:middle
-Here is one that is
-relatively large.
 
 00:43:01.136 --> 00:43:04.286 A:middle
 1680 points by 825 points.
@@ -4089,10 +3945,6 @@ property to get the pin image.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.316 --> 00:44:06.976 A:middle
-So here I am using the pin.image
-property to get the pin image.
-
 00:44:08.026 --> 00:44:12.236 A:middle
 Okay. Now I have a pin image
 and I have a map image.
@@ -4165,10 +4017,6 @@ has an offset property
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:57.846 --> 00:45:00.746 A:middle
-MKAnnotationView also
-has an offset property
 
 00:45:01.426 --> 00:45:04.866 A:middle
 and MapKit normally uses this
@@ -4251,10 +4099,6 @@ that the bottom of that pin sits
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:55.666 --> 00:46:00.036 A:middle
-on MKAnnotationView to make sure
-that the bottom of that pin sits
-
 00:46:00.036 --> 00:46:02.606 A:middle
 on the point for
 London and for Paris.
@@ -4330,10 +4174,6 @@ to take a look at it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.256 --> 00:47:00.736 A:middle
-and I just want you
-to take a look at it.
 
 00:47:01.116 --> 00:47:02.266 A:middle
 It's almost exactly the same.
@@ -4489,10 +4329,6 @@ of a table view and then scroll
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:57.486 --> 00:49:00.766 A:middle
-to stick an MKMapView inside
-of a table view and then scroll
-
 00:49:00.766 --> 00:49:03.136 A:middle
 that table view it really
 didn't perform like we liked.
@@ -4575,10 +4411,6 @@ bit to account for that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.566 --> 00:50:04.726 A:middle
-to change your app a little
-bit to account for that.
 
 00:50:04.726 --> 00:50:07.226 A:middle
 Then make sure you
@@ -4672,10 +4504,6 @@ over here today.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:59.906 --> 00:51:01.086 A:middle
-that I couldn't go
-over here today.
 
 00:51:01.466 --> 00:51:03.536 A:middle
 We introduced a ton of

--- a/2013/310.srt
+++ b/2013/310.srt
@@ -91,10 +91,6 @@ find some parallels.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.476 --> 00:01:02.836 A:middle
-about your own apps and
-find some parallels.
-
 00:01:02.836 --> 00:01:04.275 A:middle
 And I know you can
 identify with a lot
@@ -190,10 +186,6 @@ up an order you made
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.276 --> 00:02:00.376 A:middle
-like Genius Bar or pick
-up an order you made
 
 00:02:00.376 --> 00:02:01.946 A:middle
 on the Apple Store
@@ -391,10 +383,6 @@ about a new technology on iOS 7,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:57.906 --> 00:04:00.836 A:middle
-And finally, we're going to talk
-about a new technology on iOS 7,
-
 00:04:00.936 --> 00:04:03.096 A:middle
 iBeacons and that's the
 demo we'll show you.
@@ -500,10 +488,6 @@ discount like 449.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.806 --> 00:05:01.886 A:middle
-you get a partial
-discount like 449.
 
 00:05:02.116 --> 00:05:03.936 A:middle
 And if you're early, maybe
@@ -697,10 +681,6 @@ the app is on the background,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.396 --> 00:07:00.526 A:middle
-So then, on April 15th, maybe
-the app is on the background,
-
 00:07:00.526 --> 00:07:03.556 A:middle
 your phone is on your pocket,
 or whatever that date is,
@@ -796,10 +776,6 @@ inform users and it's dynamic.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.126 --> 00:08:00.706 A:middle
-This is the richer way to
-inform users and it's dynamic.
-
 00:08:00.706 --> 00:08:02.666 A:middle
 You can have those dynamic
 events 'cause your server is
@@ -886,9 +862,6 @@ in case you're wondering.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.456 --> 00:09:00.336 A:middle
-in case you're wondering.
 
 00:09:00.676 --> 00:09:02.246 A:middle
 And it's the red X.
@@ -991,10 +964,6 @@ the value, people don't want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.126 --> 00:10:00.146 A:middle
-Believe me, if you explain
-the value, people don't want
 
 00:10:00.146 --> 00:10:01.036 A:middle
 to think about these things.
@@ -1106,10 +1075,6 @@ is a great way to handle it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.496 --> 00:11:01.906 A:middle
-But if you have many types, this
-is a great way to handle it.
-
 00:11:02.476 --> 00:11:08.236 A:middle
 Why? Because it reduces
 the chance
@@ -1203,10 +1168,6 @@ so you cannot rely on it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.226 --> 00:12:00.296 A:middle
-but they might not use that
-so you cannot rely on it.
 
 00:12:00.726 --> 00:12:04.246 A:middle
 So in this way, maybe in your
@@ -1305,10 +1266,6 @@ and just stop using them.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.466 --> 00:13:01.846 A:middle
-And then you parse the list
-and just stop using them.
-
 00:13:01.986 --> 00:13:03.306 A:middle
 Usually that means
 you delete them
@@ -1404,10 +1361,6 @@ Location, "Hey,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.926 --> 00:14:01.666 A:middle
-And we told iOS Core
-Location, "Hey,
 
 00:14:01.666 --> 00:14:04.556 A:middle
 when John crosses this
@@ -1506,9 +1459,6 @@ Hillary will materialize.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.696 --> 00:15:01.086 A:middle
-Hillary will materialize.
 
 00:15:01.086 --> 00:15:02.186 A:middle
 More importantly, John's
@@ -1622,9 +1572,6 @@ in each line," for example.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.806 --> 00:16:01.016 A:middle
-in each line," for example.
-
 00:16:01.596 --> 00:16:03.376 A:middle
 So, a lot of useful things
 you can do with this.
@@ -1717,10 +1664,6 @@ full so minimize battery drain.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.436 --> 00:17:03.556 A:middle
-We want to keep the battery
-full so minimize battery drain.
 
 00:17:04.286 --> 00:17:05.846 A:middle
 When you're woken
@@ -1821,10 +1764,6 @@ don't need to do anything again.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:59.896 --> 00:18:02.676 A:middle
-or 5 minutes before that, you
-don't need to do anything again.
 
 00:18:02.676 --> 00:18:04.156 A:middle
 You've done the work you
@@ -2031,10 +1970,6 @@ with the Apple Store app,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.376 --> 00:20:00.576 A:middle
-So if you don't have an order
-with the Apple Store app,
-
 00:20:01.016 --> 00:20:02.056 A:middle
 we're not going to
 fence anything
@@ -2133,9 +2068,6 @@ if you need to do this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.056 --> 00:21:00.486 A:middle
-if you need to do this.
-
 00:21:01.046 --> 00:21:03.256 A:middle
 OK, so we've talked
 about, you know,
@@ -2223,10 +2155,6 @@ store, we're going to detect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.226 --> 00:22:02.146 A:middle
-to foreground inside the retail
-store, we're going to detect
 
 00:22:02.206 --> 00:22:03.886 A:middle
 that you're there
@@ -2324,9 +2252,6 @@ The technology behind this,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:58.196 --> 00:23:01.486 A:middle
-The technology behind this,
 
 00:23:01.546 --> 00:23:03.986 A:middle
 this In-Location Mode
@@ -2426,9 +2351,6 @@ and best practices for this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.826 --> 00:24:01.096 A:middle
-and best practices for this.
-
 00:24:02.356 --> 00:24:04.936 A:middle
 The UI is going to depend
 largely on your use case,
@@ -2520,9 +2442,6 @@ when you're in that location.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.506 --> 00:25:02.886 A:middle
-when you're in that location.
 
 00:25:03.006 --> 00:25:05.476 A:middle
 Next up, remember,
@@ -2693,10 +2612,6 @@ and to enrich their experience.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:56.346 --> 00:27:00.036 A:middle
-to welcome the user to an event
-and to enrich their experience.
-
 00:27:00.936 --> 00:27:01.446 A:middle
 What's next?
 
@@ -2783,9 +2698,6 @@ have specific IDs.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.686 --> 00:28:00.596 A:middle
-have specific IDs.
 
 00:28:00.946 --> 00:28:04.226 A:middle
 Your app can tell Core Location,
@@ -2880,10 +2792,6 @@ accuracy.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.066 --> 00:29:00.276 A:middle
-and it's a much tighter
-accuracy.
 
 00:29:00.276 --> 00:29:01.966 A:middle
 And you can know which
@@ -3072,9 +2980,6 @@ Anything like that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.506 --> 00:31:00.806 A:middle
-Anything like that.
-
 00:31:01.556 --> 00:31:04.666 A:middle
 So, pretty powerful stuff
 right at the Mona Lisa.
@@ -3168,10 +3073,6 @@ needs to be in the foreground
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.526 --> 00:32:01.586 A:middle
-But for ranging, your app
-needs to be in the foreground
-
 00:32:01.766 --> 00:32:04.296 A:middle
 or you can do it scan
 on wake which means
@@ -3258,9 +3159,6 @@ You can try it out right now.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.746 --> 00:33:02.076 A:middle
-You can try it out right now.
 
 00:33:02.296 --> 00:33:05.256 A:middle
 Finally, to remind you the big
@@ -3362,10 +3260,6 @@ engineer on his team.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.296 --> 00:34:00.356 A:middle
-And Mathieu Roig is an
-engineer on his team.
-
 00:34:00.536 --> 00:34:03.076 A:middle
 They've actually built this
 Museum app, this demo app
@@ -3455,10 +3349,6 @@ work, so let's take a look.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.676 --> 00:35:00.476 A:middle
-to make this entire thing
-work, so let's take a look.
-
 00:35:01.576 --> 00:35:03.946 A:middle
 The first one is called
 Register Beacon Region.
@@ -3543,10 +3433,6 @@ Beacon Region object using
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.916 --> 00:36:01.806 A:middle
-Next line, you create a CL
-Beacon Region object using
-
 00:36:01.806 --> 00:36:03.676 A:middle
 that UUID you just created.
 
@@ -3628,10 +3514,6 @@ at every startup and have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.336 --> 00:37:01.456 A:middle
-You don't want to do it blindly
-at every startup and have
 
 00:37:01.456 --> 00:37:03.346 A:middle
 that arrow show up
@@ -3720,10 +3602,6 @@ up your app in background
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.056 --> 00:38:00.176 A:middle
-because this will wake
-up your app in background
 
 00:38:00.176 --> 00:38:01.496 A:middle
 when your app is not running.
@@ -3815,10 +3693,6 @@ the middle of a mall.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.476 --> 00:39:00.486 A:middle
-Your restaurant is in
-the middle of a mall.
 
 00:39:01.196 --> 00:39:02.656 A:middle
 It's totally possible
@@ -3913,10 +3787,6 @@ your app is in the background.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.856 --> 00:40:03.886 A:middle
-that be a good citizen when
-your app is in the background.
-
 00:40:04.286 --> 00:40:07.736 A:middle
 Implement a meaningful
 expiration handler block
@@ -3998,10 +3868,6 @@ UILocalNotification object.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.206 --> 00:41:01.666 A:middle
-you create the
-UILocalNotification object.
 
 00:41:02.186 --> 00:41:04.966 A:middle
 You fill in the details using
@@ -4091,10 +3957,6 @@ welcome message to tell me
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.346 --> 00:42:02.086 A:middle
-and I'm expecting a
-welcome message to tell me
-
 00:42:02.086 --> 00:42:03.746 A:middle
 where I should meet
 my tour guide.
@@ -4176,10 +4038,6 @@ entrance of your location, OK.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:56.516 --> 00:43:02.236 A:middle
-So, again, this is at the
-entrance of your location, OK.
-
 00:43:03.016 --> 00:43:05.816 A:middle
 So comparing to the regular
 Geofence where you have today,
@@ -4258,10 +4116,6 @@ signals around me
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.526 --> 00:44:00.726 A:middle
-Please, monitor beacon
-signals around me
 
 00:44:00.726 --> 00:44:02.156 A:middle
 and report them back to me."
@@ -4352,10 +4206,6 @@ tells you, "I found one
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.536 --> 00:45:01.926 A:middle
-This is where iOS
-tells you, "I found one
-
 00:45:01.926 --> 00:45:03.376 A:middle
 or more beacons around you."
 
@@ -4427,10 +4277,6 @@ check the proximity property.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.156 --> 00:46:01.576 A:middle
-casted back to the region and
-check the proximity property.
 
 00:46:02.816 --> 00:46:08.366 A:middle
 And if one is found, I can
@@ -4514,10 +4360,6 @@ actually works on a device.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.136 --> 00:47:00.996 A:middle
-So let me show you how this
-actually works on a device.
 
 00:47:01.536 --> 00:47:03.546 A:middle
 So, I'm running my
@@ -4686,10 +4528,6 @@ pushes Region Monitoring,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.016 --> 00:49:01.566 A:middle
-push calendar events
-pushes Region Monitoring,
-
 00:49:01.566 --> 00:49:03.106 A:middle
 Core Location, and iBeacons.
 
@@ -4793,10 +4631,6 @@ new in Core Location.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.676 --> 00:50:02.296 A:middle
-And then, of course what's
-new in Core Location.
 
 00:50:02.646 --> 00:50:05.116 A:middle
 Here, you can find out a

--- a/2013/400.srt
+++ b/2013/400.srt
@@ -63,10 +63,6 @@ deference to your content.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:55.886 --> 00:01:00.586 A:middle
-In a word, Xcode 5 is about
-deference to your content.
-
 00:01:01.256 --> 00:01:03.576 A:middle
 It's all about bringing
 your code front and center
@@ -145,10 +141,6 @@ from the ID.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:56.206 --> 00:02:00.336 A:middle
-to share links right
-from the ID.
 
 00:02:02.086 --> 00:02:05.636 A:middle
 Now, Xcode 5 intentionally
@@ -235,10 +227,6 @@ checking out your project.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.306 --> 00:03:00.186 A:middle
-with Source Control is by
-checking out your project.
 
 00:03:01.086 --> 00:03:04.866 A:middle
 If you haven't seen it, this is
@@ -414,9 +402,6 @@ of disk to be swapped?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.226 --> 00:05:00.306 A:middle
-of disk to be swapped?
-
 00:05:01.306 --> 00:05:02.316 A:middle
 Hey, now you can do that too.
 
@@ -505,10 +490,6 @@ easy to switch
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.996 --> 00:06:01.496 A:middle
-which makes it super
-easy to switch
-
 00:06:01.496 --> 00:06:02.736 A:middle
 between your different
 identities,
@@ -590,9 +571,6 @@ it's now-it can be easier.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.886 --> 00:07:00.766 A:middle
-it's now-it can be easier.
 
 00:07:00.896 --> 00:07:03.446 A:middle
 It's just a matter of turning
@@ -763,9 +741,6 @@ And Xcode provides-
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.516 --> 00:09:03.576 A:middle
-[ Applause ]
 
 00:09:04.076 --> 00:09:06.326 A:middle
 And Xcode provides a
@@ -1119,10 +1094,6 @@ image is supposed to be named,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.556 --> 00:13:00.806 A:middle
-I can never remember if an
-image is supposed to be named,
-
 00:13:01.616 --> 00:13:05.876 A:middle
 @2x tilde iPhone,
 or tilde iPhone@2x.
@@ -1210,10 +1181,6 @@ right here in my dock.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.346 --> 00:14:01.246 A:middle
-I have an icon for that
-right here in my dock.
-
 00:14:01.246 --> 00:14:07.076 A:middle
 I can just drag it in and drop
 it into place and I'm done.
@@ -1293,9 +1260,6 @@ I see they all look great.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.616 --> 00:15:00.766 A:middle
-I see they all look great.
 
 00:15:01.126 --> 00:15:02.016 A:middle
 But over here at the end,
@@ -1377,9 +1341,6 @@ in the bottom right corner.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.856 --> 00:16:03.046 A:middle
-in the bottom right corner.
 
 00:16:03.196 --> 00:16:05.246 A:middle
 Sure enough, this Segmented
@@ -1470,9 +1431,6 @@ I can enable Auto Layout.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.716 --> 00:17:01.126 A:middle
-I can enable Auto Layout.
 
 00:17:01.126 --> 00:17:03.946 A:middle
 And you can see everything in my
@@ -1569,9 +1527,6 @@ about its horizontal layout.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.736 --> 00:18:00.826 A:middle
-about its horizontal layout.
-
 00:18:01.386 --> 00:18:02.436 A:middle
 I need more constraints.
 
@@ -1651,10 +1606,6 @@ from the Segmented Control
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.176 --> 00:19:01.566 A:middle
-on the left fixing the distance
-from the Segmented Control
 
 00:19:01.566 --> 00:19:02.326 A:middle
 to the edge of the container.
@@ -1818,10 +1769,6 @@ happens when you go
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.586 --> 00:21:00.106 A:middle
-Let's think about what
-happens when you go
 
 00:21:00.106 --> 00:21:01.636 A:middle
 to compile a source
@@ -2010,9 +1957,6 @@ And this database gets shared
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.366 --> 00:23:01.906 A:middle
-And this database gets shared
-
 00:23:01.906 --> 00:23:04.006 A:middle
 across all the files
 in your project.
@@ -2095,9 +2039,6 @@ about symbols you have no idea--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:55.516 --> 00:24:00.606 A:middle
-[ Applause ]
-
 00:24:01.106 --> 00:24:03.606 A:middle
 But the big story with
 modules is simply performance
@@ -2171,10 +2112,6 @@ which are a great way
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.896 --> 00:25:00.236 A:middle
-like inheriting constructors
-which are a great way
 
 00:25:00.236 --> 00:25:01.166 A:middle
 to define away a huge amount
@@ -2263,10 +2200,6 @@ faster, scientific code,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:57.256 --> 00:26:00.366 A:middle
-matrix operations three times
-faster, scientific code,
 
 00:26:00.366 --> 00:26:03.546 A:middle
 compression, it's 50
@@ -2432,10 +2365,6 @@ analyzer has a number
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:57.806 --> 00:28:00.446 A:middle
-It's-- This year, the
-analyzer has a number
-
 00:28:00.446 --> 00:28:01.576 A:middle
 of really great new checks,
 
@@ -2519,10 +2448,6 @@ seen some pretty massive
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:56.746 --> 00:29:00.176 A:middle
-about two years ago and we've
-seen some pretty massive
 
 00:29:00.176 --> 00:29:01.476 A:middle
 adoption in your applications.
@@ -2690,10 +2615,6 @@ to go to the console
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.776 --> 00:31:02.176 A:middle
-You don't even have
-to go to the console
 
 00:31:02.176 --> 00:31:03.136 A:middle
 and hit-- type PO [applause].
@@ -2973,9 +2894,6 @@ for your application as it runs
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.956 --> 00:34:01.486 A:middle
-for your application as it runs
-
 00:34:01.936 --> 00:34:03.956 A:middle
 which is why we can
 enable them all the time
@@ -3070,10 +2988,6 @@ you'll notice
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:56.206 --> 00:35:00.136 A:middle
-And the first thing
-you'll notice
-
 00:35:00.216 --> 00:35:02.966 A:middle
 in Xcode is the new
 beautifully minimal--
@@ -3151,10 +3065,6 @@ when I clicked on that route,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.856 --> 00:36:01.166 A:middle
-Now, you know what, when I--
-when I clicked on that route,
-
 00:36:02.436 --> 00:36:06.226 A:middle
 I actually saw a little bit of
 a spike in the CPU right here.
@@ -3225,10 +3135,6 @@ and create graph path.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.906 --> 00:37:04.556 A:middle
-OK, so here we are
-and create graph path.
-
 00:37:04.556 --> 00:37:10.176 A:middle
 All right, now I'm looking at
 this first line of code here.
@@ -3294,9 +3200,6 @@ OK. So let's click on a route.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.376 --> 00:38:04.196 A:middle
-OK. So let's click on a route.
 
 00:38:04.386 --> 00:38:06.116 A:middle
 OK, that looks much better.
@@ -3374,10 +3277,6 @@ we want to address.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.896 --> 00:39:02.116 A:middle
-So, certainly something
-we want to address.
-
 00:39:02.646 --> 00:39:05.136 A:middle
 This will be a great way to
 get us a nice one star review.
@@ -3452,10 +3351,6 @@ scale and you'll notice now
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:56.136 --> 00:40:01.556 A:middle
-So I can just mouse over image
-scale and you'll notice now
 
 00:40:01.556 --> 00:40:05.876 A:middle
 in Xcode 5, that the datatips
@@ -3535,10 +3430,6 @@ got an attributed string.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:58.836 --> 00:41:01.996 A:middle
-So things like, we've
-got an attributed string.
 
 00:41:02.026 --> 00:41:07.176 A:middle
 You want to see the string and
@@ -3752,10 +3643,6 @@ found, we have fixed,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:56.906 --> 00:44:01.016 A:middle
-we've seen that we have
-found, we have fixed,
-
 00:44:01.636 --> 00:44:04.276 A:middle
 and we have verified
 both the responsiveness
@@ -3840,10 +3727,6 @@ your applications.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.886 --> 00:45:01.596 A:middle
-that you want in
-your applications.
-
 00:45:02.326 --> 00:45:05.176 A:middle
 The new Test Navigator shows
 up just like you'd expect.
@@ -3923,10 +3806,6 @@ the new test framework XCTest.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:57.836 --> 00:46:01.206 A:middle
-into the Xcode family with
-the new test framework XCTest.
-
 00:46:02.536 --> 00:46:05.216 A:middle
 Now XCTest is very similar
 to OC unit in many ways.
@@ -4003,10 +3882,6 @@ doing a build, running tests,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.376 --> 00:47:02.096 A:middle
-that can contain things like
-doing a build, running tests,
 
 00:47:02.096 --> 00:47:04.406 A:middle
 running the analyzer,
@@ -4174,10 +4049,6 @@ for a number of reasons.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.766 --> 00:49:00.606 A:middle
-Well, this is really great
-for a number of reasons.
-
 00:49:00.896 --> 00:49:03.726 A:middle
 First of all, you
 now have a history
@@ -4267,10 +4138,6 @@ all works, I'd like to invite
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.406 --> 00:50:01.516 A:middle
-Now to show you how these
-all works, I'd like to invite
-
 00:50:01.516 --> 00:50:02.976 A:middle
 up Mike Ferris to show
 it to you in action.
@@ -4344,10 +4211,6 @@ new tests, I'll run them all now
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:57.956 --> 00:51:00.806 A:middle
-And since I've added a bunch of
-new tests, I'll run them all now
 
 00:51:00.806 --> 00:51:02.726 A:middle
 to bring my status up to date.
@@ -4514,10 +4377,6 @@ to test cases
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:58.106 --> 00:53:00.226 A:middle
-that gives me access
-to test cases
-
 00:53:00.256 --> 00:53:02.226 A:middle
 that exercise the code
 that I'm working on.
@@ -4585,10 +4444,6 @@ make it really easy for you guys
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:57.266 --> 00:54:01.776 A:middle
-Now, in Xcode 5, we want to
-make it really easy for you guys
 
 00:54:01.776 --> 00:54:03.286 A:middle
 to write great applications
@@ -4661,10 +4516,6 @@ for the last integration,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.006 --> 00:55:00.316 A:middle
-There are issue counts
-for the last integration,
 
 00:55:01.616 --> 00:55:04.326 A:middle
 graphs that show how
@@ -4900,9 +4751,6 @@ and I'll give it a name.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:57:57.896 --> 00:58:02.896 A:middle
-and I'll give it a name.
-
 00:58:03.106 --> 00:58:06.436 A:middle
 I'd like this Bot to run every
 time there are new changes made
@@ -5029,10 +4877,6 @@ both iOS 7 and OS X Mavericks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:59:56.796 --> 01:00:01.186 A:middle
-Xcode includes the SDKs for
-both iOS 7 and OS X Mavericks
 
 01:00:01.596 --> 01:00:04.756 A:middle
 and it runs on either a Mountain

--- a/2013/401.srt
+++ b/2013/401.srt
@@ -71,10 +71,6 @@ going back and forth
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.246 --> 00:01:00.836 A:middle
-a lot of the times you're
-going back and forth
-
 00:01:00.876 --> 00:01:03.286 A:middle
 between various source
 files or UI files.
@@ -169,10 +165,6 @@ here is the navigation area.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.326 --> 00:02:02.126 A:middle
-But briefly, to the left
-here is the navigation area.
-
 00:02:02.876 --> 00:02:06.546 A:middle
 All of that area are
 consists of different panes
@@ -248,10 +240,6 @@ down there at the bottom--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.546 --> 00:03:01.146 A:middle
-we have a filter bar that's
-down there at the bottom--
 
 00:03:01.216 --> 00:03:03.106 A:middle
 it's different, slightly
@@ -344,10 +332,6 @@ focus just on those things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.746 --> 00:04:03.376 A:middle
-The modified filter will
-focus just on those things
-
 00:04:03.376 --> 00:04:05.406 A:middle
 that you modified since the
 last time you checked anything
@@ -419,10 +403,6 @@ UI here to make it a lot easier
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:56.946 --> 00:05:00.916 A:middle
-in Xcode 5 we streamlined the
-UI here to make it a lot easier
 
 00:05:00.916 --> 00:05:02.336 A:middle
 to get at these various things.
@@ -510,10 +490,6 @@ a modernization suggestion,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:56.216 --> 00:06:00.096 A:middle
-And sometimes, if Xcode detects
-a modernization suggestion,
 
 00:06:00.166 --> 00:06:02.496 A:middle
 it will actually tell
@@ -603,10 +579,6 @@ the resolved breakpoints
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.246 --> 00:07:04.026 A:middle
-that this pane shows you
-the resolved breakpoints
-
 00:07:04.026 --> 00:07:05.296 A:middle
 of any symbolic ones you have.
 
@@ -683,10 +655,6 @@ to the file you want.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.966 --> 00:08:02.176 A:middle
-and then quickly go
-to the file you want.
 
 00:08:02.176 --> 00:08:04.686 A:middle
 So even if your hands are on
@@ -784,10 +752,6 @@ the issue mini navigator.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.876 --> 00:09:02.366 A:middle
-And on the-- right here is
-the issue mini navigator.
-
 00:09:02.366 --> 00:09:05.926 A:middle
 If you have any issues at the
 issue pane that are associated
@@ -872,10 +836,6 @@ new in Xcode 5 is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.296 --> 00:10:01.446 A:middle
-And then of course,
-new in Xcode 5 is
-
 00:10:01.486 --> 00:10:05.246 A:middle
 that you can get
 to tests as well.
@@ -945,10 +905,6 @@ if you hit Control 5,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:51.146 --> 00:11:00.026 A:middle
-And then finally, if you--
-if you hit Control 5,
 
 00:11:00.596 --> 00:11:03.576 A:middle
 you get to the menu that
@@ -1036,10 +992,6 @@ editor is a secondary
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.856 --> 00:12:00.946 A:middle
-Now, the assistant
-editor is a secondary
-
 00:12:00.946 --> 00:12:04.156 A:middle
 or it can even be
 tertiary that opens up
@@ -1124,10 +1076,6 @@ get underneath that, that mode.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:57.846 --> 00:13:01.236 A:middle
-about the functionality that you
-get underneath that, that mode.
 
 00:13:02.886 --> 00:13:04.466 A:middle
 Going back to the
@@ -1214,9 +1162,6 @@ And what happens in that case is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.126 --> 00:14:00.606 A:middle
-And what happens in that case is
-
 00:14:00.606 --> 00:14:04.386 A:middle
 that the assistant content
 becomes the primary content,
@@ -1300,10 +1245,6 @@ and this could be very useful.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.636 --> 00:15:02.796 A:middle
-it'll open up an assistant,
-and this could be very useful.
-
 00:15:03.146 --> 00:15:04.576 A:middle
 It exists in a variety
 of places.
@@ -1379,10 +1320,6 @@ use arrow keys and return key
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:56.956 --> 00:16:00.156 A:middle
-This is a HUD that lets you
-use arrow keys and return key
 
 00:16:00.676 --> 00:16:04.106 A:middle
 to really do anything you want.
@@ -1467,10 +1404,6 @@ where you want to go.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.256 --> 00:17:01.706 A:middle
-And very quickly get to
-where you want to go.
 
 00:17:02.186 --> 00:17:04.636 A:middle
 And also the Option
@@ -1565,10 +1498,6 @@ an arrow there.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.926 --> 00:18:00.506 A:middle
-that shows up underneath
-an arrow there.
-
 00:18:00.646 --> 00:18:02.606 A:middle
 You can-- so there's
 variety of ways to invoke it.
@@ -1655,10 +1584,6 @@ own-- your own code there.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:57.866 --> 00:19:01.316 A:middle
-and then just have your
-own-- your own code there.
-
 00:19:02.296 --> 00:19:06.366 A:middle
 But very often, you will have
 your own code where you want
@@ -1731,10 +1656,6 @@ default because as fun as it is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.906 --> 00:20:02.446 A:middle
-you can set a code completion
-default because as fun as it is
 
 00:20:02.446 --> 00:20:04.346 A:middle
 to drag code snippets,
@@ -1827,10 +1748,6 @@ can just use Command, Shift,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.466 --> 00:21:02.826 A:middle
-So, as Anders told you, you
-can just use Command, Shift,
-
 00:21:02.826 --> 00:21:07.006 A:middle
 and O to bring up Open Quickly
 and start typing the name
@@ -1915,10 +1832,6 @@ of different related content
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.916 --> 00:22:03.716 A:middle
-and I can go and see a bunch
-of different related content
 
 00:22:03.716 --> 00:22:04.796 A:middle
 in the assistant editor.
@@ -2013,10 +1926,6 @@ isLoaded here and I maybe want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.076 --> 00:23:02.956 A:middle
-to solve is I have this property
-isLoaded here and I maybe want
-
 00:23:02.956 --> 00:23:04.616 A:middle
 to give that a bit more
 of a descriptive name.
@@ -2109,10 +2018,6 @@ replace then I want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.546 --> 00:24:01.926 A:middle
-So, I'm going to choose
-replace then I want
 
 00:24:01.926 --> 00:24:04.696 A:middle
 to replace the word
@@ -2222,10 +2127,6 @@ thing I want to show you.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.956 --> 00:25:01.006 A:middle
-All right, there's one more
-thing I want to show you.
-
 00:25:01.286 --> 00:25:04.486 A:middle
 I have a method that I want to
 validate that some other methods
@@ -2325,10 +2226,6 @@ the right thing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.556 --> 00:26:00.126 A:middle
-of these are doing
-the right thing.
-
 00:26:00.476 --> 00:26:03.856 A:middle
 So, if I command click on this
 symbol it would jump right
@@ -2426,10 +2323,6 @@ assistant editor.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.236 --> 00:27:00.816 A:middle
-you open in a new
-assistant editor.
 
 00:27:01.276 --> 00:27:05.256 A:middle
 So, I can go down here and
@@ -2533,10 +2426,6 @@ don't know exactly
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.476 --> 00:28:00.896 A:middle
-This is great if you
-don't know exactly
-
 00:28:00.896 --> 00:28:04.086 A:middle
 which method you're using,
 that you want to use,
@@ -2629,10 +2518,6 @@ documentation for iOS,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.516 --> 00:29:01.876 A:middle
-That's for the built-in
-documentation for iOS,
-
 00:29:01.876 --> 00:29:03.956 A:middle
 for OS X, SDKs, etceteras.
 
@@ -2713,10 +2598,6 @@ at doxygen.org.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.916 --> 00:30:01.366 A:middle
-about the syntax,
-at doxygen.org.
 
 00:30:02.276 --> 00:30:05.096 A:middle
 So, now if you go back
@@ -2886,10 +2767,6 @@ a bunch of built-in triggers
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:56.236 --> 00:32:00.396 A:middle
-In the PrefPane, there are
-a bunch of built-in triggers
-
 00:32:00.396 --> 00:32:03.086 A:middle
 of various kinds when your
 program hits a breakpoint,
@@ -2982,10 +2859,6 @@ triggers whenever you hit
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.666 --> 00:33:02.906 A:middle
-So then, obviously that
-triggers whenever you hit
-
 00:33:02.906 --> 00:33:03.856 A:middle
 that key combination.
 
@@ -3074,10 +2947,6 @@ configure your settings
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.846 --> 00:34:01.496 A:middle
-and targets, how to
-configure your settings
 
 00:34:01.496 --> 00:34:03.856 A:middle
 to produce the products
@@ -3271,10 +3140,6 @@ explicitly depend on each other,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.936 --> 00:36:03.076 A:middle
-So, you can make targets
-explicitly depend on each other,
-
 00:36:03.206 --> 00:36:04.816 A:middle
 but you don't actually
 have to do that.
@@ -3358,10 +3223,6 @@ collection of files, targets,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.136 --> 00:37:01.056 A:middle
-Your Xcode projects are
-collection of files, targets,
 
 00:37:01.316 --> 00:37:03.326 A:middle
 schemes, and build
@@ -3458,10 +3319,6 @@ App store you definitely do.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.936 --> 00:38:00.996 A:middle
-When you're releasing to the
-App store you definitely do.
 
 00:38:00.996 --> 00:38:02.966 A:middle
 So, that's when you use
@@ -3560,10 +3417,6 @@ sources build phase will compile
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.066 --> 00:39:02.536 A:middle
-that determine how the compile
-sources build phase will compile
-
 00:39:02.536 --> 00:39:03.236 A:middle
 your sources.
 
@@ -3654,10 +3507,6 @@ editor pop-up,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.646 --> 00:40:01.656 A:middle
-So, from the project
-editor pop-up,
 
 00:40:01.656 --> 00:40:04.176 A:middle
 make sure that your target is
@@ -3751,10 +3600,6 @@ sort of bundle type output
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:58.156 --> 00:41:01.476 A:middle
-If your target produces any
-sort of bundle type output
 
 00:41:01.476 --> 00:41:04.416 A:middle
 like an application bundle,
@@ -3854,10 +3699,6 @@ it's time to ship
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.196 --> 00:42:01.076 A:middle
-to rename your product,
-it's time to ship
 
 00:42:01.076 --> 00:42:02.596 A:middle
 and you're renaming
@@ -3966,10 +3807,6 @@ along another access.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.146 --> 00:43:00.466 A:middle
-to vary your build settings
-along another access.
-
 00:43:00.656 --> 00:43:02.676 A:middle
 So, this is the build settings
 that are set in the target.
@@ -4071,10 +3908,6 @@ you see the result value
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.856 --> 00:44:01.256 A:middle
-Finally, on the far left,
-you see the result value
-
 00:44:01.256 --> 00:44:02.186 A:middle
 for every build setting
 
@@ -4175,10 +4008,6 @@ for that scheme.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.856 --> 00:45:01.986 A:middle
-to edit all the settings
-for that scheme.
-
 00:45:02.286 --> 00:45:04.676 A:middle
 To perform a scheme action,
 you can use the run button
@@ -4275,10 +4104,6 @@ test an application,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.716 --> 00:46:00.576 A:middle
-So, if your tests
-test an application,
-
 00:46:00.576 --> 00:46:04.676 A:middle
 in that application scheme's
 test action we'll add the test
@@ -4373,10 +4198,6 @@ tests in the test navigator one
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:57.046 --> 00:47:00.326 A:middle
-and you can also perform your
-tests in the test navigator one
 
 00:47:00.326 --> 00:47:03.086 A:middle
 by one or as a suite or
@@ -4475,10 +4296,6 @@ usually you build the prod--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.936 --> 00:48:02.246 A:middle
-So, when you perform an action
-usually you build the prod--
 
 00:48:02.246 --> 00:48:05.666 A:middle
 or the targets for that action
@@ -4587,10 +4404,6 @@ scheme action
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.896 --> 00:49:03.016 A:middle
-We also support additional
-scheme action
-
 00:49:03.016 --> 00:49:04.066 A:middle
 as I alluded to before.
 
@@ -4677,10 +4490,6 @@ build phase in a target?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:57.486 --> 00:50:00.096 A:middle
-versus a run script
-build phase in a target?
 
 00:50:00.656 --> 00:50:02.676 A:middle
 Well, if your script
@@ -4792,10 +4601,6 @@ everybody wants to use this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.866 --> 00:51:02.126 A:middle
-with your coworkers 'cause
-everybody wants to use this.
-
 00:51:02.426 --> 00:51:04.356 A:middle
 So, if you click the
 shared checkbox here
@@ -4901,10 +4706,6 @@ enable a diagnostic
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:59.276 --> 00:52:00.896 A:middle
-like you want to
-enable a diagnostic
-
 00:52:01.196 --> 00:52:03.116 A:middle
 or add an additional
 command line argument.
@@ -5004,10 +4805,6 @@ data that's per user to you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.676 --> 00:53:01.776 A:middle
-between all users or the
-data that's per user to you.
 
 00:53:02.236 --> 00:53:04.666 A:middle
 In the shared data section,
@@ -5202,10 +4999,6 @@ workspaces, projects, targets,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:54:59.246 --> 00:55:02.786 A:middle
-We've talked about
-workspaces, projects, targets,
-
 00:55:03.036 --> 00:55:05.086 A:middle
 schemes, and run destinations.
 
@@ -5292,10 +5085,6 @@ Xcode or existing features.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:58.786 --> 00:56:02.186 A:middle
-about the new versions of
-Xcode or existing features.
 
 00:56:02.386 --> 00:56:04.326 A:middle
 That's at devforums.apple.com.

--- a/2013/402.srt
+++ b/2013/402.srt
@@ -71,10 +71,6 @@ cannot squeeze every ounce
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.296 --> 00:01:00.756 A:middle
-We're not satisfied if we
-cannot squeeze every ounce
-
 00:01:00.756 --> 00:01:02.966 A:middle
 of performance in
 audio applications.
@@ -154,10 +150,6 @@ this is already a part
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.766 --> 00:02:04.396 A:middle
-This is simple because
-this is already a part
-
 00:02:04.396 --> 00:02:08.205 A:middle
 of the standard architecture for
 iOS apps so we encourage you,
@@ -234,10 +226,6 @@ so you definitely want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.726 --> 00:03:01.736 A:middle
-to vectorize your code
-so you definitely want
-
 00:03:01.736 --> 00:03:06.136 A:middle
 to take advantage of AVX2.
 
@@ -304,10 +292,6 @@ So if you use AVX2 in Xcode
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.396 --> 00:04:01.396 A:middle
-So if you use AVX2 in Xcode
-5, it's pretty simple,
 
 00:04:01.586 --> 00:04:03.116 A:middle
 go to the Build Configuration
@@ -392,10 +376,6 @@ building your application
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.806 --> 00:05:01.596 A:middle
-So if you're just
-building your application
-
 00:05:01.596 --> 00:05:05.716 A:middle
 with the new LLVM compiler
 in Xcode 5, you're going
@@ -467,10 +447,6 @@ default in 4.-- Xcode 4.6.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.796 --> 00:06:02.486 A:middle
-we have enabled by
-default in 4.-- Xcode 4.6.
 
 00:06:03.026 --> 00:06:06.066 A:middle
 I just want to bring
@@ -546,10 +522,6 @@ such as-- unions to do the cut--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.356 --> 00:07:02.266 A:middle
-to a well understood [inaudible]
-such as-- unions to do the cut--
 
 00:07:02.266 --> 00:07:04.076 A:middle
 type conversion and
@@ -631,10 +603,6 @@ addition to performance,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:57.486 --> 00:08:01.176 A:middle
-20 percent faster and in
-addition to performance,
-
 00:08:01.356 --> 00:08:05.946 A:middle
 sometimes you have [inaudible]
 benefit such as iOS iMovie app
@@ -702,10 +670,6 @@ we built from the grown
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.116 --> 00:09:01.296 A:middle
-This is something that
-we built from the grown
 
 00:09:01.296 --> 00:09:02.546 A:middle
 up during the past year.
@@ -786,10 +750,6 @@ and choose vectorize loops,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.376 --> 00:10:02.296 A:middle
-go to the Build Setting
-and choose vectorize loops,
-
 00:10:02.726 --> 00:10:05.826 A:middle
 and let us know, we're really
 proud of this technology
@@ -859,10 +819,6 @@ performance benefits.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.956 --> 00:11:00.876 A:middle
-that can have a significant
-performance benefits.
 
 00:11:03.206 --> 00:11:06.386 A:middle
 So what do you want to do
@@ -937,10 +893,6 @@ ask, Bob Wilson to come up,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.596 --> 00:12:02.316 A:middle
-Next up, I would like to
-ask, Bob Wilson to come up,
 
 00:12:02.676 --> 00:12:05.706 A:middle
 about all the work we have done
@@ -1020,10 +972,6 @@ right in the comments.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.476 --> 00:13:02.396 A:middle
-to document your code
-right in the comments.
 
 00:13:03.396 --> 00:13:05.486 A:middle
 So let's dive into
@@ -1170,10 +1118,6 @@ with the command line tools,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.436 --> 00:15:00.006 A:middle
-If you're not already familiar
-with the command line tools,
-
 00:15:00.526 --> 00:15:03.596 A:middle
 this is a package that we
 provide separately from Xcode
@@ -1251,10 +1195,6 @@ we have the inspiration
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:56.286 --> 00:16:00.196 A:middle
-So new in Mavericks,
-we have the inspiration
-
 00:16:00.196 --> 00:16:03.126 A:middle
 that Xcode already has
 all of those same tools,
@@ -1329,10 +1269,6 @@ a brand new Mac and you try
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.256 --> 00:17:01.036 A:middle
-Well, if you-- say you've got
-a brand new Mac and you try
 
 00:17:01.036 --> 00:17:02.736 A:middle
 to run the compiler
@@ -1419,10 +1355,6 @@ available and you just go in it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.976 --> 00:18:01.556 A:middle
-to tell you that an update is
-available and you just go in it
 
 00:18:01.556 --> 00:18:02.756 A:middle
 and install it in the same way.
@@ -1518,10 +1450,6 @@ the compiler, there's--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.086 --> 00:19:00.866 A:middle
-But before we get back to
-the compiler, there's--
-
 00:19:00.866 --> 00:19:02.636 A:middle
 there's one issue I want
 to let you know about.
@@ -1610,9 +1538,6 @@ and you can use it to run them.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.746 --> 00:20:01.086 A:middle
-and you can use it to run them.
-
 00:20:01.286 --> 00:20:03.196 A:middle
 It's now included with
 a command line tools
@@ -1686,10 +1611,6 @@ and pick that up
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.386 --> 00:21:01.476 A:middle
-and xcrun will notice
-and pick that up
-
 00:21:01.476 --> 00:21:05.786 A:middle
 and use that to set the SDK.
 
@@ -1758,10 +1679,6 @@ and a float B field and a set
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.036 --> 00:22:02.686 A:middle
-It's got an integer A field
-and a float B field and a set
 
 00:22:02.686 --> 00:22:05.576 A:middle
 of constructors that let you
@@ -1846,10 +1763,6 @@ int c field in the derive class.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:56.286 --> 00:23:00.046 A:middle
-Notice though, I've added an
-int c field in the derive class.
-
 00:23:00.216 --> 00:23:01.406 A:middle
 How do we initialize that?
 
@@ -1931,10 +1844,6 @@ important piece
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.766 --> 00:24:01.176 A:middle
-there's one other
-important piece
-
 00:24:01.336 --> 00:24:02.716 A:middle
 which is the Runtime Library.
 
@@ -2009,10 +1918,6 @@ lot of great new features there
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.796 --> 00:25:00.886 A:middle
-to check it out and there's a
-lot of great new features there
 
 00:25:00.886 --> 00:25:02.206 A:middle
 that can make you
@@ -2090,10 +1995,6 @@ unsequenced modification.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.036 --> 00:26:01.206 A:middle
-The first one is
-unsequenced modification.
 
 00:26:01.356 --> 00:26:03.606 A:middle
 This is a warning about
@@ -2181,10 +2082,6 @@ new warning which is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.506 --> 00:27:03.146 A:middle
-Let's go on to the next
-new warning which is
-
 00:27:03.146 --> 00:27:04.466 A:middle
 about integer overflow.
 
@@ -2270,10 +2167,6 @@ functions either in declarations
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.756 --> 00:28:02.596 A:middle
-And if those are in static
-functions either in declarations
-
 00:28:02.596 --> 00:28:04.596 A:middle
 or actual definitions
 with the function body
@@ -2357,10 +2250,6 @@ goes away.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.616 --> 00:29:01.106 A:middle
-and without the warning
-goes away.
-
 00:29:01.636 --> 00:29:05.086 A:middle
 So this again is a serious
 problem enabled by default,
@@ -2436,10 +2325,6 @@ want to send the close message
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.696 --> 00:30:01.916 A:middle
-and when that timer goes off, I
-want to send the close message
 
 00:30:02.176 --> 00:30:04.856 A:middle
 to the current object,
@@ -2520,10 +2405,6 @@ to do something really wrong.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.266 --> 00:31:00.716 A:middle
-to crash or it's just going
-to do something really wrong.
-
 00:31:01.446 --> 00:31:03.406 A:middle
 So this is now going to
 be treated as an error
@@ -2601,10 +2482,6 @@ projects, unused functions,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.346 --> 00:32:00.996 A:middle
-by default in new
-projects, unused functions,
 
 00:32:01.236 --> 00:32:03.446 A:middle
 implicit Boolean
@@ -2690,10 +2567,6 @@ that bugs are bad
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.166 --> 00:33:00.986 A:middle
-So everyone agrees
-that bugs are bad
-
 00:33:00.986 --> 00:33:02.796 A:middle
 and as Bob has just mentioned,
 
@@ -2770,10 +2643,6 @@ the Apple documentation site
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:56.856 --> 00:34:00.646 A:middle
-However, let's bring here
-the Apple documentation site
 
 00:34:00.886 --> 00:34:03.356 A:middle
 that will tell us exactly
@@ -2867,10 +2736,6 @@ immediately create an array."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.956 --> 00:35:02.856 A:middle
-I don't set an object to nil and
-immediately create an array."
-
 00:35:03.376 --> 00:35:07.136 A:middle
 Well, we've run the analyzer
 with this warning turned on,
@@ -2947,10 +2812,6 @@ step along the way.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.206 --> 00:36:00.196 A:middle
-and examine each
-step along the way.
 
 00:36:01.136 --> 00:36:03.086 A:middle
 So let's see what
@@ -3034,10 +2895,6 @@ improved our C++ support.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:57.106 --> 00:37:00.316 A:middle
-and we've greatly
-improved our C++ support.
-
 00:37:00.726 --> 00:37:03.086 A:middle
 So here's another
 example of a new--
@@ -3107,10 +2964,6 @@ new issues greatly benefit
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:56.696 --> 00:38:00.686 A:middle
-And know that both old and
-new issues greatly benefit
 
 00:38:00.686 --> 00:38:04.426 A:middle
 from the power of the
@@ -3186,10 +3039,6 @@ constructs a draft
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.826 --> 00:39:03.156 A:middle
-of your variables and
-constructs a draft
 
 00:39:03.396 --> 00:39:06.296 A:middle
 from extract system states--
@@ -3268,10 +3117,6 @@ analyzer knows that the type
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:56.756 --> 00:40:00.046 A:middle
-So in this case, the
-analyzer knows that the type
 
 00:40:00.046 --> 00:40:03.706 A:middle
 of object A is asset and
@@ -3357,10 +3202,6 @@ you how the problem could
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.476 --> 00:41:03.866 A:middle
-both of the methods that shows
-you how the problem could
-
 00:41:03.916 --> 00:41:04.496 A:middle
 have occurred.
 
@@ -3431,10 +3272,6 @@ allocation method it uses there
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.386 --> 00:42:00.326 A:middle
-and it sees which the
-allocation method it uses there
-
 00:42:00.746 --> 00:42:03.586 A:middle
 and this is what's required
 to report this problem.
@@ -3502,10 +3339,6 @@ on your code
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.616 --> 00:43:01.566 A:middle
-and running the analyzer
-on your code
 
 00:43:01.566 --> 00:43:04.516 A:middle
 and the only question you
@@ -3587,10 +3420,6 @@ analyzer warning is free,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.626 --> 00:44:02.366 A:middle
-If you have a project that
-analyzer warning is free,
-
 00:44:02.456 --> 00:44:05.826 A:middle
 then we highly recommend that
 you use aesthetic analysis
@@ -3667,10 +3496,6 @@ that you can change by going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.756 --> 00:45:01.146 A:middle
-And here are the defaults
-that you can change by going
-
 00:45:01.146 --> 00:45:02.686 A:middle
 to the Xcode build settings.
 
@@ -3739,10 +3564,6 @@ writing the documentation is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:57.596 --> 00:46:00.336 A:middle
-And a very handy way of
-writing the documentation is
 
 00:46:00.336 --> 00:46:02.986 A:middle
 to use structured
@@ -3823,10 +3644,6 @@ is based on your comment.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:56.936 --> 00:47:01.776 A:middle
-to you the documentation that
-is based on your comment.
-
 00:47:02.086 --> 00:47:04.776 A:middle
 Another way of viewing
 quick help is
@@ -3902,10 +3719,6 @@ declarations and this allows us
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:55.946 --> 00:48:00.886 A:middle
-and attaches comments to the
-declarations and this allows us
 
 00:48:00.886 --> 00:48:03.426 A:middle
 to create a very
@@ -3984,10 +3797,6 @@ this and it tells you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:58.096 --> 00:49:01.586 A:middle
-and the compiler notices
-this and it tells you
 
 00:49:01.586 --> 00:49:03.926 A:middle
 that you should probably
@@ -4070,9 +3879,6 @@ code will be-- all header.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.516 --> 00:50:04.736 A:middle
-[ Applause ]
-
 00:50:05.236 --> 00:50:08.246 A:middle
 So we've added support
 to structured comments
@@ -4143,10 +3949,6 @@ optimizations, it also--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:56.346 --> 00:51:00.046 A:middle
-enabling new, aggressive
-optimizations, it also--
 
 00:51:00.126 --> 00:51:02.226 A:middle
 we also want to make

--- a/2013/403.srt
+++ b/2013/403.srt
@@ -75,10 +75,6 @@ that we've made in Xcode 5
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.826 --> 00:01:02.066 A:middle
-to show you some of the changes
-that we've made in Xcode 5
-
 00:01:02.686 --> 00:01:05.116 A:middle
 that makes it easy and
 fast to get everything set
@@ -164,10 +160,6 @@ going to talk about some
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.946 --> 00:02:02.516 A:middle
-And after that we're
-going to talk about some
-
 00:02:02.516 --> 00:02:04.036 A:middle
 of the advancements
 that we've made
@@ -243,10 +235,6 @@ signing identity.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.876 --> 00:03:00.976 A:middle
-that with your distribution
-signing identity.
 
 00:03:02.316 --> 00:03:04.026 A:middle
 So if you want to
@@ -327,10 +315,6 @@ application that includes it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.116 --> 00:04:00.836 A:middle
-against the bundle ID of the
-application that includes it.
 
 00:04:01.536 --> 00:04:03.946 A:middle
 If this doesn't match what's
@@ -413,10 +397,6 @@ an Apple Developer Program.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.736 --> 00:05:01.766 A:middle
-The first step is to join
-an Apple Developer Program.
-
 00:05:01.976 --> 00:05:06.406 A:middle
 Apple has three developer
 programs, iOS, Mac and Safari.
@@ -496,10 +476,6 @@ as they crop up.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.076 --> 00:06:01.506 A:middle
-to diagnose problems
-as they crop up.
 
 00:06:02.196 --> 00:06:05.236 A:middle
 To begin telling you about
@@ -582,10 +558,6 @@ including Apple ID accounts.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.236 --> 00:07:01.276 A:middle
-for your development
-including Apple ID accounts.
-
 00:07:02.536 --> 00:07:05.906 A:middle
 We make it really easy to add
 accounts and to view details
@@ -656,10 +628,6 @@ choice Add Apple ID.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:56.136 --> 00:08:02.256 A:middle
-in the Source list and
-choice Add Apple ID.
 
 00:08:02.256 --> 00:08:04.176 A:middle
 I enter in the log
@@ -900,10 +868,6 @@ import the contains.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.186 --> 00:11:00.116 A:middle
-and Xcode will automatically
-import the contains.
-
 00:11:01.186 --> 00:11:03.836 A:middle
 This means that you can hit
 build in your new project,
@@ -984,10 +948,6 @@ so I'll go back over to slides.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.696 --> 00:12:02.626 A:middle
-So that's the account section
-so I'll go back over to slides.
 
 00:12:02.776 --> 00:12:09.016 A:middle
 And one thing to note here is
@@ -1074,10 +1034,6 @@ Nittai [phonetic],
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.246 --> 00:13:00.486 A:middle
-over to my colleague
-Nittai [phonetic],
-
 00:13:00.766 --> 00:13:01.816 A:middle
 who's going to show
 these things.
@@ -1156,10 +1112,6 @@ time consuming, and error prone.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:56.776 --> 00:14:01.176 A:middle
-that up could often be complex,
-time consuming, and error prone.
 
 00:14:01.936 --> 00:14:04.006 A:middle
 So let's take a look
@@ -1254,10 +1206,6 @@ more apps you develop the more
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.376 --> 00:15:00.696 A:middle
-but as you might imagine the
-more apps you develop the more
 
 00:15:00.696 --> 00:15:03.146 A:middle
 capabilities you take advantage
@@ -1435,10 +1383,6 @@ platform features in your apps.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.966 --> 00:17:02.596 A:middle
-for you to take advantage of
-platform features in your apps.
 
 00:17:02.596 --> 00:17:04.506 A:middle
 Now I'd like to show this
@@ -1692,10 +1636,6 @@ a variety of starting points,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.806 --> 00:20:02.056 A:middle
-Xcode comes prepackaged with
-a variety of starting points,
-
 00:20:02.056 --> 00:20:04.926 A:middle
 excuse me for various
 types of products
@@ -1860,10 +1800,6 @@ also in showing you this list
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.766 --> 00:22:00.516 A:middle
-with the Member Center and
-also in showing you this list
-
 00:22:00.516 --> 00:22:02.066 A:middle
 of teams from which
 you can choose.
@@ -1955,10 +1891,6 @@ new entitlements file
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.856 --> 00:23:01.556 A:middle
-that it's created a
-new entitlements file
 
 00:23:01.856 --> 00:23:03.686 A:middle
 with the iCloud entitlements
@@ -2134,9 +2066,6 @@ after you enable iCloud.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.066 --> 00:25:00.286 A:middle
-after you enable iCloud.
-
 00:25:00.286 --> 00:25:05.026 A:middle
 Now, let's go back to the
 Capabilities tab and take a look
@@ -2228,10 +2157,6 @@ the Capabilities tab.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.726 --> 00:26:00.016 A:middle
-I did everything from
-the Capabilities tab.
-
 00:26:00.226 --> 00:26:01.746 A:middle
 So, as I've shown you,
 
@@ -2321,10 +2246,6 @@ a familiar file picker sheet
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.736 --> 00:27:02.536 A:middle
-button and Xcode will show me
-a familiar file picker sheet
-
 00:27:02.816 --> 00:27:05.016 A:middle
 that confuse any image
 from within my project
@@ -2404,10 +2325,6 @@ in the project navigator
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.696 --> 00:28:01.206 A:middle
-So, now we can see here
-in the project navigator
 
 00:28:01.206 --> 00:28:04.316 A:middle
 that Xcode has created an
@@ -2501,10 +2418,6 @@ at the slides again.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.466 --> 00:29:00.656 A:middle
-Let's take a look
-at the slides again.
-
 00:29:01.376 --> 00:29:06.546 A:middle
 So, I've just shown you how
 the new project editor makes it
@@ -2575,10 +2488,6 @@ archive in Xcode is a bundle
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:56.016 --> 00:30:00.236 A:middle
-Well, on the basic level, an
-archive in Xcode is a bundle
 
 00:30:00.236 --> 00:30:02.706 A:middle
 that contains a built
@@ -2655,10 +2564,6 @@ you want to be able
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.506 --> 00:31:02.676 A:middle
-It's important because
-you want to be able
-
 00:31:02.676 --> 00:31:05.266 A:middle
 to symbolicate those crash
 logs should they come in.
@@ -2717,10 +2622,6 @@ what the looks like.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.896 --> 00:32:00.156 A:middle
-Let's take a look at
-what the looks like.
 
 00:32:00.686 --> 00:32:02.886 A:middle
 So here we have the app
@@ -2794,10 +2695,6 @@ IPA file which is useful
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.796 --> 00:33:01.646 A:middle
-or I can save it out as an
-IPA file which is useful
 
 00:33:01.646 --> 00:33:03.176 A:middle
 for distributing to testers,
@@ -2875,10 +2772,6 @@ contained in them,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.476 --> 00:34:00.346 A:middle
-with all those certificates
-contained in them,
 
 00:34:00.666 --> 00:34:02.336 A:middle
 even if they weren't
@@ -2962,10 +2855,6 @@ just missing or it may be harder
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.136 --> 00:35:02.446 A:middle
-as the entitlements file is
-just missing or it may be harder
-
 00:35:02.446 --> 00:35:06.296 A:middle
 to diagnose issues such as a
 typo in the name or the value
@@ -3039,10 +2928,6 @@ just the white list.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.076 --> 00:36:01.076 A:middle
-in the profile is
-just the white list.
-
 00:36:01.206 --> 00:36:03.236 A:middle
 It's a list of allowed
 entitlements
@@ -3111,10 +2996,6 @@ knows exactly what's wrong
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.666 --> 00:37:02.266 A:middle
-Xcode knows that, it
-knows exactly what's wrong
 
 00:37:02.476 --> 00:37:06.866 A:middle
 and more importantly it
@@ -3194,10 +3075,6 @@ have access to that machine,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.356 --> 00:38:02.296 A:middle
-Alternatively, if I no longer
-have access to that machine,
 
 00:38:02.856 --> 00:38:04.426 A:middle
 I provoke my identity
@@ -3332,10 +3209,6 @@ diagnosing and fixing,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.876 --> 00:40:02.266 A:middle
-will be sufficient for
-diagnosing and fixing,
 
 00:40:02.266 --> 00:40:04.096 A:middle
 just about any issue
@@ -3551,9 +3424,6 @@ by clicking this button here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.946 --> 00:43:00.266 A:middle
-by clicking this button here.
-
 00:43:01.516 --> 00:43:11.106 A:middle
 [ Pause ]
 
@@ -3620,10 +3490,6 @@ questions,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:56.576 --> 00:44:01.516 A:middle
-If your got additional
-questions,
 
 00:44:01.686 --> 00:44:03.586 A:middle
 feel free to e-mail

--- a/2013/404.srt
+++ b/2013/404.srt
@@ -71,10 +71,6 @@ the Objective-C?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.806 --> 00:01:01.526 A:middle
-So how do we evolve
-the Objective-C?
-
 00:01:01.886 --> 00:01:04.296 A:middle
 Well, there are some
 things that we focus on.
@@ -156,10 +152,6 @@ the language itself is amenable
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.186 --> 00:02:02.186 A:middle
-of this is making sure that
-the language itself is amenable
 
 00:02:02.186 --> 00:02:03.326 A:middle
 to building great tools.
@@ -248,10 +240,6 @@ about better productivity
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.426 --> 00:03:01.666 A:middle
-We're also going to talk
-about better productivity
-
 00:03:01.786 --> 00:03:03.276 A:middle
 in the use of Objective-C.
 
@@ -331,10 +319,6 @@ to pull in iAd and use
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.916 --> 00:04:01.176 A:middle
-In this case, we're going
-to pull in iAd and use
 
 00:04:01.176 --> 00:04:02.696 A:middle
 that as our demonstration.
@@ -423,10 +407,6 @@ teeny tiny innovation
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:56.816 --> 00:05:00.356 A:middle
-because #import is a
-teeny tiny innovation
 
 00:05:00.666 --> 00:05:04.036 A:middle
 over the basic #include
@@ -520,10 +500,6 @@ actually refers to and it comes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.386 --> 00:06:03.776 A:middle
-go find what is iAd/iAd.h
-actually refers to and it comes
-
 00:06:03.776 --> 00:06:04.846 A:middle
 up with a file on disk.
 
@@ -604,10 +580,6 @@ my .m, for my application code.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.226 --> 00:07:00.416 A:middle
-because that makes sense for
-my .m, for my application code.
 
 00:07:00.466 --> 00:07:05.766 A:middle
 And I happen to do that
@@ -693,10 +665,6 @@ world to cope
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.016 --> 00:08:00.836 A:middle
-within the C programming
-world to cope
 
 00:08:00.836 --> 00:08:02.886 A:middle
 with this fragility problem.
@@ -798,10 +766,6 @@ about 250 .ms here
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.806 --> 00:09:02.386 A:middle
-So it's got, you know,
-about 250 .ms here
-
 00:09:02.756 --> 00:09:05.246 A:middle
 and you can see they range
 from half a kilobyte up to
@@ -879,10 +843,6 @@ going through 425 kilobytes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:56.456 --> 00:10:01.906 A:middle
-of what's here are actually
-going through 425 kilobytes
 
 00:10:01.906 --> 00:10:03.596 A:middle
 of header files pulling
@@ -1056,10 +1016,6 @@ precompiled header
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.426 --> 00:12:01.626 A:middle
-You could extend your
-precompiled header
-
 00:12:01.756 --> 00:12:04.416 A:middle
 to include iAd.h. And now,
 
@@ -1151,9 +1107,6 @@ So what are these Modules?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.716 --> 00:13:00.156 A:middle
-So what are these Modules?
-
 00:13:00.586 --> 00:13:02.986 A:middle
 So think of them
 as an encapsulation
@@ -1239,10 +1192,6 @@ any of your local context.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.916 --> 00:14:03.616 A:middle
-by @import be changed by
-any of your local context.
-
 00:14:03.616 --> 00:14:06.556 A:middle
 So if I do this horrible
 thing that I did earlier,
@@ -1312,10 +1261,6 @@ part of a framework
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.556 --> 00:15:00.326 A:middle
-We can import just
-part of a framework
 
 00:15:00.636 --> 00:15:02.716 A:middle
 by writing @import of iAd.
@@ -1396,10 +1341,6 @@ create what Modules you used
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.766 --> 00:16:00.766 A:middle
-in the object files it
-create what Modules you used
 
 00:16:01.036 --> 00:16:03.516 A:middle
 so that we'll automatically
@@ -1493,10 +1434,6 @@ header that we know is part
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.426 --> 00:17:00.566 A:middle
-When those refer to a
-header that we know is part
 
 00:17:00.566 --> 00:17:02.216 A:middle
 of a Module, we just treat it
@@ -1654,10 +1591,6 @@ will find the Module Map,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:55.286 --> 00:19:00.016 A:middle
-to @import UIKit, the compiler
-will find the Module Map,
 
 00:19:00.016 --> 00:19:01.486 A:middle
 it tells it how to build UIKit
@@ -1845,10 +1778,6 @@ that is indexing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.616 --> 00:21:01.386 A:middle
-on the parsing and
-that is indexing.
-
 00:21:01.386 --> 00:21:03.786 A:middle
 When an Xcode is
 indexing your project,
@@ -1932,10 +1861,6 @@ and find the Module Setting,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.096 --> 00:22:01.186 A:middle
-just go into your Build Settings
-and find the Module Setting,
 
 00:22:01.456 --> 00:22:02.996 A:middle
 change it to Yes
@@ -2025,10 +1950,6 @@ requested Modules will just be
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.946 --> 00:23:01.836 A:middle
-Essentially, the fact that you
-requested Modules will just be
-
 00:23:01.836 --> 00:23:05.176 A:middle
 ignored for the C++ sources,
 you'll still get the benefits
@@ -2104,10 +2025,6 @@ feature of Modules.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:57.946 --> 00:24:00.426 A:middle
-through the Autolinking
-feature of Modules.
 
 00:24:01.696 --> 00:24:04.096 A:middle
 Now, Modules are
@@ -2200,9 +2117,6 @@ about better productivity.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.146 --> 00:25:00.216 A:middle
-about better productivity.
 
 00:25:00.216 --> 00:25:01.986 A:middle
 We're going to be
@@ -2397,10 +2311,6 @@ Array literals become
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.596 --> 00:27:01.916 A:middle
-Array literals become
-@ square bracket.
-
 00:27:03.026 --> 00:27:06.136 A:middle
 The compiler helps you remember
 keys and values and the fact
@@ -2483,10 +2393,6 @@ modern syntax that I'm not going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.816 --> 00:28:03.766 A:middle
-Now, there's a ton more to
-modern syntax that I'm not going
-
 00:28:03.766 --> 00:28:05.176 A:middle
 to cover here and
 I strongly suggest
@@ -2560,10 +2466,6 @@ potentially your experience
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.806 --> 00:29:00.676 A:middle
-that will affect
-potentially your experience
 
 00:29:00.676 --> 00:29:03.806 A:middle
 and help you write better code.
@@ -2640,10 +2542,6 @@ returns instancetype.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.826 --> 00:30:01.146 A:middle
-In the new SDK, array
-returns instancetype.
 
 00:30:02.176 --> 00:30:03.946 A:middle
 This is a contextual keyword.
@@ -2801,10 +2699,6 @@ enums like this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.446 --> 00:32:01.756 A:middle
-In the past, we declared
-enums like this.
-
 00:32:02.576 --> 00:32:05.536 A:middle
 In one line, we would declare
 the enum and enumerate,
@@ -2876,9 +2770,6 @@ that exposed this feature.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.456 --> 00:33:00.716 A:middle
-that exposed this feature.
 
 00:33:00.996 --> 00:33:04.056 A:middle
 We have NS_ENUM for a
@@ -3033,10 +2924,6 @@ enums allow us to fix this
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.266 --> 00:35:01.686 A:middle
-Because the explicitly-typed
-enums allow us to fix this
-
 00:35:01.686 --> 00:35:04.146 A:middle
 and make the enum how
 many explicit-type,
@@ -3125,10 +3012,6 @@ the core of the language.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.216 --> 00:36:02.806 A:middle
-The Objective-C Runtime is
-the core of the language.
-
 00:36:03.406 --> 00:36:05.816 A:middle
 It enables a ton of
 dynamic behavior.
@@ -3199,10 +3082,6 @@ for a small value-like objects.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:56.006 --> 00:37:00.936 A:middle
-They were added in 64-bit Cocoa
-for a small value-like objects.
 
 00:37:01.006 --> 00:37:03.336 A:middle
 And examples of a
@@ -3290,10 +3169,6 @@ is an implementation detail.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.286 --> 00:38:01.686 A:middle
-Having said all this, this
-is an implementation detail.
 
 00:38:02.116 --> 00:38:03.876 A:middle
 Some of you have
@@ -3537,10 +3412,6 @@ example of ARC is Xcode 5.0.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.736 --> 00:41:01.236 A:middle
-Specific-- another great
-example of ARC is Xcode 5.0.
-
 00:41:01.716 --> 00:41:03.626 A:middle
 This used to be a GC app.
 
@@ -3632,10 +3503,6 @@ release the object much more
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.266 --> 00:42:02.436 A:middle
-so the debug builds now
-release the object much more
-
 00:42:02.436 --> 00:42:06.166 A:middle
 like when released builds and
 we hope you appreciate that.
@@ -3716,10 +3583,6 @@ to jump back to the video,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.566 --> 00:43:00.436 A:middle
-But if you don't have time
-to jump back to the video,
-
 00:43:00.436 --> 00:43:01.836 A:middle
 here's what you need to do.
 
@@ -3794,10 +3657,6 @@ I'm going to be talking about
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.356 --> 00:44:02.736 A:middle
-So, there are three things
-I'm going to be talking about
 
 00:44:03.316 --> 00:44:06.056 A:middle
 and we're going to be talking
@@ -3874,10 +3733,6 @@ have two instance variables.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.896 --> 00:45:02.376 A:middle
-Let's say in a method you
-have two instance variables.
 
 00:45:03.546 --> 00:45:05.526 A:middle
 And one of the instance
@@ -3969,10 +3824,6 @@ it may look like this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.096 --> 00:46:01.496 A:middle
-Now when we wrote the code,
-it may look like this.
-
 00:46:01.496 --> 00:46:04.206 A:middle
 It may look like we're just
 assigning the block to ivar1
@@ -4054,10 +3905,6 @@ the lifetime on objects.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:57.746 --> 00:47:01.246 A:middle
-Weak variables do not extend
-the lifetime on objects.
-
 00:47:02.116 --> 00:47:04.806 A:middle
 They are-- and therefore,
 
@@ -4134,9 +3981,6 @@ Well what do we do about this?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:56.686 --> 00:48:00.056 A:middle
-Well what do we do about this?
 
 00:48:00.266 --> 00:48:01.706 A:middle
 Well, it's actually
@@ -4224,10 +4068,6 @@ course, the warning goes away.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.886 --> 00:49:02.736 A:middle
-And if we do that, of
-course, the warning goes away.
-
 00:49:03.646 --> 00:49:06.786 A:middle
 So this is great.
 
@@ -4309,10 +4149,6 @@ We have a +1-- you can express
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.626 --> 00:50:06.836 A:middle
-We have a +1-- you can express
-+1 to ARC via CFBridgingRetain.
-
 00:50:07.116 --> 00:50:09.116 A:middle
 You can express a decrement
 
@@ -4387,10 +4223,6 @@ use these conventions
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:56.326 --> 00:51:00.696 A:middle
-Well, what if we can just
-use these conventions
 
 00:51:00.696 --> 00:51:03.146 A:middle
 to make this bridge
@@ -4474,10 +4306,6 @@ to return retained and--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:57.176 --> 00:52:01.486 A:middle
-We decided that we're going
-to return retained and--
-
 00:52:01.746 --> 00:52:03.136 A:middle
 but we're following
 the convention.
@@ -4556,10 +4384,6 @@ using the new SDKs.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:57.876 --> 00:53:00.316 A:middle
-from your code if you're
-using the new SDKs.
 
 00:53:00.836 --> 00:53:04.656 A:middle
 So to wrap up, we have Modules.
@@ -4644,9 +4468,6 @@ and one Thursday afternoon.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:58.376 --> 00:54:00.156 A:middle
-and one Thursday afternoon.
 
 00:54:01.326 --> 00:54:02.666 A:middle
 Oh sorry, related sessions.

--- a/2013/405.srt
+++ b/2013/405.srt
@@ -55,10 +55,6 @@ and this code does just that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.986 --> 00:01:04.876 A:middle
-to design your user interface,
-and this code does just that.
-
 00:01:05.046 --> 00:01:07.466 A:middle
 For example, it creates
 an image,
@@ -222,10 +218,6 @@ the view doesn't do much all
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:57.896 --> 00:03:01.896 A:middle
-to design your view, but also
-the view doesn't do much all
-
 00:03:01.896 --> 00:03:02.476 A:middle
 by itself.
 
@@ -308,10 +300,6 @@ pieces, the first being scenes.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.466 --> 00:04:04.516 A:middle
-Now, storyboards are made of two
-pieces, the first being scenes.
-
 00:04:04.916 --> 00:04:10.116 A:middle
 Now scenes are like a screen
 of your iPhone or a portion
@@ -393,10 +381,6 @@ make connections between scenes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.166 --> 00:05:03.056 A:middle
-And we're going to learn how to
-make connections between scenes
 
 00:05:03.246 --> 00:05:05.386 A:middle
 and between the scenes
@@ -483,10 +467,6 @@ Application
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.826 --> 00:06:00.476 A:middle
-it's like a Master-Detail
-Application
-
 00:06:00.476 --> 00:06:01.556 A:middle
 or a Tabbed Application.
 
@@ -564,10 +544,6 @@ in the past when you start
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.216 --> 00:07:00.486 A:middle
-Now you might have wondered
-in the past when you start
 
 00:07:00.486 --> 00:07:03.826 A:middle
 up an application on your
@@ -654,10 +630,6 @@ I want is my designer actually
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.916 --> 00:08:03.696 A:middle
-Now these are empty and what
-I want is my designer actually
-
 00:08:03.696 --> 00:08:06.326 A:middle
 gave me a bunch of images for
 me to work with today on stage.
@@ -730,10 +702,6 @@ to go back to the first scene.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.096 --> 00:09:00.696 A:middle
-and I want that scene to be able
-to go back to the first scene.
 
 00:09:01.036 --> 00:09:03.396 A:middle
 So I'm going to need something
@@ -891,10 +859,6 @@ I see I have my button here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.806 --> 00:11:02.756 A:middle
-So we can type in "button" and
-I see I have my button here.
-
 00:11:02.966 --> 00:11:06.436 A:middle
 Now, I can drag my button out
 and drop it on to my canvas,
@@ -969,10 +933,6 @@ they're really useful to be able
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.386 --> 00:12:01.976 A:middle
-These are called guides and
-they're really useful to be able
-
 00:12:01.976 --> 00:12:04.166 A:middle
 to get your user
 interface elements
@@ -1043,10 +1003,6 @@ this title to be centered
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.456 --> 00:13:00.076 A:middle
-And the last thing is I want
-this title to be centered
 
 00:13:00.076 --> 00:13:01.826 A:middle
 and I want it right
@@ -1124,10 +1080,6 @@ to select the timer
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.046 --> 00:14:01.026 A:middle
-down the con-- I'm going
-to select the timer
-
 00:14:01.526 --> 00:14:04.836 A:middle
 and then hold the control
 key while I'm dragging
@@ -1202,10 +1154,6 @@ this one has to be 56.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.856 --> 00:15:01.096 A:middle
-the designer said
-this one has to be 56.
-
 00:15:01.436 --> 00:15:03.056 A:middle
 So again, I can hold
 the option key down.
@@ -1277,10 +1225,6 @@ some related method information
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.896 --> 00:16:01.646 A:middle
-The tool tips will give you
-some related method information
 
 00:16:02.026 --> 00:16:04.486 A:middle
 which can be useful if you're
@@ -1437,10 +1381,6 @@ I click there, that's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.876 --> 00:18:01.456 A:middle
-to the Size Inspector, and if
-I click there, that's going
-
 00:18:01.456 --> 00:18:04.266 A:middle
 to show me the position of my
 object as well as the width
@@ -1519,10 +1459,6 @@ so, well, to control this view.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.036 --> 00:19:02.836 A:middle
-to control this view controller,
-so, well, to control this view.
 
 00:19:03.356 --> 00:19:06.096 A:middle
 So right now, if I click
@@ -1658,10 +1594,6 @@ Editor now and we're going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.876 --> 00:21:06.976 A:middle
-So, I can open up my Assistant
-Editor now and we're going
-
 00:21:07.596 --> 00:21:09.136 A:middle
 to make a little
 RIM for our code
@@ -1723,9 +1655,6 @@ named time label.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.776 --> 00:22:00.706 A:middle
-named time label.
 
 00:22:01.146 --> 00:22:03.846 A:middle
 So now in my controller,
@@ -1859,10 +1788,6 @@ to make an action connection
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.186 --> 00:24:03.416 A:middle
-instead of an outlet, I'm going
-to make an action connection
-
 00:24:03.416 --> 00:24:06.116 A:middle
 which will connect to a
 method and I'm going to call
@@ -1931,10 +1856,6 @@ right in there for me.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.366 --> 00:25:02.406 A:middle
-and it'll add my code
-right in there for me.
 
 00:25:03.446 --> 00:25:04.956 A:middle
 It's great for like
@@ -2066,10 +1987,6 @@ properties to show up.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.616 --> 00:27:00.726 A:middle
-you don't want all of your
-properties to show up.
-
 00:27:00.726 --> 00:27:03.096 A:middle
 You might have a lot of
 properties in your project
@@ -2149,9 +2066,6 @@ with storyboards.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.996 --> 00:28:00.766 A:middle
-&gt;&gt; Thank you Kelly.
 
 00:28:01.396 --> 00:28:02.156 A:middle
 Hello everyone.
@@ -2252,10 +2166,6 @@ activate segues from code rather
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.246 --> 00:29:02.606 A:middle
-I want to show you how to
-activate segues from code rather
-
 00:29:02.606 --> 00:29:04.426 A:middle
 than just from user
 interface elements.
@@ -2340,9 +2250,6 @@ where Kelly left it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.236 --> 00:30:00.236 A:middle
-where Kelly left it.
-
 00:30:01.586 --> 00:30:03.906 A:middle
 And the first thing I'm
 going to do is set up so
@@ -2421,10 +2328,6 @@ select the MyViewController,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.966 --> 00:31:00.266 A:middle
-To do that, I'm going to
-select the MyViewController,
 
 00:31:00.656 --> 00:31:03.926 A:middle
 I'm going to go to its
@@ -2515,10 +2418,6 @@ and it can also intervene
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.106 --> 00:32:01.126 A:middle
-from that user interface element
-and it can also intervene
-
 00:32:01.126 --> 00:32:03.636 A:middle
 at special times for the
 user interface element
@@ -2608,9 +2507,6 @@ and drop it on to my map view.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.596 --> 00:33:00.906 A:middle
-and drop it on to my map view.
-
 00:33:00.906 --> 00:33:04.236 A:middle
 What this will allow me to
 do is that when the user taps
@@ -2698,10 +2594,6 @@ home region method
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.326 --> 00:34:00.686 A:middle
-to call the center
-home region method
 
 00:34:00.686 --> 00:34:01.816 A:middle
 that I implemented earlier.
@@ -2794,10 +2686,6 @@ runs for route.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:56.976 --> 00:35:00.236 A:middle
-performSegueWithIdentifier
-runs for route.
-
 00:35:01.276 --> 00:35:03.176 A:middle
 Now, I haven't shown you
 the segue yet, I'll show you
@@ -2873,10 +2761,6 @@ segment-- my push segue.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.446 --> 00:36:02.246 A:middle
-and do my standard push
-segment-- my push segue.
 
 00:36:02.246 --> 00:36:04.936 A:middle
 But this time, I'm going
@@ -2958,10 +2842,6 @@ that's very important.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.176 --> 00:37:01.856 A:middle
-You see this one more method
-that's very important.
 
 00:37:02.076 --> 00:37:03.756 A:middle
 This method is called
@@ -3057,10 +2937,6 @@ the identifier of the segue.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.346 --> 00:38:03.256 A:middle
-because you didn't check
-the identifier of the segue.
 
 00:38:03.366 --> 00:38:05.236 A:middle
 As I mentioned, the
@@ -3159,10 +3035,6 @@ to ask some other object
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.256 --> 00:39:01.776 A:middle
-So it's going to need
-to ask some other object
-
 00:39:01.776 --> 00:39:03.546 A:middle
 and in this case that would
 be the view controller,
@@ -3251,10 +3123,6 @@ to be displayed on screen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.576 --> 00:40:02.576 A:middle
-to actually show what needs
-to be displayed on screen.
-
 00:40:03.046 --> 00:40:04.656 A:middle
 You can certainly imagine
 having a Table View
@@ -3327,10 +3195,6 @@ of when I run that route.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.036 --> 00:41:02.296 A:middle
-and here you see a detail
-of when I run that route.
-
 00:41:02.536 --> 00:41:04.966 A:middle
 So, what else can we do?
 
@@ -3401,10 +3265,6 @@ adding a UIView
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:57.866 --> 00:42:01.016 A:middle
-Now, normally, just
-adding a UIView
 
 00:42:01.326 --> 00:42:03.876 A:middle
 to your user interface
@@ -3500,10 +3360,6 @@ and drag a connection
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.816 --> 00:43:01.256 A:middle
-down to my view controller
-and drag a connection
-
 00:43:01.256 --> 00:43:04.466 A:middle
 up to the GraphView and it's
 good I did that 'cause it shows
@@ -3580,10 +3436,6 @@ controller was created.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.986 --> 00:44:01.916 A:middle
-from which your view
-controller was created.
 
 00:44:02.826 --> 00:44:05.496 A:middle
 This is important because
@@ -3674,10 +3526,6 @@ work such as past data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.316 --> 00:45:00.406 A:middle
-to do some additional
-work such as past data
 
 00:45:00.406 --> 00:45:01.536 A:middle
 between view controllers.
@@ -3773,10 +3621,6 @@ going to want some kind
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.606 --> 00:46:01.366 A:middle
-And when we do that, we're
-going to want some kind
-
 00:46:01.366 --> 00:46:03.546 A:middle
 of a login panel for the user.
 
@@ -3870,10 +3714,6 @@ arrow pointing to it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:57.626 --> 00:47:00.316 A:middle
-that had the large
-arrow pointing to it.
-
 00:47:00.316 --> 00:47:02.886 A:middle
 And so calling this method
 means you'll create one
@@ -3966,10 +3806,6 @@ you see a large flow
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.436 --> 00:48:00.936 A:middle
-because they let
-you see a large flow
-
 00:48:00.936 --> 00:48:02.826 A:middle
 of your application
 in one place.
@@ -4060,10 +3896,6 @@ objects that I want to talk
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.096 --> 00:49:01.726 A:middle
-So, there's two last
-objects that I want to talk
-
 00:49:01.726 --> 00:49:04.926 A:middle
 about real quick and these
 objects are called NSNib
@@ -4147,10 +3979,6 @@ load those prototypes,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.136 --> 00:50:01.226 A:middle
-And as you do those--
-load those prototypes,
 
 00:50:01.226 --> 00:50:02.726 A:middle
 it's actually loading
@@ -4245,10 +4073,6 @@ and very much related
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:57.676 --> 00:51:00.496 A:middle
-And very important
-and very much related
 
 00:51:00.496 --> 00:51:02.776 A:middle
 to how interface builder

--- a/2013/406.srt
+++ b/2013/406.srt
@@ -87,10 +87,6 @@ and I want to describe it once.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.656 --> 00:01:02.776 A:middle
-So I have an interface here
-and I want to describe it once.
-
 00:01:03.446 --> 00:01:06.816 A:middle
 But I wanted to look good in
 both portrait and landscape.
@@ -171,10 +167,6 @@ constraints for us
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.766 --> 00:02:00.336 A:middle
-that you provide the
-constraints for us
 
 00:02:00.526 --> 00:02:03.826 A:middle
 and then we automatically
@@ -271,9 +263,6 @@ of the font on the fly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.116 --> 00:03:00.116 A:middle
-of the font on the fly.
-
 00:03:00.956 --> 00:03:04.946 A:middle
 So, using Auto Layout and using
 relationships to describe things
@@ -367,10 +356,6 @@ writing a single line of code,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.956 --> 00:04:00.316 A:middle
-relationships again, without
-writing a single line of code,
 
 00:04:00.636 --> 00:04:02.086 A:middle
 and that is just a huge win.
@@ -467,9 +452,6 @@ for this is per view controller
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.466 --> 00:05:01.356 A:middle
-for this is per view controller
 
 00:05:01.356 --> 00:05:03.036 A:middle
 or per Interface
@@ -572,9 +554,6 @@ MaskIntoConstraints.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.916 --> 00:06:00.086 A:middle
-MaskIntoConstraints.
 
 00:06:00.606 --> 00:06:02.866 A:middle
 What this does is it just
@@ -682,10 +661,6 @@ Mac, brand new for Xcode,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.586 --> 00:07:01.526 A:middle
-it was brand new for the
-Mac, brand new for Xcode,
-
 00:07:01.526 --> 00:07:04.686 A:middle
 and it was all about helping you
 create Auto Layout interfaces
@@ -771,10 +746,6 @@ of development, right,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.426 --> 00:08:00.236 A:middle
-Now, as we talk about phases
-of development, right,
 
 00:08:00.236 --> 00:08:01.816 A:middle
 we're adding features
@@ -878,9 +849,6 @@ for probably quite a while.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.396 --> 00:09:01.016 A:middle
-for probably quite a while.
-
 00:09:01.466 --> 00:09:03.396 A:middle
 And it's really important
 in this phase
@@ -978,9 +946,6 @@ to react the changes around you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.946 --> 00:10:01.476 A:middle
-to react the changes around you.
 
 00:10:02.476 --> 00:10:05.286 A:middle
 So, with Xcode 5,
@@ -1080,10 +1045,6 @@ constraints at."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.686 --> 00:11:00.166 A:middle
-to reflect what my
-constraints at."
-
 00:11:00.166 --> 00:11:03.076 A:middle
 And we've added features that
 give you the precise control
@@ -1167,10 +1128,6 @@ going to build a splash screen
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.106 --> 00:12:02.946 A:middle
-What we're going to do is we're
-going to build a splash screen
-
 00:12:03.276 --> 00:12:04.816 A:middle
 by adding some buttons here.
 
@@ -1250,10 +1207,6 @@ them, all right, we're good.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.976 --> 00:13:00.736 A:middle
-And let's resize this, position
-them, all right, we're good.
 
 00:13:00.966 --> 00:13:02.756 A:middle
 Now, I'm going to
@@ -1355,10 +1308,6 @@ control drag between views
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.076 --> 00:14:01.406 A:middle
-Just like you can
-control drag between views
 
 00:14:01.816 --> 00:14:05.376 A:middle
 to add relationships like
@@ -1541,10 +1490,6 @@ context sensitive.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:56.946 --> 00:16:01.596 A:middle
-So, Control-Drag is
-context sensitive.
-
 00:16:02.086 --> 00:16:06.166 A:middle
 So based upon the views I'm
 dragging between and the angle
@@ -1639,9 +1584,6 @@ But when I got my artwork,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.796 --> 00:17:00.976 A:middle
-But when I got my artwork,
-
 00:17:00.976 --> 00:17:04.096 A:middle
 I would probably
 want to delete this.
@@ -1733,10 +1675,6 @@ buttons done here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.606 --> 00:18:00.996 A:middle
-Great! I've go my two
-buttons done here.
 
 00:18:01.906 --> 00:18:03.136 A:middle
 Let's talk about the
@@ -1841,10 +1779,6 @@ existing constraints I have
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.106 --> 00:19:00.206 A:middle
-That will clear any
-existing constraints I have
-
 00:19:00.206 --> 00:19:04.166 A:middle
 on just this view, and then
 it will add some suggested
@@ -1928,9 +1862,6 @@ and hit the Delete.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:56.216 --> 00:20:01.736 A:middle
-[ Applause ]
 
 00:20:02.236 --> 00:20:03.986 A:middle
 Who knew that deleting
@@ -2021,10 +1952,6 @@ adjusting the strategy
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:57.596 --> 00:21:00.096 A:middle
-and I want to add one for
-adjusting the strategy
 
 00:21:00.596 --> 00:21:03.286 A:middle
 that I want, and then I
@@ -2117,10 +2044,6 @@ what's the nearest neighbor?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.036 --> 00:22:00.616 A:middle
-to Nearest Neighbor," OK,
-what's the nearest neighbor?
-
 00:22:01.046 --> 00:22:03.786 A:middle
 The nearest neighbor
 is the nearest sibling
@@ -2212,10 +2135,6 @@ at the same time
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.826 --> 00:23:01.206 A:middle
-and Design Time Layout
-at the same time
-
 00:23:01.206 --> 00:23:03.186 A:middle
 and let Auto Layout do
 all the work for me.
@@ -2299,10 +2218,6 @@ it will add a leading top
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:54.866 --> 00:24:00.086 A:middle
-20 and what that will do is
-it will add a leading top
 
 00:24:00.396 --> 00:24:02.046 A:middle
 and trailing constraint
@@ -2394,9 +2309,6 @@ So I click that, boom!
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.326 --> 00:25:00.036 A:middle
-So I click that, boom!
-
 00:25:00.036 --> 00:25:02.596 A:middle
 Constraints and layout
 all in one action.
@@ -2487,10 +2399,6 @@ buttons.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.526 --> 00:26:01.326 A:middle
-through their respective
-buttons.
 
 00:26:01.656 --> 00:26:02.866 A:middle
 Now, I'm having stage fright
@@ -2594,10 +2502,6 @@ start occluding, overlapping,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.456 --> 00:27:01.046 A:middle
-or really short, they might
-start occluding, overlapping,
-
 00:27:01.386 --> 00:27:03.006 A:middle
 and I definitely
 don't want that.
@@ -2688,10 +2592,6 @@ bunch of constraints
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.996 --> 00:28:02.506 A:middle
-And now, I got a
-bunch of constraints
-
 00:28:02.506 --> 00:28:03.796 A:middle
 so let's go take a look
 at what we got here.
@@ -2772,10 +2672,6 @@ stuff to overlap.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.916 --> 00:29:01.636 A:middle
-We don't want that
-stuff to overlap.
-
 00:29:02.006 --> 00:29:04.636 A:middle
 So I go and tell my
 designer, "Hey, Mr. Designer,
@@ -2852,10 +2748,6 @@ the constraints that you want.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.816 --> 00:30:00.056 A:middle
-so that you can quickly create
-the constraints that you want.
 
 00:30:00.056 --> 00:30:02.596 A:middle
 A little pro tip, if you
@@ -2948,10 +2840,6 @@ standard space and there we go.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:56.146 --> 00:31:00.626 A:middle
-So I'm just going to use the
-standard space and there we go.
 
 00:31:00.826 --> 00:31:03.406 A:middle
 Now that slider should
@@ -3046,10 +2934,6 @@ about this view to preview it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.536 --> 00:32:01.896 A:middle
-but now I can change attributes
-about this view to preview it.
-
 00:32:02.546 --> 00:32:04.486 A:middle
 So for example, I can say,
 what is it going to look
@@ -3128,10 +3012,6 @@ right at my fingertips.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.006 --> 00:33:00.506 A:middle
-with that problem right,
-right at my fingertips.
 
 00:33:01.716 --> 00:33:03.146 A:middle
 So, to do that, I'm going
@@ -3213,10 +3093,6 @@ my orientation to landscape.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:51.026 --> 00:34:00.086 A:middle
-And now I'm going to change
-my orientation to landscape.
 
 00:34:00.956 --> 00:34:02.766 A:middle
 Again, this is just previewing
@@ -3315,10 +3191,6 @@ some suggestions now
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.816 --> 00:35:01.646 A:middle
-but I can also get
-some suggestions now
-
 00:35:01.646 --> 00:35:03.666 A:middle
 with Xcode 5 by opening
 the Menu.
@@ -3400,10 +3272,6 @@ the Auto Layout resolving menu
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:56.856 --> 00:36:01.036 A:middle
-for that fine control, using
-the Auto Layout resolving menu
 
 00:36:01.076 --> 00:36:04.076 A:middle
 for those kind of broader brush
@@ -3503,10 +3371,6 @@ run your app in the middle
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.676 --> 00:37:01.796 A:middle
-If you were to build and
-run your app in the middle
 
 00:37:01.796 --> 00:37:03.896 A:middle
 of writing a line of code,
@@ -3612,10 +3476,6 @@ constraints to your view.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.076 --> 00:38:00.296 A:middle
-by just not adding enough
-constraints to your view.
-
 00:38:00.766 --> 00:38:03.396 A:middle
 So, if you we take my example
 here with my warrior imageView,
@@ -3716,10 +3576,6 @@ height constraints
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.706 --> 00:39:01.936 A:middle
-I've added two-- two
-height constraints
 
 00:39:01.936 --> 00:39:03.726 A:middle
 to my warrior imageView
@@ -3900,10 +3756,6 @@ currently 32 point shorter
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:56.996 --> 00:41:00.246 A:middle
-So, that tells me that it's
-currently 32 point shorter
-
 00:41:00.246 --> 00:41:01.776 A:middle
 than the height of the
 button in the canvas
@@ -3995,10 +3847,6 @@ here and choose Equal Heights.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:56.556 --> 00:42:00.836 A:middle
-I'm going to Control-Drag down
-here and choose Equal Heights.
 
 00:42:00.916 --> 00:42:03.976 A:middle
 So, this constraint is going to
@@ -4176,10 +4024,6 @@ point out the fact
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.496 --> 00:44:02.406 A:middle
-This time, I want to
-point out the fact
-
 00:44:02.566 --> 00:44:04.796 A:middle
 that this menu is
 divided into two halves,
@@ -4267,10 +4111,6 @@ that the player can load.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.226 --> 00:45:01.376 A:middle
-for every saved game
-that the player can load.
 
 00:45:02.236 --> 00:45:03.876 A:middle
 And the cell has a
@@ -4361,10 +4201,6 @@ me an orange constraint.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:56.976 --> 00:46:00.466 A:middle
-And when I did that, it gave
-me an orange constraint.
 
 00:46:00.996 --> 00:46:04.746 A:middle
 It's orange because my
@@ -4460,10 +4296,6 @@ fully specify the layout
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.156 --> 00:47:02.256 A:middle
-And these are enough to
-fully specify the layout
-
 00:47:02.256 --> 00:47:04.146 A:middle
 of my two labels.
 
@@ -4543,10 +4375,6 @@ is add a little padding
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.236 --> 00:48:00.196 A:middle
-So, what I want to do
-is add a little padding
 
 00:48:00.196 --> 00:48:01.556 A:middle
 on the right side, so that
@@ -4645,10 +4473,6 @@ this button here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.916 --> 00:49:01.946 A:middle
-you can see I have
-this button here.
-
 00:49:02.236 --> 00:49:04.806 A:middle
 And that's-- that indicates
 
@@ -4731,10 +4555,6 @@ here, it gives me a suggestion
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:57.236 --> 00:50:01.116 A:middle
-If I click on this button
-here, it gives me a suggestion
-
 00:50:01.436 --> 00:50:05.226 A:middle
 for how I might want
 to fix this issue.
@@ -4814,10 +4634,6 @@ let's imagine that instead
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:56.756 --> 00:51:00.076 A:middle
-And so for this example,
-let's imagine that instead
 
 00:51:00.076 --> 00:51:01.036 A:middle
 of this Date label here.
@@ -4912,10 +4728,6 @@ height constraints,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:57.236 --> 00:52:04.366 A:middle
-And when I delete these
-height constraints,
-
 00:52:04.366 --> 00:52:07.246 A:middle
 my view is ambiguous because
 Interface Builder doesn't have
@@ -4997,10 +4809,6 @@ navigator, issue navigator.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:56.366 --> 00:53:00.216 A:middle
-in your document using the mini
-navigator, issue navigator.
 
 00:53:01.276 --> 00:53:03.196 A:middle
 If you want to quickly
@@ -5093,10 +4901,6 @@ format for this.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:59.466 --> 00:54:01.056 A:middle
-and diff-able XML
-format for this.
 
 00:54:01.056 --> 00:54:01.156 A:middle
 [ Applause ]

--- a/2013/407.srt
+++ b/2013/407.srt
@@ -73,10 +73,6 @@ debugging is twice as hard
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.586 --> 00:01:00.906 A:middle
-"Everybody knows that
-debugging is twice as hard
-
 00:01:01.256 --> 00:01:02.816 A:middle
 as writing a program
 in the first place.
@@ -157,10 +153,6 @@ breakpoints navigator.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.816 --> 00:02:00.096 A:middle
-of course, we go to the
-breakpoints navigator.
 
 00:02:00.096 --> 00:02:06.616 A:middle
 And here you see a list of all
@@ -244,10 +236,6 @@ catch those errors in unit tests
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.636 --> 00:03:02.146 A:middle
-So that's a really great way to
-catch those errors in unit tests
-
 00:03:02.146 --> 00:03:06.286 A:middle
 and in your OpenGL
 ES games on iOS.
@@ -321,10 +309,6 @@ why you got to this point
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.646 --> 00:04:01.306 A:middle
-And so, you can figure out
-why you got to this point
 
 00:04:01.306 --> 00:04:03.866 A:middle
 and why maybe you need
@@ -404,10 +388,6 @@ some register states.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.236 --> 00:05:00.486 A:middle
-or you need to find out
-some register states.
-
 00:05:01.156 --> 00:05:09.406 A:middle
 And so, you can click on this
 toggle down here and change auto
@@ -486,10 +466,6 @@ the new debugging gauges
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.846 --> 00:06:01.346 A:middle
-about today including
-the new debugging gauges
-
 00:06:01.496 --> 00:06:03.746 A:middle
 which we saw briefly.
 
@@ -565,10 +541,6 @@ correct in the first place.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.946 --> 00:07:00.446 A:middle
-code that may not even be
-correct in the first place.
 
 00:07:00.446 --> 00:07:06.006 A:middle
 So if performance is
@@ -653,10 +625,6 @@ debugging gauges
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.246 --> 00:08:00.586 A:middle
-There's a bunch of
-debugging gauges
 
 00:08:00.586 --> 00:08:03.426 A:middle
 to show you the performance
@@ -743,10 +711,6 @@ which is the meter view.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.146 --> 00:09:01.886 A:middle
-First we have this view here
-which is the meter view.
-
 00:09:02.696 --> 00:09:04.966 A:middle
 The meter view shows you a
 snapshot of what's happening
@@ -825,10 +789,6 @@ across the whole system
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.316 --> 00:10:00.756 A:middle
-The next area is the utilization
-across the whole system
 
 00:10:00.756 --> 00:10:03.346 A:middle
 because all know that our
@@ -1006,10 +966,6 @@ it has similar sections
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.716 --> 00:12:06.586 A:middle
-And like the CPU report,
-it has similar sections
-
 00:12:06.636 --> 00:12:08.366 A:middle
 and the first section
 is the meter view.
@@ -1079,10 +1035,6 @@ can see at a glance
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:57.476 --> 00:13:00.176 A:middle
-And this is where you
-can see at a glance
 
 00:13:00.216 --> 00:13:02.706 A:middle
 that something might be going
@@ -1223,10 +1175,6 @@ time I change the filter.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.316 --> 00:15:00.606 A:middle
-or a quarter of a second every
-time I change the filter.
-
 00:15:00.606 --> 00:15:04.896 A:middle
 I'm going to assume that Apple
 has done an incredible job
@@ -1281,9 +1229,6 @@ And oops, so one key value pair.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.126 --> 00:16:02.076 A:middle
-And oops, so one key value pair.
 
 00:16:02.076 --> 00:16:02.816 A:middle
 So that's good.
@@ -1344,10 +1289,6 @@ what I saw, yup!
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:56.866 --> 00:17:01.476 A:middle
-Now, just to reconfirm
-what I saw, yup!
 
 00:17:01.986 --> 00:17:04.685 A:middle
 So now, we don't want
@@ -1425,10 +1366,6 @@ created, nothing is wrong here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.266 --> 00:18:01.276 A:middle
-So here is where the cache is
-created, nothing is wrong here.
-
 00:18:01.276 --> 00:18:07.366 A:middle
 Here is what I make use
 of it, seems-- looks OK.
@@ -1496,9 +1433,6 @@ So that the debug gauge,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.996 --> 00:19:02.386 A:middle
-So that the debug gauge,
 
 00:19:02.386 --> 00:19:05.046 A:middle
 the memory gauge validates
@@ -1575,9 +1509,6 @@ and memory gauge and try it out.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.576 --> 00:20:00.026 A:middle
-and memory gauge and try it out.
-
 00:20:02.376 --> 00:20:03.796 A:middle
 So memory seems pretty stable,
 
@@ -1651,10 +1582,6 @@ slew of threats just came on.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.146 --> 00:21:02.876 A:middle
-So I can see that a whole
-slew of threats just came on.
-
 00:21:03.616 --> 00:21:05.386 A:middle
 Now this-- that's
 weird too, you know,
@@ -1722,10 +1649,6 @@ report, scroll to the bottom,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.046 --> 00:22:05.636 A:middle
-And I'm going to bring up the
-report, scroll to the bottom,
 
 00:22:06.216 --> 00:22:08.836 A:middle
 try the rotation again.
@@ -1803,9 +1726,6 @@ to your application, thank you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.516 --> 00:23:07.216 A:middle
-[ Applause ]
 
 00:23:07.716 --> 00:23:08.756 A:middle
 &gt;&gt; Thank you, Han Ming.
@@ -1886,10 +1806,6 @@ all of the context we need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.336 --> 00:24:01.426 A:middle
-But a lot of times, we get
-all of the context we need
-
 00:24:01.666 --> 00:24:03.726 A:middle
 from our code and so it
 would be great to be able
@@ -1964,10 +1880,6 @@ handy because right there
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:56.826 --> 00:25:01.126 A:middle
-[applause] It's really
-handy because right there
 
 00:25:01.126 --> 00:25:03.136 A:middle
 in your code, right
@@ -2057,9 +1969,6 @@ and let's take a look at that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.516 --> 00:26:05.926 A:middle
-[ Pause ]
-
 00:26:06.426 --> 00:26:08.186 A:middle
 So we'll run our
 application here
@@ -2112,10 +2021,6 @@ creating a Bezier path
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:56.606 --> 00:27:00.356 A:middle
-So here we are, we're
-creating a Bezier path
 
 00:27:00.356 --> 00:27:02.166 A:middle
 that will become our mask
@@ -2184,10 +2089,6 @@ to nil that out.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.736 --> 00:28:01.186 A:middle
-I can enter zero
-to nil that out.
 
 00:28:01.536 --> 00:28:04.296 A:middle
 And now as we step over
@@ -2264,9 +2165,6 @@ We see that's 200, R1 is 100.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.946 --> 00:29:04.196 A:middle
-We see that's 200, R1 is 100.
-
 00:29:04.246 --> 00:29:05.146 A:middle
 So they're both the same,
 
@@ -2336,9 +2234,6 @@ So we're nearly there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.706 --> 00:30:01.436 A:middle
-So we're nearly there.
 
 00:30:02.806 --> 00:30:05.446 A:middle
 Now another thing you can
@@ -2411,10 +2306,6 @@ know, can picture the latitude
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.166 --> 00:31:01.266 A:middle
-not many people know, you
-know, can picture the latitude
-
 00:31:01.266 --> 00:31:04.026 A:middle
 and longitude of that, but we
 can use our visual Quick Looks
@@ -2485,10 +2376,6 @@ these things are put together
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.956 --> 00:32:01.246 A:middle
-with the information about how
-these things are put together
 
 00:32:01.246 --> 00:32:02.306 A:middle
 because it's really interesting.
@@ -2566,10 +2453,6 @@ to use in the past.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:56.916 --> 00:33:00.096 A:middle
-that you may have had
-to use in the past.
 
 00:33:00.256 --> 00:33:03.916 A:middle
 We also support NSString and
@@ -2649,10 +2532,6 @@ latitude and longitude is,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.176 --> 00:34:01.456 A:middle
-And so recognizing what that
-latitude and longitude is,
 
 00:34:01.636 --> 00:34:04.236 A:middle
 is very difficult unless
@@ -2734,10 +2613,6 @@ keynote document
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.466 --> 00:35:00.036 A:middle
-In fact, it's this
-keynote document
-
 00:35:00.036 --> 00:35:03.186 A:middle
 and I can see it right inside
 Xcode which is really powerful.
@@ -2814,10 +2689,6 @@ had invisible background
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.856 --> 00:36:02.396 A:middle
-And I had one icon that
-had invisible background
-
 00:36:02.516 --> 00:36:04.526 A:middle
 that was bigger and I didn't
 know which one it was.
@@ -2889,10 +2760,6 @@ switch gears and talk
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.836 --> 00:37:00.166 A:middle
-And now I'd like to
-switch gears and talk
 
 00:37:00.166 --> 00:37:02.106 A:middle
 about the specific
@@ -2968,10 +2835,6 @@ to come up.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.146 --> 00:38:02.226 A:middle
-for these XPC services
-to come up.
 
 00:38:02.226 --> 00:38:04.246 A:middle
 And when they do, your
@@ -3053,10 +2916,6 @@ you can check out the CPU
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.716 --> 00:39:02.106 A:middle
-in the debug navigator,
-you can check out the CPU
-
 00:39:02.106 --> 00:39:04.236 A:middle
 and memory reports for those.
 
@@ -3127,10 +2986,6 @@ our application starting up.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.476 --> 00:40:00.976 A:middle
-So I'll click the run here,
-our application starting up.
 
 00:40:01.176 --> 00:40:05.426 A:middle
 Now we've hit a breakpoint where
@@ -3274,10 +3129,6 @@ processes that you have running,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.186 --> 00:42:01.136 A:middle
-as well as your-- any XPC
-processes that you have running,
-
 00:42:01.136 --> 00:42:05.206 A:middle
 this is so that you can go
 back, change your source code
@@ -3340,10 +3191,6 @@ XPC integration in Xcode
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:54.196 --> 00:43:00.636 A:middle
-And we hope that the
-XPC integration in Xcode
 
 00:43:02.026 --> 00:43:05.806 A:middle
 for debugging your XPC
@@ -3422,10 +3269,6 @@ maybe use the new Quick Looks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.716 --> 00:44:02.976 A:middle
-Maybe you look at the CPU,
-maybe use the new Quick Looks
 
 00:44:03.056 --> 00:44:05.036 A:middle
 to solve the problem

--- a/2013/408.srt
+++ b/2013/408.srt
@@ -62,9 +62,6 @@ to give you better performance.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.496 --> 00:01:00.886 A:middle
-to give you better performance.
-
 00:01:01.566 --> 00:01:04.885 A:middle
 And then finally, we're
 going to talk about some new
@@ -129,10 +126,6 @@ at how that's possible.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.246 --> 00:02:01.016 A:middle
-So let's have a look
-at how that's possible.
 
 00:02:01.846 --> 00:02:05.756 A:middle
 We use Xcode's build
@@ -207,10 +200,6 @@ on code size.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.276 --> 00:03:02.116 A:middle
-without compromising
-on code size.
-
 00:03:02.606 --> 00:03:07.306 A:middle
 But for SciMark-2, we
 want more than that.
@@ -283,10 +272,6 @@ basic optimizations can provide
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.436 --> 00:04:03.046 A:middle
-so the kind of performance that
-basic optimizations can provide
-
 00:04:03.046 --> 00:04:07.226 A:middle
 and then we tell the compiler
 to be more aggressive with O3
@@ -356,10 +341,6 @@ longer available to the compiler
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.696 --> 00:05:01.426 A:middle
-that we've processed is no
-longer available to the compiler
-
 00:05:01.426 --> 00:05:03.946 A:middle
 when we move on to
 the next source file.
@@ -428,10 +409,6 @@ to the compiler and then
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.196 --> 00:06:01.426 A:middle
-which passes the LTO flag
-to the compiler and then
-
 00:06:01.426 --> 00:06:03.986 A:middle
 on to the linker so
 that the compiler
@@ -493,10 +470,6 @@ out what is most effective
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.646 --> 00:07:00.716 A:middle
-with these settings and find
-out what is most effective
 
 00:07:00.776 --> 00:07:03.876 A:middle
 and what is right for your app.
@@ -569,10 +542,6 @@ it up into multiple chunks
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.306 --> 00:08:02.556 A:middle
-at once instead of splitting
-it up into multiple chunks
-
 00:08:02.656 --> 00:08:05.326 A:middle
 that will then be split into
 -- across multiple cores.
@@ -631,10 +600,6 @@ operations, killing dead code,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:56.826 --> 00:09:00.476 A:middle
-removing redundant
-operations, killing dead code,
 
 00:09:01.116 --> 00:09:05.026 A:middle
 but to do that effectively,
@@ -791,10 +756,6 @@ to be conservative.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.556 --> 00:11:01.506 A:middle
-The compiler has
-to be conservative.
-
 00:11:02.696 --> 00:11:07.736 A:middle
 It has to believe that alias
 may exist between pointer C
@@ -920,10 +881,6 @@ based
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.316 --> 00:13:01.236 A:middle
-but there are complications
-based
-
 00:13:01.236 --> 00:13:04.376 A:middle
 on the underlying language,
 so about the floating point.
@@ -992,10 +949,6 @@ of a NaN or Not a Number,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:57.316 --> 00:14:01.456 A:middle
-Likewise, there's the concept
-of a NaN or Not a Number,
 
 00:14:02.216 --> 00:14:05.426 A:middle
 which means that a result of
@@ -1069,10 +1022,6 @@ our result changes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.766 --> 00:15:02.786 A:middle
-of evaluation and
-our result changes
-
 00:15:02.956 --> 00:15:04.316 A:middle
 in the least significant bits.
 
@@ -1135,10 +1084,6 @@ the compiler will be much more
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:55.326 --> 00:16:00.116 A:middle
-to relax IEEE compliance and now
-the compiler will be much more
 
 00:16:00.116 --> 00:16:03.346 A:middle
 aggressive about these
@@ -1217,10 +1162,6 @@ away the extra calculations
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.556 --> 00:17:03.716 A:middle
-to be more aggressive and fold
-away the extra calculations
-
 00:17:04.066 --> 00:17:06.126 A:middle
 giving much faster results.
 
@@ -1279,10 +1220,6 @@ and we want to use all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:54.796 --> 00:18:00.036 A:middle
-On iOS, we have ARM NEON
-and we want to use all
 
 00:18:00.036 --> 00:18:04.126 A:middle
 of these instructions to get the
@@ -1359,10 +1296,6 @@ at a time giving a very,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.426 --> 00:19:03.196 A:middle
-We compile four elements
-at a time giving a very,
-
 00:19:03.196 --> 00:19:07.316 A:middle
 very powerful improvement to
 our application's performance.
@@ -1437,10 +1370,6 @@ of these instructions.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.376 --> 00:20:01.936 A:middle
-It knows the semantics
-of these instructions.
-
 00:20:03.396 --> 00:20:08.296 A:middle
 So, it notices that we're doing
 a multiply and then accumulate,
@@ -1508,10 +1437,6 @@ independent vector extensions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:56.216 --> 00:21:02.626 A:middle
-so LLVM provides target
-independent vector extensions
-
 00:21:03.056 --> 00:21:06.926 A:middle
 that allow us to put the vector
 information into the type.
@@ -1577,10 +1502,6 @@ performed as vectors.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.426 --> 00:22:01.036 A:middle
-to be efficiently
-performed as vectors.
-
 00:22:02.496 --> 00:22:06.336 A:middle
 It assumes that it knows
 the underlying vector width
@@ -1643,10 +1564,6 @@ to you about some
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:58.716 --> 00:23:00.186 A:middle
-But he also talked
-to you about some
 
 00:23:00.186 --> 00:23:02.046 A:middle
 of the disadvantages
@@ -1719,10 +1636,6 @@ compute-intensive loops can
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:56.306 --> 00:24:03.066 A:middle
-So, only applications that have
-compute-intensive loops can
 
 00:24:03.066 --> 00:24:04.236 A:middle
 benefit from vectorization.
@@ -1800,10 +1713,6 @@ minor improvements due
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:57.736 --> 00:25:02.226 A:middle
-you see nice or very
-minor improvements due
-
 00:25:02.226 --> 00:25:03.036 A:middle
 to vectorization.
 
@@ -1876,9 +1785,6 @@ It is the Facetune app.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.576 --> 00:26:02.056 A:middle
-It is the Facetune app.
 
 00:26:02.526 --> 00:26:06.496 A:middle
 And a few weeks ago, we've
@@ -1955,10 +1861,6 @@ and turn the switch.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.266 --> 00:27:01.986 A:middle
-search for vectorization
-and turn the switch.
 
 00:27:03.026 --> 00:27:04.726 A:middle
 And once you enable
@@ -2038,10 +1940,6 @@ save them to a third array.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.796 --> 00:28:01.416 A:middle
-add the numbers together and
-save them to a third array.
-
 00:28:01.506 --> 00:28:03.656 A:middle
 That's a very basic loop, right?
 
@@ -2116,10 +2014,6 @@ process eight elements using the
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:54.596 --> 00:29:00.066 A:middle
-Because Haswell processors can
-process eight elements using the
-
 00:29:00.066 --> 00:29:05.696 A:middle
 AVX 2 instruction set and we
 support this instruction set.
@@ -2190,10 +2084,6 @@ variable or some argument
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.826 --> 00:30:03.756 A:middle
-The compiler only sees some
-variable or some argument
 
 00:30:03.756 --> 00:30:06.826 A:middle
 for function and it could be
@@ -2277,10 +2167,6 @@ are two problems.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.686 --> 00:31:00.116 A:middle
-But I say that there
-are two problems.
 
 00:31:00.816 --> 00:31:03.596 A:middle
 And this is the second problems
@@ -2366,9 +2252,6 @@ It's counterintuitive.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.086 --> 00:32:00.296 A:middle
-It's counterintuitive.
-
 00:32:00.296 --> 00:32:01.726 A:middle
 I didn't think it would happen.
 
@@ -2448,10 +2331,6 @@ code to check if the pointers
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.476 --> 00:33:05.436 A:middle
-Before every loop, we add some
-code to check if the pointers
-
 00:33:05.436 --> 00:33:07.136 A:middle
 that we're using overlap.
 
@@ -2525,10 +2404,6 @@ the compiler
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.846 --> 00:34:00.376 A:middle
-Remember how we tell
-the compiler
 
 00:34:01.506 --> 00:34:03.876 A:middle
 that pointers don't point
@@ -2604,9 +2479,6 @@ that you can use in some cases.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.826 --> 00:35:04.846 A:middle
-that you can use in some cases.
-
 00:35:04.846 --> 00:35:09.286 A:middle
 And there is also another
 thing that you can do.
@@ -2670,10 +2542,6 @@ information unless we inline the
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:55.346 --> 00:36:00.166 A:middle
-and we don't have any
-information unless we inline the
 
 00:36:00.166 --> 00:36:02.236 A:middle
 function call, and then
@@ -2758,9 +2626,6 @@ about in this context.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.846 --> 00:37:01.086 A:middle
-about in this context.
-
 00:37:01.136 --> 00:37:07.256 A:middle
 So, the vectorizer in order to
 vectorize a lot of loops has
@@ -2823,9 +2688,6 @@ tells the compiler,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.536 --> 00:38:02.176 A:middle
-"You cannot add runtime checks
 
 00:38:02.176 --> 00:38:04.616 A:middle
 and you cannot keep the
@@ -2976,10 +2838,6 @@ million elements in the array
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:58.546 --> 00:40:01.726 A:middle
-So we're processing all
-million elements in the array
-
 00:40:02.776 --> 00:40:03.966 A:middle
 into this temp variable.
 
@@ -3051,10 +2909,6 @@ for these processors.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.526 --> 00:41:02.376 A:middle
-And the compiler optimizes
-for these processors.
-
 00:41:04.926 --> 00:41:09.706 A:middle
 So, the compiler looks at the
 code that we have right here.
@@ -3125,10 +2979,6 @@ by unrolling it a little bit.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:56.746 --> 00:42:01.226 A:middle
-The compiler optimizes the code
-by unrolling it a little bit.
 
 00:42:01.826 --> 00:42:04.846 A:middle
 And the compiler
@@ -3206,10 +3056,6 @@ that one independent --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:56.156 --> 00:43:00.716 A:middle
-So we have the greens
-that one independent --
-
 00:43:01.066 --> 00:43:03.266 A:middle
 that's one chain of calculation
 and we have the purples.
@@ -3281,9 +3127,6 @@ The vectorizer did a good job.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.906 --> 00:44:00.206 A:middle
-The vectorizer did a good job.
-
 00:44:01.106 --> 00:44:03.006 A:middle
 But when we enable unrolling,
 
@@ -3354,10 +3197,6 @@ integers, but it's not okay
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:57.766 --> 00:45:01.006 A:middle
-And this is okay for
-integers, but it's not okay
 
 00:45:01.186 --> 00:45:03.706 A:middle
 for floating point numbers
@@ -3435,10 +3274,6 @@ look like this,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.686 --> 00:46:00.256 A:middle
-And this array will
-look like this,
-
 00:46:00.256 --> 00:46:02.676 A:middle
 will look like red green blue,
 red green blue, red green blue.
@@ -3511,10 +3346,6 @@ gather all of the greens.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:57.776 --> 00:47:00.706 A:middle
-that we need to do is
-gather all of the greens.
 
 00:47:01.756 --> 00:47:03.766 A:middle
 Now this is a pretty
@@ -3604,10 +3435,6 @@ greens, load the reds.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.346 --> 00:48:01.226 A:middle
-We just load the
-greens, load the reds.
-
 00:48:02.226 --> 00:48:02.906 A:middle
 That's very cheap.
 
@@ -3686,10 +3513,6 @@ between these two loops?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.706 --> 00:49:01.196 A:middle
-Now, what is the big difference
-between these two loops?
-
 00:49:01.436 --> 00:49:06.896 A:middle
 The only difference is that the
 one on top uses signed indices
@@ -3755,10 +3578,6 @@ the vectorizer will be able
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:56.586 --> 00:50:00.696 A:middle
-or signed indices, then
-the vectorizer will be able
 
 00:50:00.696 --> 00:50:01.556 A:middle
 to vectorize your code.
@@ -3847,10 +3666,6 @@ only two things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.686 --> 00:51:00.976 A:middle
-And now, there are
-only two things
-
 00:51:00.976 --> 00:51:01.766 A:middle
 that you need to remember.
 
@@ -3931,10 +3746,6 @@ and we'll answer your questions.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.086 --> 00:52:02.446 A:middle
-So you can always contact us
-and we'll answer your questions.
 
 00:52:02.986 --> 00:52:05.976 A:middle
 So, thank you very much

--- a/2013/409.srt
+++ b/2013/409.srt
@@ -148,10 +148,6 @@ either way you're going to want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.096 --> 00:02:01.256 A:middle
-it was just getting greedy, but
-either way you're going to want
-
 00:02:01.256 --> 00:02:03.896 A:middle
 to write a test to define
 what the correct behavior is
@@ -224,10 +220,6 @@ OS X server can run that test
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:56.016 --> 00:03:00.036 A:middle
-to your source repository,
-OS X server can run that test
 
 00:03:00.366 --> 00:03:01.966 A:middle
 when someone else on
@@ -316,10 +308,6 @@ the OS X server provides.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.096 --> 00:04:00.876 A:middle
-into the continuous integration
-the OS X server provides.
-
 00:04:02.096 --> 00:04:06.166 A:middle
 And finally, we'll look at
 some advanced configurations
@@ -389,10 +377,6 @@ the variation of that benchmark
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:55.716 --> 00:05:00.036 A:middle
-of that benchmark over time, or
-the variation of that benchmark
 
 00:05:00.076 --> 00:05:01.026 A:middle
 across different hardware.
@@ -469,10 +453,6 @@ level block diagram
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.176 --> 00:06:01.876 A:middle
-So here, we have a high
-level block diagram
-
 00:06:01.876 --> 00:06:03.876 A:middle
 of how your app might
 be structured.
@@ -547,10 +527,6 @@ the new testing framework
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:55.366 --> 00:07:00.846 A:middle
-It's really up to you, but
-the new testing framework
-
 00:07:01.296 --> 00:07:03.926 A:middle
 and UI features in
 Xcode 5 are designed
@@ -610,9 +586,6 @@ So what does a test look like?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.446 --> 00:08:01.226 A:middle
-So what does a test look like?
-
 00:08:03.456 --> 00:08:06.536 A:middle
 Tests are just ordinary
 Objective-C code.
@@ -670,10 +643,6 @@ which has been injected
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:57.736 --> 00:09:00.686 A:middle
-from the Xc test bundle
-which has been injected
 
 00:09:00.686 --> 00:09:01.516 A:middle
 into your application.
@@ -752,10 +721,6 @@ easy to run any test or group
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.996 --> 00:10:03.116 A:middle
-We've also made it really
-easy to run any test or group
-
 00:10:03.116 --> 00:10:05.746 A:middle
 of tests with just one click.
 
@@ -820,10 +785,6 @@ is really easy even
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.106 --> 00:11:01.746 A:middle
-Running each test
-is really easy even
-
 00:11:01.746 --> 00:11:03.206 A:middle
 without the test navigator open.
 
@@ -883,10 +844,6 @@ no tests for our project,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.986 --> 00:12:00.416 A:middle
-As you noticed we have
-no tests for our project,
 
 00:12:01.486 --> 00:12:06.076 A:middle
 go down to the plus menu
@@ -953,10 +910,6 @@ snippet ahead of time
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.766 --> 00:13:07.496 A:middle
-So, we created a code
-snippet ahead of time
-
 00:13:07.586 --> 00:13:10.136 A:middle
 that has a pre-cooked test
 for this demo which I'm going
@@ -1021,10 +974,6 @@ see if the second--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.076 --> 00:14:01.446 A:middle
-Then, we check to
-see if the second--
 
 00:14:01.446 --> 00:14:03.956 A:middle
 if the first piece is
@@ -1158,10 +1107,6 @@ test indicator.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.416 --> 00:16:00.586 A:middle
-by clicking on the
-test indicator.
 
 00:16:01.666 --> 00:16:04.066 A:middle
 So now we have a test
@@ -1297,10 +1242,6 @@ is bumped up by 5 percent.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.716 --> 00:18:02.576 A:middle
-gets a health pack and health
-is bumped up by 5 percent.
-
 00:18:03.676 --> 00:18:07.346 A:middle
 This may include EDGE Cases,
 but this is still situations
@@ -1375,10 +1316,6 @@ how it might throw an exemption
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.766 --> 00:19:03.776 A:middle
-to fail however it emits errors,
-how it might throw an exemption
-
 00:19:04.816 --> 00:19:07.866 A:middle
 if your addition method takes
 2 billion plus 2 billion,
@@ -1447,10 +1384,6 @@ created with useful information
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.526 --> 00:20:02.706 A:middle
-that those errors are actually
-created with useful information
 
 00:20:02.706 --> 00:20:06.436 A:middle
 in them and that they're
@@ -1527,10 +1460,6 @@ to your test class.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.866 --> 00:21:03.216 A:middle
-and giving it a reference
-to your test class.
-
 00:21:03.856 --> 00:21:05.216 A:middle
 Putting data and documents
 
@@ -1594,10 +1523,6 @@ will pass and then tear
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.046 --> 00:22:01.356 A:middle
-which in this case
-will pass and then tear
 
 00:22:01.356 --> 00:22:02.776 A:middle
 down is called on that instance.
@@ -1668,10 +1593,6 @@ all of the same test classes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.706 --> 00:23:04.016 A:middle
-Xcode 5 actually recognizes
-all of the same test classes
-
 00:23:04.376 --> 00:23:07.576 A:middle
 and will show you your classes
 and your test methods inside
@@ -1737,10 +1658,6 @@ to help you quickly run
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:57.996 --> 00:24:01.496 A:middle
-and the editor indicators
-to help you quickly run
-
 00:24:01.496 --> 00:24:02.666 A:middle
 and debug your tests
 
@@ -1801,10 +1718,6 @@ Add test failure breakpoint.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:52.426 --> 00:25:01.066 A:middle
-on the plus button and select
-Add test failure breakpoint.
 
 00:25:01.446 --> 00:25:03.846 A:middle
 So this special breakpoint stops
@@ -1879,9 +1792,6 @@ to move the piece there.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.516 --> 00:26:03.476 A:middle
-[ Pause ]
-
 00:26:03.976 --> 00:26:05.686 A:middle
 The debugger tool
 tip was telling us
@@ -1941,10 +1851,6 @@ over it and it looks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:56.716 --> 00:27:01.106 A:middle
-I'm going to step
-over it and it looks
 
 00:27:01.106 --> 00:27:02.466 A:middle
 like all location is not nil
@@ -2012,10 +1918,6 @@ NSRect and the boards--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.996 --> 00:28:02.036 A:middle
-and the performance of
-NSRect and the boards--
-
 00:28:02.766 --> 00:28:05.226 A:middle
 the location we were going to--
 in the form of an NSPoint,
@@ -2077,10 +1979,6 @@ under Perform Action,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.036 --> 00:29:00.536 A:middle
-So in the Product menu
-under Perform Action,
 
 00:29:00.536 --> 00:29:01.826 A:middle
 I'm going to select test again.
@@ -2150,10 +2048,6 @@ are any other test.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.026 --> 00:30:00.746 A:middle
-Let's see if there
-are any other test.
-
 00:30:02.106 --> 00:30:04.696 A:middle
 There's another test called test
 vertical move and let's switch
@@ -2216,9 +2110,6 @@ back to the slides.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:49.516 --> 00:31:11.906 A:middle
-[ Pause ]
 
 00:31:12.406 --> 00:31:13.806 A:middle
 So we just saw a
@@ -2287,10 +2178,6 @@ didn't see it in the demo
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.796 --> 00:32:04.406 A:middle
-The test pluses category we
-didn't see it in the demo
 
 00:32:04.556 --> 00:32:07.366 A:middle
 but it's a good way-- what it
@@ -2436,9 +2323,6 @@ is right for your team.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:56.516 --> 00:34:02.316 A:middle
-[ Pause ]
-
 00:34:02.816 --> 00:34:06.526 A:middle
 So, you could have multiple bots
 -- integrate all of the products
@@ -2511,9 +2395,6 @@ So once you've set up a bot
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.866 --> 00:35:01.546 A:middle
-So once you've set up a bot
 
 00:35:01.546 --> 00:35:04.656 A:middle
 for your project any time
@@ -2589,10 +2470,6 @@ on the simulator although
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:56.326 --> 00:36:01.526 A:middle
-You can also run your test
-on the simulator although
-
 00:36:01.526 --> 00:36:04.456 A:middle
 in the current OS X server
 seed that's not supported,
@@ -2662,10 +2539,6 @@ indicator to see what's wrong.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.006 --> 00:37:03.946 A:middle
-So I'm going to click on this
-indicator to see what's wrong.
-
 00:37:04.516 --> 00:37:10.236 A:middle
 [ Pause ]
 
@@ -2720,10 +2593,6 @@ can see all your tests and all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:55.726 --> 00:38:00.266 A:middle
-So I have-- this is where you
-can see all your tests and all
 
 00:38:00.266 --> 00:38:01.996 A:middle
 of the devices that are
@@ -2799,9 +2668,6 @@ So what could have gone wrong?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:54.786 --> 00:39:00.196 A:middle
-So what could have gone wrong?
 
 00:39:00.196 --> 00:39:02.766 A:middle
 Perhaps integration
@@ -2880,10 +2746,6 @@ for this method to find
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.766 --> 00:40:01.786 A:middle
-So let's look at the header
-for this method to find
-
 00:40:01.786 --> 00:40:02.856 A:middle
 out when it was introduced.
 
@@ -2945,9 +2807,6 @@ new AP-- the older API.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:56.516 --> 00:41:02.896 A:middle
-[ Pause ]
-
 00:41:03.396 --> 00:41:07.756 A:middle
 And now I think I fixed
 the test and fixed my code,
@@ -3002,10 +2861,6 @@ integrate.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.576 --> 00:42:00.906 A:middle
-to the bott and performing
-integrate.
-
 00:42:01.516 --> 00:42:07.016 A:middle
 [ Pause ]
 
@@ -3058,10 +2913,6 @@ is launched as we talked
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.596 --> 00:43:04.146 A:middle
-Then your application
-is launched as we talked
 
 00:43:04.146 --> 00:43:06.366 A:middle
 about earlier in the application
@@ -3191,10 +3042,6 @@ if you can start fresh
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.466 --> 00:45:02.256 A:middle
-Now, all of this is great
-if you can start fresh
 
 00:45:02.616 --> 00:45:05.086 A:middle
 with a brand new OS X
@@ -3335,9 +3182,6 @@ in Objective-C using Xc test.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.156 --> 00:47:00.156 A:middle
-in Objective-C using Xc test.
-
 00:47:01.906 --> 00:47:04.356 A:middle
 In the demo, we showed
 just how easy it was
@@ -3404,10 +3248,6 @@ on different devices
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.536 --> 00:48:01.596 A:middle
-of configurations
-on different devices
-
 00:48:02.026 --> 00:48:05.286 A:middle
 and how you can run all those
 configurations all the time
@@ -3473,10 +3313,6 @@ questions or feedback,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:56.856 --> 00:49:00.056 A:middle
-So, if you have any
-questions or feedback,
 
 00:49:00.396 --> 00:49:02.226 A:middle
 please let our evangelist

--- a/2013/410.srt
+++ b/2013/410.srt
@@ -78,10 +78,6 @@ starts loading data.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.396 --> 00:01:00.526 A:middle
-it starts executing,
-starts loading data.
-
 00:01:00.646 --> 00:01:04.025 A:middle
 It starts loading more
 and more and more data.
@@ -180,9 +176,6 @@ from your application,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.246 --> 00:02:00.196 A:middle
-from your application,
-
 00:02:00.496 --> 00:02:03.526 A:middle
 and because you're using too
 much memory the system needs
@@ -277,9 +270,6 @@ on to talking about Objective-C,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.266 --> 00:03:00.206 A:middle
-on to talking about Objective-C,
 
 00:03:00.436 --> 00:03:03.216 A:middle
 challenges on that front
@@ -381,10 +371,6 @@ don't like we can go directly
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.396 --> 00:04:00.906 A:middle
-that if you see a trend you
-don't like we can go directly
-
 00:04:00.906 --> 00:04:03.156 A:middle
 to Instruments from
 the debug gauge.
@@ -470,10 +456,6 @@ really what you're looking for.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.206 --> 00:05:02.126 A:middle
-to find that information and
-really what you're looking for.
 
 00:05:02.436 --> 00:05:05.596 A:middle
 So if you're looking for one
@@ -661,10 +643,6 @@ important information
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.286 --> 00:07:01.756 A:middle
-to measure a lot of
-important information
-
 00:07:01.756 --> 00:07:03.836 A:middle
 about the allocations that
 have already occurred.
@@ -761,9 +739,6 @@ That's no longer the case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.666 --> 00:08:00.866 A:middle
-That's no longer the case.
-
 00:08:01.456 --> 00:08:04.256 A:middle
 My total live bytes being
 reported here, 57 meg,
@@ -846,10 +821,6 @@ which files have been mapped
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:56.516 --> 00:09:00.476 A:middle
-which files, zoom back out,
-which files have been mapped
 
 00:09:00.476 --> 00:09:02.616 A:middle
 into my application,
@@ -1031,10 +1002,6 @@ the library and bring
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.766 --> 00:11:02.696 A:middle
-I'm going to dig into
-the library and bring
-
 00:11:02.696 --> 00:11:05.886 A:middle
 out one other familiar
 favorite, VM Tracker,
@@ -1107,10 +1074,6 @@ if you've used the Instruments
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.116 --> 00:12:01.946 A:middle
-I'd also like to point out that
-if you've used the Instruments
 
 00:12:01.976 --> 00:12:04.206 A:middle
 from sort of a casual
@@ -1199,10 +1162,6 @@ now more fully represented
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.306 --> 00:13:01.446 A:middle
-that virtual memory is
-now more fully represented
 
 00:13:01.656 --> 00:13:02.546 A:middle
 in allocations.
@@ -1376,10 +1335,6 @@ distinct chunks of memory.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.906 --> 00:15:00.766 A:middle
-And obviously they have
-distinct chunks of memory.
-
 00:15:01.186 --> 00:15:03.356 A:middle
 So this is a nice
 logical concept
@@ -1464,10 +1419,6 @@ it finds a page that's unused
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.916 --> 00:16:00.706 A:middle
-and running at this point, but
-it finds a page that's unused
 
 00:16:00.706 --> 00:16:03.386 A:middle
 and it maps it to a page
@@ -1561,10 +1512,6 @@ run into that limit.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.536 --> 00:17:01.496 A:middle
-So it's possible to
-run into that limit.
-
 00:17:01.736 --> 00:17:04.746 A:middle
 It is much more likely instead
 that I'll run into limits
@@ -1654,10 +1601,6 @@ have to keep in memory in order
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:56.236 --> 00:18:00.076 A:middle
-sorry, information that we
-have to keep in memory in order
-
 00:18:00.076 --> 00:18:01.686 A:middle
 for you to be able to
 continue executing.
@@ -1739,10 +1682,6 @@ versus shared memory.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:57.666 --> 00:19:00.226 A:middle
-of private memory
-versus shared memory.
 
 00:19:01.326 --> 00:19:03.566 A:middle
 When I create a memory
@@ -1917,10 +1856,6 @@ for fairly large things,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.886 --> 00:21:00.836 A:middle
-But it can also be used
-for fairly large things,
-
 00:21:00.936 --> 00:21:02.566 A:middle
 and it's in this managed area.
 
@@ -2014,10 +1949,6 @@ there are some types
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.926 --> 00:22:00.576 A:middle
-in mind are that
-there are some types
-
 00:22:00.636 --> 00:22:02.766 A:middle
 that are more expensive
 than others.
@@ -2102,10 +2033,6 @@ like it's going to add
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:58.716 --> 00:23:00.336 A:middle
-And this may not seem
-like it's going to add
 
 00:23:00.336 --> 00:23:02.296 A:middle
 up in a hurry except that some
@@ -2198,10 +2125,6 @@ deallocated on your behalf.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.616 --> 00:24:02.436 A:middle
-that the VM region is
-deallocated on your behalf.
-
 00:24:02.836 --> 00:24:04.516 A:middle
 So what can I do to investigate?
 
@@ -2282,9 +2205,6 @@ than just Objective-C classes.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.706 --> 00:25:01.736 A:middle
-than just Objective-C classes.
 
 00:25:01.956 --> 00:25:03.586 A:middle
 Specifically we're much,
@@ -2375,10 +2295,6 @@ pointer from any active object
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.856 --> 00:26:02.646 A:middle
-because there is no longer a
-pointer from any active object
 
 00:26:02.646 --> 00:26:04.956 A:middle
 that you reference we
@@ -2481,10 +2397,6 @@ cluttering up the world.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.326 --> 00:27:00.226 A:middle
-of other things and it's
-cluttering up the world.
-
 00:27:00.486 --> 00:27:02.766 A:middle
 And in this place
 maybe the right thing
@@ -2575,10 +2487,6 @@ there's some warmup cost here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.936 --> 00:28:02.426 A:middle
-Now, you may find that
-there's some warmup cost here.
-
 00:28:02.556 --> 00:28:04.756 A:middle
 We're loading code that
 hasn't been used before.
@@ -2663,10 +2571,6 @@ in the first place?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:59.736 --> 00:29:01.376 A:middle
-and how did I get there
-in the first place?
 
 00:29:02.296 --> 00:29:03.156 A:middle
 Well, here's how it happens.
@@ -2849,9 +2753,6 @@ that you're going to reference
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.386 --> 00:31:00.416 A:middle
-that you're going to reference
-
 00:31:00.416 --> 00:31:02.166 A:middle
 after the auto release
 pool has been drained.
@@ -2937,10 +2838,6 @@ to 0 the object is freed back
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.386 --> 00:32:02.136 A:middle
-Whenever the account drops
-to 0 the object is freed back
 
 00:32:02.136 --> 00:32:03.056 A:middle
 to the malloc subsystem.
@@ -3031,10 +2928,6 @@ many retains you're going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.926 --> 00:33:02.316 A:middle
-And so if you write too
-many retains you're going
 
 00:33:02.316 --> 00:33:05.196 A:middle
 to get objects that may not
@@ -3131,10 +3024,6 @@ issues you need to be able
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.726 --> 00:34:01.556 A:middle
-when you're debugging
-issues you need to be able
-
 00:34:01.556 --> 00:34:05.056 A:middle
 to understand all of the
 data, understand what retain
@@ -3208,10 +3097,6 @@ display of the cycle
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.576 --> 00:35:02.266 A:middle
-very nice graphical
-display of the cycle
 
 00:35:02.406 --> 00:35:05.426 A:middle
 so you can easily understand
@@ -3304,10 +3189,6 @@ problem that you have.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.746 --> 00:36:01.496 A:middle
-that this is the sort of
-problem that you have.
-
 00:36:02.866 --> 00:36:05.526 A:middle
 So how do we fix that?
 
@@ -3389,10 +3270,6 @@ only available
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.936 --> 00:37:00.186 A:middle
-previously this was
-only available
-
 00:37:00.186 --> 00:37:02.386 A:middle
 for iOS on the iOS Simulator.
 
@@ -3455,10 +3332,6 @@ underscore release.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.156 --> 00:38:00.276 A:middle
-in the debugger ObjC
-underscore release.
 
 00:38:00.446 --> 00:38:03.916 A:middle
 So it looks like we've
@@ -3531,10 +3404,6 @@ grouped together into one chunk.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:55.666 --> 00:39:00.336 A:middle
-auto release, retain release all
-grouped together into one chunk.
-
 00:39:01.006 --> 00:39:03.526 A:middle
 Now the scope bar here
 allows me to change my view
@@ -3601,9 +3470,6 @@ let's see here --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:54.516 --> 00:40:00.676 A:middle
-[ Pause ]
 
 00:40:01.176 --> 00:40:02.726 A:middle
 What we've got --
@@ -3694,10 +3560,6 @@ a little bit later,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.446 --> 00:41:00.746 A:middle
-So I'll talk about this
-a little bit later,
-
 00:41:00.746 --> 00:41:04.526 A:middle
 but what we really needed to
 do is was use a local NSError
@@ -3755,10 +3617,6 @@ the app a little bit and sort
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:57.496 --> 00:42:00.106 A:middle
-And I can just go ahead and use
-the app a little bit and sort
 
 00:42:00.106 --> 00:42:02.206 A:middle
 of get some activity going on.
@@ -3846,10 +3704,6 @@ the system configuration
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.016 --> 00:43:01.836 A:middle
-And they're all coming from
-the system configuration
-
 00:43:01.836 --> 00:43:03.236 A:middle
 system library.
 
@@ -3920,10 +3774,6 @@ and releases.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.356 --> 00:44:01.246 A:middle
-and not many retains
-and releases.
 
 00:44:01.966 --> 00:44:04.766 A:middle
 Well, I'd like to pair these up
@@ -4005,10 +3855,6 @@ a look at a couple leaks.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.496 --> 00:45:02.866 A:middle
-on an iOS device and taking
-a look at a couple leaks.
-
 00:45:04.516 --> 00:45:12.806 A:middle
 [ Applause ]
 
@@ -4089,10 +3935,6 @@ that's managed by ARC.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.306 --> 00:46:02.586 A:middle
-when it's an object
-that's managed by ARC.
 
 00:46:02.586 --> 00:46:06.146 A:middle
 And, finally, you
@@ -4176,10 +4018,6 @@ info is actually very useful.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.676 --> 00:47:02.266 A:middle
-that additional debugging
-info is actually very useful.
-
 00:47:02.266 --> 00:47:10.456 A:middle
 And so you can set it by just
 using the scheme editor and so
@@ -4255,9 +4093,6 @@ many things inside them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.056 --> 00:48:00.296 A:middle
-many things inside them.
 
 00:48:01.396 --> 00:48:03.916 A:middle
 And when they're copied
@@ -4346,10 +4181,6 @@ define a weakly notified self
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:55.626 --> 00:49:01.156 A:middle
-In this case we can just
-define a weakly notified self
 
 00:49:01.246 --> 00:49:03.176 A:middle
 and use it inside the block.
@@ -4511,10 +4342,6 @@ probably the best way to go.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.266 --> 00:51:00.116 A:middle
-and this is actually
-probably the best way to go.
-
 00:51:00.116 --> 00:51:05.256 A:middle
 Just create a strong object,
 promote your weak reference
@@ -4591,10 +4418,6 @@ easily get crashes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:57.846 --> 00:52:00.856 A:middle
-And so you can very
-easily get crashes
 
 00:52:00.856 --> 00:52:02.506 A:middle
 because these are
@@ -4679,10 +4502,6 @@ an auto release pool wrapping
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:57.476 --> 00:53:02.096 A:middle
-And this means that if there's
-an auto release pool wrapping
-
 00:53:02.096 --> 00:53:04.536 A:middle
 the assignment you can get
 some interesting behavior,
@@ -4753,10 +4572,6 @@ talk about is bridge gaps.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:53.446 --> 00:54:00.026 A:middle
-The final keyword I want to
-talk about is bridge gaps.
 
 00:54:00.026 --> 00:54:03.386 A:middle
 Now, ARC is great for
@@ -4841,10 +4656,6 @@ managed reference to a void star
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:54:57.606 --> 00:55:02.656 A:middle
-If you're casting from an ARC
-managed reference to a void star
-
 00:55:02.656 --> 00:55:03.546 A:middle
 or a CF reference,
 
@@ -4919,10 +4730,6 @@ is just older hardware.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:57.466 --> 00:56:00.976 A:middle
-If you're on an iPhone this
-is just older hardware.
 
 00:56:01.786 --> 00:56:04.556 A:middle
 Test your first install
@@ -5005,10 +4812,6 @@ warnings are issued
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:58.766 --> 00:57:01.356 A:middle
-And for iOS memory
-warnings are issued
 
 00:57:01.356 --> 00:57:02.836 A:middle
 and processes have terminated.
@@ -5103,10 +4906,6 @@ of your application,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:57:59.706 --> 00:58:01.996 A:middle
-This will lead to fragmentation
-of your application,
 
 00:58:02.336 --> 00:58:03.926 A:middle
 and avoidance is

--- a/2013/412.srt
+++ b/2013/412.srt
@@ -78,10 +78,6 @@ dig right in.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.966 --> 00:01:02.366 A:middle
-And after that we'll
-dig right in.
-
 00:01:02.516 --> 00:01:04.726 A:middle
 We'll start exploring the
 Xcode Service and we'll talk
@@ -166,10 +162,6 @@ give you the opportunity
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.446 --> 00:02:00.726 A:middle
-Continuous Integration will
-give you the opportunity
 
 00:02:00.726 --> 00:02:02.796 A:middle
 to do testing on
@@ -350,10 +342,6 @@ a single run of a bot.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.426 --> 00:04:01.966 A:middle
-And an integration is just
-a single run of a bot.
-
 00:04:02.236 --> 00:04:04.176 A:middle
 So every time your bot
 runs, your bot is said
@@ -434,10 +422,6 @@ source repository changes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.946 --> 00:05:02.676 A:middle
-So you can build when your
-source repository changes
 
 00:05:02.676 --> 00:05:03.806 A:middle
 and you can tell the server
@@ -621,9 +605,6 @@ and of course there's Xcode 5.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.806 --> 00:07:00.746 A:middle
-and of course there's Xcode 5.
-
 00:07:00.996 --> 00:07:02.886 A:middle
 So let's start by digging
 
@@ -717,10 +698,6 @@ it's never look better
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.826 --> 00:08:01.586 A:middle
-Server looks great,
-it's never look better
-
 00:08:01.586 --> 00:08:03.926 A:middle
 and we're actually servicing
 some really useful information
@@ -809,10 +786,6 @@ when it's turned
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.486 --> 00:09:00.476 A:middle
-The Xcode Service
-when it's turned
 
 00:09:00.476 --> 00:09:03.046 A:middle
 on in OS X Server will
@@ -905,10 +878,6 @@ and also download all
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.256 --> 00:10:02.506 A:middle
-and iOS signing identities
-and also download all
-
 00:10:02.506 --> 00:10:03.686 A:middle
 of the team provisioning
 profiles
@@ -991,9 +960,6 @@ the way you like it to.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:54.516 --> 00:11:00.946 A:middle
-[ Applause ]
 
 00:11:01.446 --> 00:11:03.806 A:middle
 And of course, if you're
@@ -1085,10 +1051,6 @@ the Add button right here
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.266 --> 00:12:00.166 A:middle
-So, to do that, we click
-the Add button right here
 
 00:12:01.506 --> 00:12:03.496 A:middle
 and we'll be asked for
@@ -1192,10 +1154,6 @@ support source control hosting
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.806 --> 00:13:01.086 A:middle
-And as an example, we do
-support source control hosting
 
 00:13:01.086 --> 00:13:03.896 A:middle
 like I said and here's
@@ -1379,10 +1337,6 @@ full commit history for all
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.616 --> 00:15:02.436 A:middle
-in the server you'll also see
-full commit history for all
-
 00:15:02.436 --> 00:15:04.736 A:middle
 of the commits that were
 included in that build.
@@ -1470,10 +1424,6 @@ can be hard to set up,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.356 --> 00:16:01.046 A:middle
-And they're great but they
-can be hard to set up,
 
 00:16:01.166 --> 00:16:04.146 A:middle
 they can be hard to maintain,
@@ -1569,10 +1519,6 @@ idea if you want to able
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.256 --> 00:17:00.826 A:middle
-and that's really good
-idea if you want to able
 
 00:17:00.826 --> 00:17:01.946 A:middle
 to access it from anywhere.
@@ -1675,10 +1621,6 @@ get source code for your team.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.286 --> 00:18:03.186 A:middle
-So that's a really great way to
-get source code for your team.
-
 00:18:04.106 --> 00:18:05.956 A:middle
 So, let's see what the state
 of this project is like.
@@ -1769,10 +1711,6 @@ the bot for Bubblegum.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.166 --> 00:19:02.426 A:middle
-I'm going to show you
-the bot for Bubblegum.
 
 00:19:02.426 --> 00:19:03.146 A:middle
 I'll click on that here.
@@ -1969,10 +1907,6 @@ when this bot run.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.186 --> 00:21:01.016 A:middle
-that were created
-when this bot run.
-
 00:21:01.316 --> 00:21:02.446 A:middle
 So you made-- the only sub--
 
@@ -2067,10 +2001,6 @@ integration sessions
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.266 --> 00:22:01.666 A:middle
-of his classic late night
-integration sessions
 
 00:22:02.016 --> 00:22:03.496 A:middle
 where he wasn't as
@@ -2247,10 +2177,6 @@ for that particular test case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.386 --> 00:24:01.686 A:middle
-it will show me the source code
-for that particular test case.
-
 00:24:01.896 --> 00:24:03.006 A:middle
 I think that's really great.
 
@@ -2357,10 +2283,6 @@ Service is running unit tests
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:57.026 --> 00:25:01.036 A:middle
-and what this means is the Xcode
-Service is running unit tests
-
 00:25:01.146 --> 00:25:02.496 A:middle
 on all these devices.
 
@@ -2466,10 +2388,6 @@ like from the beginning.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.706 --> 00:26:01.636 A:middle
-I'll show you what it looks
-like from the beginning.
-
 00:26:02.406 --> 00:26:04.286 A:middle
 So, I'll put in an
 Xcode project,
@@ -2556,10 +2474,6 @@ project, let's create a bot.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.716 --> 00:27:02.496 A:middle
-Okay. So we created a new
-project, let's create a bot.
 
 00:27:02.796 --> 00:27:05.746 A:middle
 We do that in a Product Menu,
@@ -2656,10 +2570,6 @@ bot to run static analysis,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.676 --> 00:28:01.166 A:middle
-You may or may not want your
-bot to run static analysis,
 
 00:28:01.166 --> 00:28:02.926 A:middle
 to perform tests or
@@ -2762,10 +2672,6 @@ the Assistant, that's good
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.046 --> 00:29:00.036 A:middle
-that I left checked in
-the Assistant, that's good
-
 00:29:00.336 --> 00:29:02.956 A:middle
 but if you don't do that, you
 can always show your scheme
@@ -2857,9 +2763,6 @@ Thank you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:55.516 --> 00:30:01.536 A:middle
-[ Applause ]
 
 00:30:02.036 --> 00:30:02.726 A:middle
 &gt;&gt; Thank you, Brent.
@@ -2962,10 +2865,6 @@ and test results.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.126 --> 00:31:00.856 A:middle
-issues and warnings
-and test results.
-
 00:31:01.536 --> 00:31:04.766 A:middle
 In the center you see summary
 grafts for your build history
@@ -3054,10 +2953,6 @@ created a rebuild and it was
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:56.786 --> 00:32:02.206 A:middle
-And with just a few clicks, it
-created a rebuild and it was
 
 00:32:02.206 --> 00:32:04.346 A:middle
 on the server ready for him and
@@ -3156,9 +3051,6 @@ or remote repositories
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.146 --> 00:33:00.206 A:middle
-or remote repositories
-
 00:33:00.206 --> 00:33:03.866 A:middle
 that you've already
 connected up in server app.
@@ -3254,10 +3146,6 @@ right in your iOS device.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.706 --> 00:34:00.736 A:middle
-from the Xcode Service
-right in your iOS device.
-
 00:34:01.516 --> 00:34:07.936 A:middle
 [ Applause ]
 
@@ -3341,10 +3229,6 @@ some bots are queued ready
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.546 --> 00:35:00.176 A:middle
-Some bots are succeeding,
-some bots are queued ready
 
 00:35:00.176 --> 00:35:02.626 A:middle
 to be built, some bots
@@ -3450,10 +3334,6 @@ that our project went
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.026 --> 00:36:00.646 A:middle
-So you can see here
-that our project went
-
 00:36:00.646 --> 00:36:02.386 A:middle
 through a particularly
 rough patch of having a lot
@@ -3548,10 +3428,6 @@ of all the bots in your server.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.486 --> 00:37:01.546 A:middle
-or spare monitor presentation
-of all the bots in your server.
 
 00:37:02.036 --> 00:37:04.496 A:middle
 So if you have an open
@@ -3728,10 +3604,6 @@ the Archives page.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.476 --> 00:39:00.046 A:middle
-And of course we have
-the Archives page.
-
 00:39:00.046 --> 00:39:01.956 A:middle
 And the Archives page is
 a great way to ship builds
@@ -3828,9 +3700,6 @@ then you'll be glad to hear
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.336 --> 00:40:00.916 A:middle
-then you'll be glad to hear
 
 00:40:00.916 --> 00:40:03.186 A:middle
 that the Xcode Service
@@ -4025,10 +3894,6 @@ my team, we recently switched
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.536 --> 00:42:01.796 A:middle
-And the third is if you are like
-my team, we recently switched
-
 00:42:01.796 --> 00:42:03.666 A:middle
 to Git and we're a little
 branch happy right now
@@ -4118,10 +3983,6 @@ get yourself a copy of Xcode 5
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.746 --> 00:43:01.616 A:middle
-And after that, you need to
-get yourself a copy of Xcode 5
-
 00:43:01.616 --> 00:43:05.356 A:middle
 and Xcode 5 will run happily
 on Mountain Lion and Mavericks
@@ -4207,10 +4068,6 @@ once you've set up these bots,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:56.946 --> 00:44:00.036 A:middle
-It's super simple to set up and
-once you've set up these bots,
 
 00:44:00.686 --> 00:44:04.336 A:middle
 you can build and you can
@@ -4314,10 +4171,6 @@ source control session later
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.976 --> 00:45:02.406 A:middle
-and also there's a dedicated
-source control session later
 
 00:45:02.406 --> 00:45:03.006 A:middle
 in the week too.

--- a/2013/413.srt
+++ b/2013/413.srt
@@ -75,10 +75,6 @@ that knows how to do all kinds
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.386 --> 00:01:02.546 A:middle
-LLDB is essentially a library
-that knows how to do all kinds
-
 00:01:02.546 --> 00:01:04.916 A:middle
 of interesting things with
 the running application.
@@ -175,10 +171,6 @@ defect in your code.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:56.196 --> 00:02:00.016 A:middle
-and finding a specific
-defect in your code.
-
 00:02:00.236 --> 00:02:01.846 A:middle
 Because our collective
 goal is to make sure
@@ -266,10 +258,6 @@ faster, more predictably
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.376 --> 00:03:02.656 A:middle
-of the old features working
-faster, more predictably
-
 00:03:02.916 --> 00:03:04.726 A:middle
 with fewer edge cases
 that you need to worry
@@ -355,10 +343,6 @@ Objective-Constants,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:59.736 --> 00:04:02.366 A:middle
-for Objective-C,
-Objective-Constants,
 
 00:04:02.956 --> 00:04:06.556 A:middle
 they just showed up in LLDB and
@@ -453,10 +437,6 @@ ideas, things like assertions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.596 --> 00:05:01.596 A:middle
-They should be familiar
-ideas, things like assertions
-
 00:05:01.596 --> 00:05:04.156 A:middle
 and logging, static
 analysis, and using some
@@ -546,10 +526,6 @@ been taken care of,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:56.766 --> 00:06:00.156 A:middle
-that these have not
-been taken care of,
 
 00:06:00.526 --> 00:06:02.306 A:middle
 that's why you're not getting
@@ -642,10 +618,6 @@ on how you can write debug code
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:55.726 --> 00:07:00.146 A:middle
-And lastly, we want to focus
-on how you can write debug code
 
 00:07:00.386 --> 00:07:02.916 A:middle
 without stopping your
@@ -740,10 +712,6 @@ need to pick our focus.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.946 --> 00:08:01.986 A:middle
-The answer is step one we
-need to pick our focus.
-
 00:08:02.506 --> 00:08:03.666 A:middle
 We need to choose what it is
 
@@ -828,9 +796,6 @@ Thank you, Sean.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.186 --> 00:09:00.006 A:middle
-&gt;&gt; Thank you very much, Kate.
-
 00:09:00.756 --> 00:09:04.066 A:middle
 I'm really excited to show you
 all the great ways you can debug
@@ -909,10 +874,6 @@ cases where your app is,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.906 --> 00:10:03.966 A:middle
-So this is really for
-cases where your app is,
-
 00:10:04.306 --> 00:10:07.336 A:middle
 has encountered something
 that just can't be.
@@ -986,10 +947,6 @@ compiled into your code,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.076 --> 00:11:00.516 A:middle
-When you've got an assertion
-compiled into your code,
-
 00:11:01.646 --> 00:11:06.046 A:middle
 the condition is evaluated
 only if the assertion is there.
@@ -1058,10 +1015,6 @@ are that you're sending out.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.076 --> 00:12:02.306 A:middle
-how severe the log messages
-are that you're sending out.
 
 00:12:03.386 --> 00:12:07.236 A:middle
 You can distinguish between
@@ -1142,9 +1095,6 @@ and printing everything.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.656 --> 00:13:00.776 A:middle
-and printing everything.
 
 00:13:01.406 --> 00:13:03.416 A:middle
 Now maybe, you want to
@@ -1296,10 +1246,6 @@ console to achieve many
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.716 --> 00:15:00.676 A:middle
-through the LLDB
-console to achieve many
-
 00:15:00.676 --> 00:15:02.366 A:middle
 of the same things
 and a couple more.
@@ -1366,10 +1312,6 @@ that a couple of times,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.076 --> 00:16:00.916 A:middle
-Now, after you've used
-that a couple of times,
 
 00:16:00.956 --> 00:16:03.066 A:middle
 you're probably going to say,
@@ -1598,10 +1540,6 @@ at the console, then going back
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.606 --> 00:19:01.866 A:middle
-back to Xcode, doing something
-at the console, then going back
-
 00:19:01.866 --> 00:19:03.656 A:middle
 to your app doing some what--
 
@@ -1684,10 +1622,6 @@ this in Xcode too.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.136 --> 00:20:02.016 A:middle
-There's a way to do
-this in Xcode too.
-
 00:20:02.726 --> 00:20:05.636 A:middle
 You select the breakpoint,
 you right-click,
@@ -1765,10 +1699,6 @@ this example here,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.886 --> 00:21:00.496 A:middle
-So let's look at
-this example here,
-
 00:21:00.776 --> 00:21:05.356 A:middle
 I'm stopped at the Init function
 for a class I wrote and I want
@@ -1837,9 +1767,6 @@ to the current value of self.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:56.866 --> 00:22:00.626 A:middle
-to the current value of self.
-
 00:22:00.816 --> 00:22:04.906 A:middle
 That's really handy and you
 can do in the next code too.
@@ -1902,10 +1829,6 @@ watchpoint set variable command
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:55.116 --> 00:23:00.176 A:middle
-In this case, you use the
-watchpoint set variable command
 
 00:23:00.176 --> 00:23:04.846 A:middle
 to do so and LLDB will stop the
@@ -1973,10 +1896,6 @@ stopped right
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.416 --> 00:24:00.456 A:middle
-Now notice here we've
-stopped right
 
 00:24:00.456 --> 00:24:03.656 A:middle
 after we actually set the
@@ -2049,10 +1968,6 @@ that I run into when I'm trying
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.696 --> 00:25:04.996 A:middle
-One of the most annoying things
-that I run into when I'm trying
-
 00:25:04.996 --> 00:25:08.726 A:middle
 to step is I'm at one place
 in my function, I want to get
@@ -2119,10 +2034,6 @@ line you tell it to or if you're
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:53.726 --> 00:26:01.036 A:middle
-until which will stop at the
-line you tell it to or if you're
 
 00:26:01.036 --> 00:26:04.086 A:middle
 about to leave the function
@@ -2191,10 +2102,6 @@ you were doing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.186 --> 00:27:01.246 A:middle
-and we remember what
-you were doing
-
 00:27:01.376 --> 00:27:02.676 A:middle
 when you hit that breakpoint.
 
@@ -2257,10 +2164,6 @@ where you're testing your code
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:56.946 --> 00:28:01.816 A:middle
-Sometimes you're in situations
-where you're testing your code
 
 00:28:02.006 --> 00:28:04.386 A:middle
 and you're trying to
@@ -2327,10 +2230,6 @@ and you can watch it run.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.786 --> 00:29:01.196 A:middle
-when you've entered function
-and you can watch it run.
 
 00:29:02.736 --> 00:29:07.356 A:middle
 Now remember, because we're
@@ -2404,9 +2303,6 @@ I'm Enrico.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.776 --> 00:30:00.796 A:middle
-I'm Enrico.
 
 00:30:00.866 --> 00:30:04.126 A:middle
 I'm one of the engineers that
@@ -2495,10 +2391,6 @@ of the LLDB facilities
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.216 --> 00:31:00.586 A:middle
-Well, I like to think
-of the LLDB facilities
-
 00:31:00.666 --> 00:31:03.186 A:middle
 to show data as a tool box.
 
@@ -2581,10 +2473,6 @@ clang right there,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.286 --> 00:32:01.126 A:middle
-We're actually having
-clang right there,
 
 00:32:01.196 --> 00:32:03.686 A:middle
 that means a type
@@ -2670,10 +2558,6 @@ that Apple implemented
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.486 --> 00:33:02.756 A:middle
-Description is the select
-that Apple implemented
-
 00:33:02.756 --> 00:33:06.196 A:middle
 for see some classes, but
 that you can also implement
@@ -2741,10 +2625,6 @@ types, maybe we got a library
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:56.406 --> 00:34:00.056 A:middle
-or maybe it's not our own
-types, maybe we got a library
 
 00:34:00.056 --> 00:34:01.506 A:middle
 and we're trying to
@@ -2903,10 +2783,6 @@ with the LLDB data formatters.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.696 --> 00:36:01.386 A:middle
-And the way to get here is
-with the LLDB data formatters.
-
 00:36:02.036 --> 00:36:08.556 A:middle
 The cool news is, we did all
 the work for system libraries.
@@ -3052,10 +2928,6 @@ name, you say type name full,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:57.986 --> 00:38:02.076 A:middle
-The base matching is by
-name, you say type name full,
-
 00:38:02.076 --> 00:38:04.666 A:middle
 LLDB call this function
 to summarize the object.
@@ -3139,10 +3011,6 @@ string if you have any?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.316 --> 00:39:01.286 A:middle
-what's your summary
-string if you have any?
 
 00:39:01.696 --> 00:39:03.346 A:middle
 Do you have children?
@@ -3236,10 +3104,6 @@ first and my last name.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:58.606 --> 00:40:00.326 A:middle
-that represent my
-first and my last name.
-
 00:40:00.776 --> 00:40:03.526 A:middle
 And since our Python strings,
 I'm really free to the--
@@ -3312,10 +3176,6 @@ its format 'cause they didn't
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.056 --> 00:41:00.136 A:middle
-and you don't really know
-its format 'cause they didn't
 
 00:41:00.136 --> 00:41:01.086 A:middle
 [inaudible] you how
@@ -3396,10 +3256,6 @@ the expression parser,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.766 --> 00:42:00.856 A:middle
-of having the compiler
-the expression parser,
-
 00:42:01.286 --> 00:42:03.336 A:middle
 you can define a
 full native structure
@@ -3474,10 +3330,6 @@ it can extend the debugger
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.286 --> 00:43:00.556 A:middle
-Let's talk about ways that
-it can extend the debugger
 
 00:43:00.846 --> 00:43:04.186 A:middle
 and make the debugger
@@ -3559,10 +3411,6 @@ terms of how easy
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.426 --> 00:44:01.796 A:middle
-that transition in
-terms of how easy
 
 00:44:01.796 --> 00:44:04.296 A:middle
 to maintain your commands
@@ -3655,10 +3503,6 @@ of a great LLDB Command.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.146 --> 00:45:03.936 A:middle
-Let's make a quick example
-of a great LLDB Command.
-
 00:45:04.536 --> 00:45:06.706 A:middle
 Let's say that my
 program is a recursion.
@@ -3750,10 +3594,6 @@ the debugger, the entire power
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.046 --> 00:46:02.036 A:middle
-It means it's the full power of
-the debugger, the entire power
-
 00:46:02.036 --> 00:46:05.516 A:middle
 of the debugger and you that you
 use in Xcode is available to you
@@ -3833,10 +3673,6 @@ suddenly becomes a live entity,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:56.956 --> 00:47:00.616 A:middle
-all that wet and toiling too
-suddenly becomes a live entity,
 
 00:47:00.836 --> 00:47:03.726 A:middle
 you can suddenly type and type
@@ -3929,10 +3765,6 @@ of Python commands.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:57.446 --> 00:48:00.656 A:middle
-That's the prototype
-of Python commands.
-
 00:48:01.616 --> 00:48:04.526 A:middle
 They get past the debugger
 which an SB Debugger.
@@ -4022,10 +3854,6 @@ of your recursion.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.856 --> 00:49:01.686 A:middle
-like there's 10 frames
-of your recursion.
 
 00:49:01.926 --> 00:49:04.846 A:middle
 This is how you do
@@ -4194,10 +4022,6 @@ have counted the frames
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:58.906 --> 00:51:01.306 A:middle
-Some of you probably
-have counted the frames
 
 00:51:01.396 --> 00:51:03.506 A:middle
 and raise your hand
@@ -4370,10 +4194,6 @@ one breakpoint command at.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:57.616 --> 00:53:00.416 A:middle
-And that's how you bind
-one breakpoint command at.
-
 00:53:01.026 --> 00:53:05.226 A:middle
 Let's give an example,
 let's go back
@@ -4458,10 +4278,6 @@ recursion is and I need to stop
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:57.306 --> 00:54:00.796 A:middle
-I need to see how deep the
-recursion is and I need to stop
 
 00:54:00.796 --> 00:54:03.476 A:middle
 if that's more deep than
@@ -4638,9 +4454,6 @@ up a debug session with LLDB.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:59.796 --> 00:56:01.476 A:middle
-up a debug session with LLDB.
-
 00:56:02.226 --> 00:56:04.656 A:middle
 It's a great place to
 treat debugger settings.
@@ -4708,10 +4521,6 @@ be effective when debugging.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:56.786 --> 00:57:00.096 A:middle
-Sean showed us great way to
-be effective when debugging.
 
 00:57:01.076 --> 00:57:03.606 A:middle
 How I can use logging
@@ -4801,10 +4610,6 @@ what you're looking for,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:57:58.286 --> 00:58:00.796 A:middle
-If you don't know exactly
-what you're looking for,
 
 00:58:01.036 --> 00:58:02.756 A:middle
 you can use the appropriate

--- a/2013/414.srt
+++ b/2013/414.srt
@@ -202,10 +202,6 @@ that project under Git
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.036 --> 00:03:01.036 A:middle
-with a new project, putting
-that project under Git
-
 00:03:01.036 --> 00:03:05.086 A:middle
 and automatically pushing that
 project to your OS X server.
@@ -272,10 +268,6 @@ you open a project
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:56.886 --> 00:04:01.126 A:middle
-Now the first time
-you open a project
 
 00:04:01.126 --> 00:04:03.416 A:middle
 in Xcode 5 you'll
@@ -355,10 +347,6 @@ blame for modified files.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.046 --> 00:05:01.616 A:middle
-We've also added support for
-blame for modified files.
 
 00:05:01.996 --> 00:05:06.646 A:middle
 I'm sure you've been working in
@@ -509,10 +497,6 @@ new features of Xcode 5
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:56.726 --> 00:07:00.476 A:middle
-We've taken a lot of the
-new features of Xcode 5
-
 00:07:00.546 --> 00:07:02.186 A:middle
 and all the old ones
 and put them
@@ -591,10 +575,6 @@ copies right there
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.336 --> 00:08:00.256 A:middle
-of those working
-copies right there
-
 00:08:00.256 --> 00:08:02.466 A:middle
 so you know what you
 are committing to
@@ -658,10 +638,6 @@ that you have checked
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.026 --> 00:09:00.726 A:middle
-as recent repositories
-that you have checked
 
 00:09:00.726 --> 00:09:02.016 A:middle
 out from right there.
@@ -731,10 +707,6 @@ that's a little ambiguous
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.806 --> 00:10:00.496 A:middle
-But if you put in a URL
-that's a little ambiguous
 
 00:10:00.956 --> 00:10:03.766 A:middle
 such as sometimes if you have
@@ -961,10 +933,6 @@ now loaded all the history
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.236 --> 00:13:02.726 A:middle
-So I click that and Xcode has
-now loaded all the history
-
 00:13:02.726 --> 00:13:04.326 A:middle
 for this workspace.
 
@@ -1048,10 +1016,6 @@ of that commit and allows me
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.956 --> 00:14:01.296 A:middle
-that were changed as part
-of that commit and allows me
-
 00:14:01.296 --> 00:14:02.526 A:middle
 to look at the changes.
 
@@ -1119,10 +1083,6 @@ for your main app
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.416 --> 00:15:00.246 A:middle
-You'll have a repository
-for your main app
 
 00:15:00.246 --> 00:15:03.666 A:middle
 and you may be using some Open
@@ -1277,10 +1237,6 @@ only had one branch
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.446 --> 00:17:02.586 A:middle
-This particular project
-only had one branch
-
 00:17:02.626 --> 00:17:04.756 A:middle
 so it didn't even ask me which
 branch I wanted to checkout.
@@ -1361,10 +1317,6 @@ of the other tools sessions,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.256 --> 00:18:01.936 A:middle
-which you may have seen in some
-of the other tools sessions,
 
 00:18:02.766 --> 00:18:05.556 A:middle
 and now there is this libraries
@@ -1509,10 +1461,6 @@ but I know that we're going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.126 --> 00:20:00.116 A:middle
-Currently it's set to optional
-but I know that we're going
-
 00:20:00.116 --> 00:20:00.876 A:middle
 to soon require this to build.
 
@@ -1596,10 +1544,6 @@ get access to it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.686 --> 00:21:01.496 A:middle
-of my coworkers can
-get access to it
-
 00:21:01.496 --> 00:21:03.226 A:middle
 when they update their
 local working copies.
@@ -1674,10 +1618,6 @@ this branch locally in Git,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.606 --> 00:22:02.706 A:middle
-Now since I just created
-this branch locally in Git,
 
 00:22:03.046 --> 00:22:04.976 A:middle
 I know that all my coworkers
@@ -1756,10 +1696,6 @@ two branches that asks me
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.896 --> 00:23:01.506 A:middle
-Now we see because I have
-two branches that asks me
-
 00:23:01.506 --> 00:23:02.536 A:middle
 which one I want to check out.
 
@@ -1835,10 +1771,6 @@ including our multiple working
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:57.396 --> 00:24:01.646 A:middle
-in the new checkout workflow
-including our multiple working
 
 00:24:01.646 --> 00:24:02.366 A:middle
 copy support.
@@ -1916,9 +1848,6 @@ collaboration tool.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.146 --> 00:25:00.136 A:middle
-collaboration tool.
 
 00:25:00.666 --> 00:25:03.226 A:middle
 We've added one of the most
@@ -2108,10 +2037,6 @@ So let's look back at those
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.336 --> 00:27:03.436 A:middle
-So let's look back at those
-3 C's of Source Control
 
 00:27:03.436 --> 00:27:05.856 A:middle
 that Kevin was talking
@@ -2307,9 +2232,6 @@ at the code and do the merge.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.806 --> 00:29:00.966 A:middle
-at the code and do the merge.
-
 00:29:02.556 --> 00:29:04.656 A:middle
 Make sure that you're always
 checking each other's code
@@ -2406,10 +2328,6 @@ high level concept
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.886 --> 00:30:02.906 A:middle
-So let's look at a
-high level concept
-
 00:30:02.906 --> 00:30:04.216 A:middle
 of what exactly is a branch.
 
@@ -2498,10 +2416,6 @@ and merge it and now everything
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:56.956 --> 00:31:01.366 A:middle
-And at that point we'll go ahead
-and merge it and now everything
 
 00:31:01.366 --> 00:31:02.696 A:middle
 that was on that branch is now
@@ -2595,9 +2509,6 @@ by making a commit locally.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.736 --> 00:32:00.816 A:middle
-by making a commit locally.
-
 00:32:01.206 --> 00:32:03.596 A:middle
 Now committing locally in
 Git does not push that change
@@ -2689,10 +2600,6 @@ this in a quick little demo.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.886 --> 00:33:04.296 A:middle
-So let's take a look at
-this in a quick little demo.
-
 00:33:05.286 --> 00:33:10.726 A:middle
 So I'm going to login to my
 account and I'm also working
@@ -2767,10 +2674,6 @@ that I can't switch to it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.346 --> 00:34:00.446 A:middle
-and since I'm already on
-that I can't switch to it.
 
 00:34:00.916 --> 00:34:03.026 A:middle
 However, we see that there are
@@ -2853,10 +2756,6 @@ this particular initialization
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.586 --> 00:35:01.606 A:middle
-It looks like there's not
-this particular initialization
 
 00:35:01.606 --> 00:35:02.506 A:middle
 method anymore.
@@ -2942,10 +2841,6 @@ it looks like it now takes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.416 --> 00:36:00.056 A:middle
-to support Swimming and
-it looks like it now takes
-
 00:36:00.056 --> 00:36:02.476 A:middle
 in an extra boolean that
 it didn't have before
@@ -3021,9 +2916,6 @@ that just fixes all of them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.226 --> 00:37:00.196 A:middle
-that just fixes all of them.
 
 00:37:00.196 --> 00:37:02.366 A:middle
 So let's rerun the two unit
@@ -3209,10 +3101,6 @@ and discard the changes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.336 --> 00:39:01.746 A:middle
-from the Master branch
-and discard the changes
-
 00:39:01.746 --> 00:39:04.266 A:middle
 that were conflicting from
 the Surf and Turf branch.
@@ -3297,10 +3185,6 @@ in addition
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.816 --> 00:40:00.186 A:middle
-to resolve that conflict
-in addition
 
 00:40:00.186 --> 00:40:01.976 A:middle
 to the normal merge
@@ -3397,10 +3281,6 @@ Control in Xcode 5
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.746 --> 00:41:03.746 A:middle
-So that's Source
-Control in Xcode 5
-
 00:41:03.776 --> 00:41:05.386 A:middle
 with the Continuous
 integration Server.
@@ -3483,10 +3363,6 @@ of Source Control in Xcode
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.656 --> 00:42:01.396 A:middle
-of Source Control in Xcode
-5 that we've seen today.
 
 00:42:02.486 --> 00:42:04.896 A:middle
 We've seen how the new
@@ -3583,10 +3459,6 @@ team member so much easier.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.936 --> 00:43:02.616 A:middle
-with a new project for a new
-team member so much easier.
 
 00:43:03.006 --> 00:43:04.206 A:middle
 Or if you're working

--- a/2013/415.srt
+++ b/2013/415.srt
@@ -153,10 +153,6 @@ the next best thing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.746 --> 00:02:02.416 A:middle
-Once you've done that,
-the next best thing
-
 00:02:02.416 --> 00:02:04.466 A:middle
 that you can do is go into--
 
@@ -244,9 +240,6 @@ you can also see example code,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.936 --> 00:03:01.776 A:middle
-you can also see example code,
-
 00:03:01.776 --> 00:03:03.766 A:middle
 so you can see exactly
 what you need to do
@@ -325,10 +318,6 @@ when you're coding away,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.476 --> 00:04:00.856 A:middle
-If you're anything like me,
-when you're coding away,
 
 00:04:00.856 --> 00:04:03.896 A:middle
 you want to be able to access
@@ -416,10 +405,6 @@ to any programming guides
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.426 --> 00:05:00.876 A:middle
-but you also get our links
-to any programming guides
-
 00:05:01.476 --> 00:05:04.416 A:middle
 that might be helpful with
 that particular symbol
@@ -505,10 +490,6 @@ go is the Developer Forums.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.116 --> 00:06:01.176 A:middle
-the next best place you can
-go is the Developer Forums.
-
 00:06:01.816 --> 00:06:08.056 A:middle
 So devforums.apple.com and
 we have areas for iOS, OS X.
@@ -587,10 +568,6 @@ employees there as well.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.796 --> 00:07:02.106 A:middle
-And also, you also have Apple
-employees there as well.
 
 00:07:02.996 --> 00:07:07.666 A:middle
 So over here, if you see an
@@ -676,10 +653,6 @@ actually an Apple engineer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.906 --> 00:08:04.346 A:middle
-And actually, Rincewind is
-actually an Apple engineer.
 
 00:08:04.376 --> 00:08:06.006 A:middle
 So if you ever see an avatar
@@ -768,10 +741,6 @@ about this is bug reporting
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.216 --> 00:09:00.676 A:middle
-So, one of the first main areas
-about this is bug reporting
-
 00:09:00.676 --> 00:09:04.676 A:middle
 and for that I'm going
 to hand off to Tanya.
@@ -852,10 +821,6 @@ to make an amazing platform,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:55.106 --> 00:10:00.316 A:middle
-You see we worked really hard
-to make an amazing platform,
 
 00:10:00.316 --> 00:10:04.146 A:middle
 make amazing tools that help
@@ -943,10 +908,6 @@ Tanya, I saw this problem,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.086 --> 00:11:02.976 A:middle
-Sometimes they say, well,
-Tanya, I saw this problem,
-
 00:11:02.976 --> 00:11:05.746 A:middle
 but it was an extremely
 trivial issue,
@@ -1022,10 +983,6 @@ copies of the bug.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.196 --> 00:12:01.936 A:middle
-I'm sure you have 12
-copies of the bug.
-
 00:12:02.456 --> 00:12:04.796 A:middle
 I am sure someone else
 has already filed it,
@@ -1090,10 +1047,6 @@ go through our list of bugs
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.016 --> 00:13:02.546 A:middle
-the first thing we do is to
-go through our list of bugs
 
 00:13:02.686 --> 00:13:06.976 A:middle
 to figure out what is it
@@ -1161,10 +1114,6 @@ track the status of your bug.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:56.326 --> 00:14:01.146 A:middle
-and you can use this ID to
-track the status of your bug.
 
 00:14:02.076 --> 00:14:05.236 A:middle
 Also, even after the bug
@@ -1239,10 +1188,6 @@ use these bug reports for.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.646 --> 00:15:01.636 A:middle
-there are few things you can
-use these bug reports for.
-
 00:15:02.276 --> 00:15:06.776 A:middle
 Bugs, if you notice something
 does not work as expected,
@@ -1313,10 +1258,6 @@ graphical representation
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.266 --> 00:16:01.556 A:middle
-So let's look at the
-graphical representation
 
 00:16:01.746 --> 00:16:02.926 A:middle
 of the problem at hand.
@@ -1470,10 +1411,6 @@ was fixed and we also recommend
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.026 --> 00:18:00.956 A:middle
-you verify that the problem
-was fixed and we also recommend
-
 00:18:00.956 --> 00:18:03.296 A:middle
 that you do this as
 soon as possible.
@@ -1550,10 +1487,6 @@ it correctly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:57.826 --> 00:19:00.366 A:middle
-so that we can prioritize
-it correctly.
-
 00:19:01.536 --> 00:19:06.466 A:middle
 Even if your issue was tagged as
 a duplicate, you have the option
@@ -1628,9 +1561,6 @@ You collected the information
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.786 --> 00:20:00.266 A:middle
-You collected the information
-
 00:20:00.266 --> 00:20:02.266 A:middle
 and sent it back to
 us which is great.
@@ -1699,10 +1629,6 @@ and reproducibility.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.416 --> 00:21:01.116 A:middle
-configuration information
-and reproducibility.
-
 00:21:01.596 --> 00:21:05.296 A:middle
 Let's start by looking
 at the title.
@@ -1768,10 +1694,6 @@ would search for the issue
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.196 --> 00:22:02.166 A:middle
-about how is it that you
-would search for the issue
 
 00:22:03.136 --> 00:22:04.936 A:middle
 and hopefully that will
@@ -1997,10 +1919,6 @@ an example summary
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:56.966 --> 00:25:00.956 A:middle
-So let's look at
-an example summary
-
 00:25:01.896 --> 00:25:03.146 A:middle
 for the copy and paste problem.
 
@@ -2084,10 +2002,6 @@ file using terminal?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.616 --> 00:26:01.546 A:middle
-Did you open the
-file using terminal?
-
 00:26:01.716 --> 00:26:03.726 A:middle
 That might be a relevant
 piece of information.
@@ -2168,10 +2082,6 @@ expect might not be consistent
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.586 --> 00:27:04.026 A:middle
-because sometimes what you
-expect might not be consistent
-
 00:27:04.336 --> 00:27:05.936 A:middle
 with what the engineer expects.
 
@@ -2231,10 +2141,6 @@ when does the problem occur,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:54.766 --> 00:28:00.536 A:middle
-Use a section to specify
-when does the problem occur,
 
 00:28:00.536 --> 00:28:02.556 A:middle
 when does is it not occur?
@@ -2309,10 +2215,6 @@ report there might be extra
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:55.146 --> 00:29:00.526 A:middle
-Now when you're filing a bug
-report there might be extra
-
 00:29:00.526 --> 00:29:03.986 A:middle
 information that you
 can attach to your bug
@@ -2379,10 +2281,6 @@ logs you can attach
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.706 --> 00:30:01.926 A:middle
-on what sorts of
-logs you can attach
 
 00:30:02.156 --> 00:30:03.326 A:middle
 to what sorts of problems.
@@ -2462,10 +2360,6 @@ of the process that had crashed.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.106 --> 00:31:02.486 A:middle
-for the name of the application
-of the process that had crashed.
-
 00:31:03.016 --> 00:31:04.876 A:middle
 And will also contain
 a timestamp
@@ -2534,10 +2428,6 @@ system state information.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.726 --> 00:32:00.946 A:middle
-important application and
-system state information.
-
 00:32:01.466 --> 00:32:03.966 A:middle
 They might contain
 some error information
@@ -2603,10 +2493,6 @@ when it comes to bug reports.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.406 --> 00:33:03.816 A:middle
-And this is especially relevant
-when it comes to bug reports.
 
 00:33:03.816 --> 00:33:07.366 A:middle
 You see, you might have
@@ -2688,10 +2574,6 @@ use Command+Shift and 3.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.106 --> 00:34:02.666 A:middle
-To capture the full screen,
-use Command+Shift and 3.
-
 00:34:02.666 --> 00:34:07.106 A:middle
 To capture a part of the
 screen use Command+Shift and 4,
@@ -2760,10 +2642,6 @@ essentially a state snapshot
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.686 --> 00:35:02.996 A:middle
-You know, snapshots are
-essentially a state snapshot
 
 00:35:03.526 --> 00:35:05.656 A:middle
 of all the processes
@@ -2839,9 +2717,6 @@ and will contain the timestamp
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.596 --> 00:36:01.316 A:middle
-and will contain the timestamp
-
 00:36:01.316 --> 00:36:03.296 A:middle
 from when the problem
 had happened.
@@ -2916,10 +2791,6 @@ of work and it's probably going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:55.686 --> 00:37:01.896 A:middle
-I have to admit, this is a lot
-of work and it's probably going
-
 00:37:01.896 --> 00:37:02.746 A:middle
 to take a lot of time.
 
@@ -2989,10 +2860,6 @@ the configuration information
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:54.766 --> 00:38:00.586 A:middle
-With that, let's talk about
-the configuration information
 
 00:38:00.616 --> 00:38:02.106 A:middle
 component of a bug report.
@@ -3071,10 +2938,6 @@ collecting this information.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.396 --> 00:39:01.776 A:middle
-on how you can go about
-collecting this information.
 
 00:39:02.276 --> 00:39:05.516 A:middle
 Last component, we're
@@ -3227,10 +3090,6 @@ MFi developer programs.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.906 --> 00:41:03.466 A:middle
-of our iOS, OS X and
-MFi developer programs.
-
 00:41:03.466 --> 00:41:04.926 A:middle
 So, if you have question
 about how
@@ -3300,10 +3159,6 @@ you need to do is go
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.556 --> 00:42:01.766 A:middle
-To do that, what
-you need to do is go
 
 00:42:01.766 --> 00:42:05.576 A:middle
 to
@@ -3516,10 +3371,6 @@ you back to Nahir.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:57.246 --> 00:45:00.296 A:middle
-With that let me hand
-you back to Nahir.
-
 00:45:03.906 --> 00:45:07.036 A:middle
 &gt;&gt; So now, you've made your
 app, got all the help you need
@@ -3604,10 +3455,6 @@ pictures of our products,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:57.916 --> 00:46:00.236 A:middle
-You can get full
-pictures of our products,
 
 00:46:00.236 --> 00:46:01.316 A:middle
 you can get to those links.
@@ -3792,10 +3639,6 @@ get In-App purchases and how
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.096 --> 00:48:02.316 A:middle
-And also you can go in to
-get In-App purchases and how
-
 00:48:02.316 --> 00:48:03.706 A:middle
 to set those things up as well.
 
@@ -3878,10 +3721,6 @@ mentioned is a very large area,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:52.486 --> 00:49:00.006 A:middle
-Now, iTunes Connect as I
-mentioned is a very large area,
 
 00:49:00.006 --> 00:49:03.736 A:middle
 so we actually have gigantic

--- a/2013/416.srt
+++ b/2013/416.srt
@@ -62,9 +62,6 @@ to do it's just an XML file.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.006 --> 00:01:00.226 A:middle
-to do it's just an XML file.
-
 00:01:00.876 --> 00:01:02.826 A:middle
 So today we're going
 to be talking
@@ -127,10 +124,6 @@ a bit instead of writing code
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.206 --> 00:02:02.926 A:middle
-and handlers in my scripts quite
-a bit instead of writing code
 
 00:02:02.926 --> 00:02:05.206 A:middle
 over and over, I like
@@ -207,10 +200,6 @@ another one and then I would put
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.176 --> 00:03:01.056 A:middle
-and then I would create
-another one and then I would put
-
 00:03:01.056 --> 00:03:04.866 A:middle
 in in some of my scripts and
 not in some of the other ones
@@ -276,10 +265,6 @@ loaded by the script,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.296 --> 00:04:01.756 A:middle
-Because Libraries are
-loaded by the script,
-
 00:04:02.106 --> 00:04:04.466 A:middle
 the script is controlling
 how they use
@@ -342,10 +327,6 @@ your libraries publish their own
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:56.246 --> 00:05:00.886 A:middle
-In addition you can also have
-your libraries publish their own
 
 00:05:00.886 --> 00:05:05.126 A:middle
 terminology which means
@@ -414,10 +395,6 @@ to bring in dictionaries
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:56.326 --> 00:06:01.106 A:middle
-to import terminology and
-to bring in dictionaries
-
 00:06:01.186 --> 00:06:03.266 A:middle
 and libraries into your script
 
@@ -478,10 +455,6 @@ script file in memory
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.386 --> 00:07:03.006 A:middle
-and then talk to that
-script file in memory
 
 00:07:03.006 --> 00:07:04.486 A:middle
 and have it do things for you.
@@ -545,9 +518,6 @@ to locate folders locally,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.846 --> 00:08:00.156 A:middle
-to locate folders locally,
 
 00:08:00.446 --> 00:08:03.186 A:middle
 regardless of how drives
@@ -621,10 +591,6 @@ so let's take a look at it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.036 --> 00:09:01.936 A:middle
-with our AppleScript Libraries
-so let's take a look at it.
-
 00:09:02.686 --> 00:09:04.826 A:middle
 We're going to start
 very simply;
@@ -697,9 +663,6 @@ up the contextual menu.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.156 --> 00:10:00.976 A:middle
-up the contextual menu.
-
 00:10:01.836 --> 00:10:03.646 A:middle
 Now some of you might know
 
@@ -756,10 +719,6 @@ we'll have something like how,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:56.366 --> 00:11:00.196 A:middle
-to upper case transformation, so
-we'll have something like how,
 
 00:11:00.196 --> 00:11:05.946 A:middle
 now brown cow in lower case
@@ -834,10 +793,6 @@ library, so it beings
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:56.386 --> 00:12:01.576 A:middle
-An AppleScript script
-library, so it beings
-
 00:12:01.576 --> 00:12:04.986 A:middle
 with having a handler some
 kind of AppleScript handler
@@ -908,10 +863,6 @@ we're going to take this
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.536 --> 00:13:00.686 A:middle
-Something simple right, now
-we're going to take this
-
 00:13:00.736 --> 00:13:03.476 A:middle
 and make this and make
 this into a library
@@ -981,10 +932,6 @@ newly saved AppleScript file
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:55.036 --> 00:14:01.866 A:middle
-Libraries and then you take your
-newly saved AppleScript file
-
 00:14:03.016 --> 00:14:06.726 A:middle
 and you drag that into the
 Script Libraries folders
@@ -1044,10 +991,6 @@ I left the name extension off,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.696 --> 00:15:02.966 A:middle
-of your library and you notice
-I left the name extension off,
-
 00:15:02.966 --> 00:15:04.666 A:middle
 you don't need to have
 the name extension there.
@@ -1105,10 +1048,6 @@ one meaning I want upper case.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:56.376 --> 00:16:00.326 A:middle
-and I have a case indicator of
-one meaning I want upper case.
 
 00:16:00.856 --> 00:16:05.126 A:middle
 So I run my script, it
@@ -1180,9 +1119,6 @@ of AppleScript objective C.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.696 --> 00:17:01.786 A:middle
-of AppleScript objective C.
-
 00:17:02.156 --> 00:17:04.796 A:middle
 So this will be a
 simple library written
@@ -1243,9 +1179,6 @@ or capitalized string.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:59.336 --> 00:18:00.656 A:middle
-or capitalized string.
 
 00:18:01.536 --> 00:18:04.606 A:middle
 Once that transforms
@@ -1315,10 +1248,6 @@ text transform and ASOC stands
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:56.876 --> 00:19:01.696 A:middle
-I'm going to call this one ASOC
-text transform and ASOC stands
-
 00:19:01.696 --> 00:19:03.426 A:middle
 for AppleScript objective C.
 
@@ -1385,10 +1314,6 @@ number, a bundle version number,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.386 --> 00:20:02.506 A:middle
-it contains a short version
-number, a bundle version number,
 
 00:20:02.696 --> 00:20:07.646 A:middle
 a copyright string, the
@@ -1520,10 +1445,6 @@ library, prepared it for use,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.836 --> 00:22:03.026 A:middle
-that the script has located the
-library, prepared it for use,
-
 00:22:03.026 --> 00:22:07.136 A:middle
 it's ready to go, I can
 encase it within a tell block
@@ -1586,10 +1507,6 @@ Cocoa class NSString
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.146 --> 00:23:00.536 A:middle
-into the power of the
-Cocoa class NSString
 
 00:23:00.536 --> 00:23:01.906 A:middle
 to do all the heavy lifting.
@@ -1668,9 +1585,6 @@ of this is giving it a name,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.556 --> 00:24:00.756 A:middle
-of this is giving it a name,
-
 00:24:00.756 --> 00:24:07.016 A:middle
 I'm going to call it AppleScript
 change case and we're done,
@@ -1736,10 +1650,6 @@ could save the script
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.066 --> 00:25:02.176 A:middle
-that folder and then you
-could save the script
-
 00:25:02.606 --> 00:25:06.426 A:middle
 in there and that's it.
 
@@ -1800,10 +1710,6 @@ we get an error that says
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.846 --> 00:26:02.266 A:middle
-when we try to compile it
-we get an error that says
-
 00:26:02.266 --> 00:26:04.646 A:middle
 that it couldn't find that
 script so you'll know early
@@ -1859,10 +1765,6 @@ doesn't have native support
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.636 --> 00:27:02.016 A:middle
-That's because AppleScript
-doesn't have native support
 
 00:27:02.076 --> 00:27:04.926 A:middle
 for doing case changes and
@@ -1926,10 +1828,6 @@ easy thing to do.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.356 --> 00:28:00.306 A:middle
-but that's a pretty
-easy thing to do.
 
 00:28:01.336 --> 00:28:03.356 A:middle
 I'm going to open
@@ -1997,10 +1895,6 @@ distributing and reusing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.516 --> 00:29:02.516 A:middle
-because when you start
-distributing and reusing
-
 00:29:02.516 --> 00:29:05.056 A:middle
 and updating libraries you
 can use it to distinguish
@@ -2067,9 +1961,6 @@ to an AppleScript string.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.056 --> 00:30:00.276 A:middle
-to an AppleScript string.
-
 00:30:05.696 --> 00:30:10.856 A:middle
 All right so that's it we've
 created an AppleScript objective
@@ -2124,10 +2015,6 @@ AppleScript objective C we can
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.296 --> 00:31:00.196 A:middle
-So you can see that using
-AppleScript objective C we can
 
 00:31:00.196 --> 00:31:02.136 A:middle
 go beyond what we
@@ -2214,10 +2101,6 @@ example that Chris had there
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.746 --> 00:32:02.076 A:middle
-and so we were looking at the
-example that Chris had there
-
 00:32:02.796 --> 00:32:05.376 A:middle
 and if we look at the syntax
 that was involved here,
@@ -2281,10 +2164,6 @@ remembering the names of 150
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:56.006 --> 00:33:00.756 A:middle
-because I can remember this,
-remembering the names of 150
-
 00:33:00.756 --> 00:33:04.856 A:middle
 or 200 different handlers that's
 really a pain, I want to be able
@@ -2347,10 +2226,6 @@ AppleScript editor application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.516 --> 00:34:01.516 A:middle
-that get displayed within the
-AppleScript editor application.
 
 00:34:01.886 --> 00:34:08.235 A:middle
 These scripting dictionary files
@@ -2417,10 +2292,6 @@ see an example script
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.576 --> 00:35:00.346 A:middle
-or you can actually
-see an example script
-
 00:35:00.346 --> 00:35:02.286 A:middle
 that uses the terminology.
 
@@ -2483,10 +2354,6 @@ an sdef file is supposed
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.936 --> 00:36:01.976 A:middle
-that tells the system how
-an sdef file is supposed
 
 00:36:01.976 --> 00:36:02.546 A:middle
 to be read.
@@ -2553,10 +2420,6 @@ that are all lower case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.676 --> 00:37:03.176 A:middle
-of four character codes
-that are all lower case.
-
 00:37:03.666 --> 00:37:07.346 A:middle
 So those are used by Apple
 applications like definder
@@ -2618,10 +2481,6 @@ that gets this 8 character code
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:57.486 --> 00:38:00.336 A:middle
-commands are the only thing
-that gets this 8 character code
 
 00:38:00.896 --> 00:38:02.206 A:middle
 and the reason it does is
@@ -2687,10 +2546,6 @@ tag in my command pairing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:56.806 --> 00:39:00.906 A:middle
-so I insert a parameter
-tag in my command pairing
-
 00:39:01.566 --> 00:39:04.236 A:middle
 and this one gets
 the name of two,
@@ -2752,10 +2607,6 @@ name has to match the type
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:56.396 --> 00:40:00.816 A:middle
-the most important being its
-name has to match the type
 
 00:40:00.816 --> 00:40:05.506 A:middle
 that you just called in the
@@ -2889,10 +2740,6 @@ always have an example script
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:56.406 --> 00:42:00.516 A:middle
-What I like to do myself is
-always have an example script
-
 00:42:00.516 --> 00:42:02.366 A:middle
 of how to call the command.
 
@@ -2964,10 +2811,6 @@ that file, we give it the name
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.466 --> 00:43:03.816 A:middle
-Now that we've done that we save
-that file, we give it the name
-
 00:43:03.816 --> 00:43:06.176 A:middle
 that we had for it,
 AppleScript text utilities
@@ -3036,10 +2879,6 @@ and the little action menu
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.216 --> 00:44:01.226 A:middle
-of the resources folder
-and the little action menu
 
 00:44:01.226 --> 00:44:03.596 A:middle
 that you can do things
@@ -3179,10 +3018,6 @@ string using NSString's string
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.926 --> 00:46:04.046 A:middle
-string, converts it to a Cocoa
-string using NSString's string
-
 00:46:04.516 --> 00:46:09.736 A:middle
 method, string with string and
 then based upon a comparison
@@ -3244,10 +3079,6 @@ and now we can call it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.076 --> 00:47:01.206 A:middle
-it is now installed
-and now we can call it
 
 00:47:01.596 --> 00:47:04.376 A:middle
 so next step using the library.
@@ -3314,10 +3145,6 @@ through it real quick,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.566 --> 00:48:01.666 A:middle
-Now I'll walk you
-through it real quick,
-
 00:48:01.666 --> 00:48:04.836 A:middle
 you get the selected items that
 are selected and you iterate
@@ -3383,10 +3210,6 @@ library identifier and what
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.116 --> 00:49:02.546 A:middle
-and then my script
-library identifier and what
-
 00:49:02.546 --> 00:49:05.746 A:middle
 that does is dynamically
 load my library
@@ -3450,10 +3273,6 @@ clean and it's a smooth syntax.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.106 --> 00:50:02.646 A:middle
-it's powerful to use, it's
-clean and it's a smooth syntax.
 
 00:50:03.276 --> 00:50:06.626 A:middle
 Now when you deploy libraries,
@@ -3521,10 +3340,6 @@ and access
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:58.516 --> 00:51:01.456 A:middle
-enabling quick development
-and access
 
 00:51:01.456 --> 00:51:03.466 A:middle
 to your favorite
@@ -3595,9 +3410,6 @@ was given to the world.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:57.516 --> 00:52:02.656 A:middle
-[ Applause ]
-
 00:52:03.156 --> 00:52:05.586 A:middle
 In 1993 AppleScript released
 
@@ -3667,7 +3479,4 @@ it, thank you so much.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:56.016 --> 00:53:00.006 A:middle
-[ Silence ]
 

--- a/2013/417.srt
+++ b/2013/417.srt
@@ -64,10 +64,6 @@ bullet pointing the whole list,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:56.956 --> 00:01:00.636 A:middle
-Well, without actually just
-bullet pointing the whole list,
-
 00:01:01.196 --> 00:01:05.465 A:middle
 we're going to be talking about
 Automator and AppleScript.
@@ -140,10 +136,6 @@ it automatically gets pushed
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.676 --> 00:02:02.376 A:middle
-You store it in the Cloud, and
-it automatically gets pushed
-
 00:02:02.756 --> 00:02:06.386 A:middle
 to another computer using
 your same iCloud account.
@@ -211,10 +203,6 @@ where you're taking something
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.516 --> 00:03:04.456 A:middle
-So here's an AirDrop example
-where you're taking something
 
 00:03:04.456 --> 00:03:06.616 A:middle
 from your Cloud and
@@ -293,10 +281,6 @@ an email, you know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:59.446 --> 00:04:01.096 A:middle
-And she asked me in
-an email, you know,
 
 00:04:01.096 --> 00:04:02.806 A:middle
 Can you share that with me?
@@ -378,10 +362,6 @@ using a default setting which is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.026 --> 00:05:04.166 A:middle
-and Privacy Control Panel, she's
-using a default setting which is
-
 00:05:04.166 --> 00:05:07.036 A:middle
 for Mac App Store and
 identified developers.
@@ -449,9 +429,6 @@ built into our editing apps.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.516 --> 00:06:01.546 A:middle
-[ Applause ]
 
 00:06:02.046 --> 00:06:02.726 A:middle
 Yeah. Really nice.
@@ -523,10 +500,6 @@ it says code sign.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:56.416 --> 00:07:00.256 A:middle
-of the Save sheet and
-it says code sign.
 
 00:07:00.926 --> 00:07:03.296 A:middle
 It's for code signing
@@ -601,10 +574,6 @@ in Automator.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:57.506 --> 00:08:00.076 A:middle
-I get the Save sheet
-in Automator.
-
 00:08:00.466 --> 00:08:01.836 A:middle
 And at the bottom
 of the Save sheet
@@ -678,10 +647,6 @@ hard on this applet.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.116 --> 00:09:00.206 A:middle
-And I worked long and
-hard on this applet.
 
 00:09:00.206 --> 00:09:01.026 A:middle
 I'm very proud of it.
@@ -766,10 +731,6 @@ life easier on my users here
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.076 --> 00:10:01.346 A:middle
-So how do I -- how do I make
-life easier on my users here
 
 00:10:01.756 --> 00:10:03.926 A:middle
 and not have them think
@@ -935,10 +896,6 @@ we have Gatekeeper, it --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:57.196 --> 00:12:00.106 A:middle
-to distribute them now that
-we have Gatekeeper, it --
-
 00:12:00.106 --> 00:12:02.196 A:middle
 its default settings,
 you might want
@@ -1013,10 +970,6 @@ to be pasting these
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.616 --> 00:13:00.716 A:middle
-with text I'm going
-to be pasting these
-
 00:13:00.716 --> 00:13:03.056 A:middle
 in the bottom part of my script.
 
@@ -1087,10 +1040,6 @@ introducing AppleScript
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:57.036 --> 00:14:01.366 A:middle
-So new in Mavericks we're
-introducing AppleScript
 
 00:14:01.366 --> 00:14:04.306 A:middle
 libraries that will
@@ -1165,10 +1114,6 @@ commands are run
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.496 --> 00:15:00.936 A:middle
-And the script library
-commands are run
-
 00:15:00.936 --> 00:15:03.656 A:middle
 by the process that's
 executing the script.
@@ -1235,10 +1180,6 @@ it will work perfectly.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.366 --> 00:16:01.086 A:middle
-in some terminology and
-it will work perfectly.
 
 00:16:02.006 --> 00:16:05.536 A:middle
 Now, in support of that, we've
@@ -1313,10 +1254,6 @@ simple AppleScript handler
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:57.466 --> 00:17:01.126 A:middle
-You can have this very
-simple AppleScript handler
-
 00:17:01.126 --> 00:17:02.146 A:middle
 that you've created.
 
@@ -1387,10 +1324,6 @@ of your script library.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.716 --> 00:18:04.936 A:middle
-That is now a representation
-of your script library.
 
 00:18:05.556 --> 00:18:08.926 A:middle
 The AppleScript architecture
@@ -1525,10 +1458,6 @@ exactly the same way
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.736 --> 00:20:02.016 A:middle
-And this will function
-exactly the same way
-
 00:20:02.266 --> 00:20:04.156 A:middle
 as a library did before.
 
@@ -1604,10 +1533,6 @@ another issue going on here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.926 --> 00:21:03.496 A:middle
-In addition, there's
-another issue going on here.
-
 00:21:03.566 --> 00:21:06.386 A:middle
 You'll notice that there
 is a variable called
@@ -1680,10 +1605,6 @@ load it, and make its resources
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.116 --> 00:22:03.136 A:middle
-And that means it will take it,
-load it, and make its resources
-
 00:22:03.136 --> 00:22:06.856 A:middle
 and handlers available
 for the script globally.
@@ -1747,10 +1668,6 @@ use clause for just a second.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.246 --> 00:23:02.166 A:middle
-Now, let's talk about the
-use clause for just a second.
 
 00:23:02.586 --> 00:23:06.256 A:middle
 It's about importing
@@ -1821,10 +1738,6 @@ use clause is my friend,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:56.496 --> 00:24:00.636 A:middle
-So here to show you the
-use clause is my friend,
 
 00:24:00.636 --> 00:24:01.246 A:middle
 Chris Nebel.
@@ -1924,10 +1837,6 @@ gets a bit messy after a while,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.836 --> 00:25:02.066 A:middle
-It gets a bit out of -- it
-gets a bit messy after a while,
-
 00:25:02.066 --> 00:25:03.536 A:middle
 especially when you have
 to do ten of these a day.
@@ -2000,9 +1909,6 @@ He's been Cc'd.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.906 --> 00:26:00.816 A:middle
-He's been Cc'd.
 
 00:26:00.996 --> 00:26:02.686 A:middle
 Everyone else, it goes "To."
@@ -2087,10 +1993,6 @@ it's mail selection
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.546 --> 00:27:00.396 A:middle
-I have to specify that
-it's mail selection
-
 00:27:00.396 --> 00:27:02.096 A:middle
 because contacts
 has a selection to.
@@ -2166,10 +2068,6 @@ does is it lets you get rid
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.046 --> 00:28:02.466 A:middle
-So, essentially, what use
-does is it lets you get rid
 
 00:28:02.466 --> 00:28:04.996 A:middle
 of all the bookkeeping that
@@ -2326,10 +2224,6 @@ only a simple one but one
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.026 --> 00:30:03.416 A:middle
-to construct a library, not
-only a simple one but one
-
 00:30:03.416 --> 00:30:07.786 A:middle
 in AppleScript Objective-C, one
 that actually has a terminology.
@@ -2407,10 +2301,6 @@ located in a central location.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:56.916 --> 00:31:00.536 A:middle
-You know, they -- they're
-located in a central location.
-
 00:31:00.536 --> 00:31:03.416 A:middle
 They're organized
 by application.
@@ -2478,10 +2368,6 @@ both applications and --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:55.706 --> 00:32:00.026 A:middle
-And we've integrated it in
-both applications and --
 
 00:32:00.476 --> 00:32:04.916 A:middle
 so that there's no more need
@@ -2564,10 +2450,6 @@ many people don't know that,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.826 --> 00:33:04.626 A:middle
-So, when it comes to Automator,
-many people don't know that,
-
 00:33:04.626 --> 00:33:08.616 A:middle
 when you run an Automator
 workflow or applet,
@@ -2641,10 +2523,6 @@ it more than once
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.616 --> 00:34:02.896 A:middle
-And you can insert
-it more than once
 
 00:34:02.896 --> 00:34:04.326 A:middle
 in your workflow if you want.
@@ -2725,10 +2603,6 @@ looks just for movie files.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.236 --> 00:35:01.736 A:middle
-filter finder items, so it
-looks just for movie files.
-
 00:35:01.736 --> 00:35:04.096 A:middle
 In case something else
 gets accidentally dropped
@@ -2797,10 +2671,6 @@ If you drag four or five
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.006 --> 00:36:02.586 A:middle
-If you drag four or five
-10GB files onto this,
 
 00:36:02.806 --> 00:36:06.656 A:middle
 it can go on for quite a while,
@@ -2882,10 +2752,6 @@ file appears along
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.156 --> 00:37:01.176 A:middle
-and the second encoded
-file appears along
 
 00:37:01.176 --> 00:37:02.536 A:middle
 with a notification.
@@ -3041,9 +2907,6 @@ from the spinning gear menu.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.296 --> 00:39:00.546 A:middle
-from the spinning gear menu.
-
 00:39:00.606 --> 00:39:04.706 A:middle
 But, when it's done, all you
 get is just the gear disappears.
@@ -3130,9 +2993,6 @@ So let's see how we did that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.386 --> 00:40:01.236 A:middle
-So let's see how we did that.
-
 00:40:01.666 --> 00:40:05.076 A:middle
 I have it open in
 Automator over here.
@@ -3211,9 +3071,6 @@ so it won't take quite as long.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.656 --> 00:41:01.086 A:middle
-so it won't take quite as long.
-
 00:41:01.306 --> 00:41:02.496 A:middle
 There's one file;
 there's the next
@@ -3290,9 +3147,6 @@ So this just writes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.926 --> 00:42:01.286 A:middle
-So this just writes
 
 00:42:01.286 --> 00:42:04.936 A:middle
 out a message anytime
@@ -3376,10 +3230,6 @@ rest of the script.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.196 --> 00:43:00.586 A:middle
-it's going to run the
-rest of the script.
-
 00:43:00.586 --> 00:43:05.836 A:middle
 So this little hunk of line
 noise breaks up the input line
@@ -3443,10 +3293,6 @@ it through notification filter.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.796 --> 00:44:03.906 A:middle
-the Syslog command, and pipe
-it through notification filter.
 
 00:44:05.716 --> 00:44:07.186 A:middle
 So, now, this will
@@ -3517,9 +3363,6 @@ This means you don't have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.776 --> 00:45:00.886 A:middle
-This means you don't have
 
 00:45:00.886 --> 00:45:04.016 A:middle
 to create these modal
@@ -3596,10 +3439,6 @@ meeting for you in Calendar.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.616 --> 00:46:02.626 A:middle
-and then create a new
-meeting for you in Calendar.
-
 00:46:03.146 --> 00:46:05.666 A:middle
 It has a lot of other commands
 that are just basically,
@@ -3674,10 +3513,6 @@ just click the radio button
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.596 --> 00:47:01.206 A:middle
-You select that and then
-just click the radio button
 
 00:47:01.206 --> 00:47:01.996 A:middle
 to turn it on.
@@ -3766,10 +3601,6 @@ you how to do this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.776 --> 00:48:00.496 A:middle
-through it to show
-you how to do this.
-
 00:48:01.256 --> 00:48:04.616 A:middle
 So it's an applet by default,
 
@@ -3831,10 +3662,6 @@ there's a new file format.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:55.286 --> 00:49:00.326 A:middle
-Well, if I click on that,
-there's a new file format.
 
 00:49:00.516 --> 00:49:03.696 A:middle
 If you have Speakable Items
@@ -3915,10 +3742,6 @@ no matter what program I'm in,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:58.246 --> 00:50:02.956 A:middle
-like it is here, if I want to,
-no matter what program I'm in,
-
 00:50:03.286 --> 00:50:06.516 A:middle
 if I want to eject
 it, I just simply --
@@ -3981,10 +3804,6 @@ this a try in Mavericks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:59.216 --> 00:51:02.636 A:middle
-So we encourage you to give
-this a try in Mavericks.
 
 00:51:03.666 --> 00:51:08.186 A:middle
 So, in summary, this has been
@@ -4053,10 +3872,6 @@ notification support in addition
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:58.166 --> 00:52:01.666 A:middle
-And we've implemented
-notification support in addition
-
 00:52:01.666 --> 00:52:03.796 A:middle
 to our new Speakable Workflows.
 
@@ -4118,10 +3933,6 @@ to everybody to use it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:57.406 --> 00:53:01.376 A:middle
-to us, to engineers,
-to everybody to use it
 
 00:53:01.376 --> 00:53:05.196 A:middle
 to create automations that
@@ -4198,7 +4009,4 @@ this afternoon, guys.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:52.516 --> 00:54:02.340 A:middle
-[ Silence ]
 

--- a/2013/500.srt
+++ b/2013/500.srt
@@ -54,10 +54,6 @@ other graphic technologies
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.426 --> 00:01:01.976 A:middle
-and it can collaborate with
-other graphic technologies
-
 00:01:02.526 --> 00:01:05.196 A:middle
 like Core Image, Core
 Animation, and GLKit
@@ -124,9 +120,6 @@ Then we will present some
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.336 --> 00:02:00.386 A:middle
-Then we will present some
 
 00:02:00.386 --> 00:02:02.566 A:middle
 of the new features
@@ -278,10 +271,6 @@ connected to vertices
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.146 --> 00:04:00.866 A:middle
-The triangles are
-connected to vertices
-
 00:04:01.576 --> 00:04:04.046 A:middle
 and the vertices
 may have a normal
@@ -356,10 +345,6 @@ simply set a light instance
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.946 --> 00:05:02.566 A:middle
-To add a light to your scene,
-simply set a light instance
-
 00:05:02.766 --> 00:05:05.246 A:middle
 to your node with the
 light property of the node.
@@ -433,10 +418,6 @@ several parameters
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.636 --> 00:06:00.826 A:middle
-Then a camera has
-several parameters
 
 00:06:00.826 --> 00:06:03.986 A:middle
 to control how a scene is
@@ -519,10 +500,6 @@ a SCNView if you want to render
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.836 --> 00:07:05.076 A:middle
-And for this, Scene Kit provides
-a SCNView if you want to render
-
 00:07:05.076 --> 00:07:08.116 A:middle
 into a view, a SCNLayer if you
 want to render into a layer
@@ -591,10 +568,6 @@ like width, length, height,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.896 --> 00:08:03.156 A:middle
-with simple parameters
-like width, length, height,
-
 00:08:03.476 --> 00:08:06.346 A:middle
 corner radius, segment
 count, et cetera.
@@ -654,10 +627,6 @@ and an extrusion depth.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.606 --> 00:09:01.636 A:middle
-and give your Bezier path
-and an extrusion depth.
 
 00:09:02.426 --> 00:09:06.146 A:middle
 Optionally, you can even provide
@@ -734,10 +703,6 @@ load a scene from a file.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:56.906 --> 00:10:00.576 A:middle
-Now, the other way is to
-load a scene from a file.
-
 00:10:01.166 --> 00:10:03.276 A:middle
 And loading a scene
 from a file is essential
@@ -806,10 +771,6 @@ Preview or with Quick Look
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.816 --> 00:11:02.196 A:middle
-You can open them in
-Preview or with Quick Look
 
 00:11:02.196 --> 00:11:03.156 A:middle
 to get a preview of it.
@@ -887,10 +848,6 @@ you do
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.166 --> 00:12:02.566 A:middle
-And then, any modification
-you do
-
 00:12:02.566 --> 00:12:05.696 A:middle
 on the scene graph automatically
 reflects into the view.
@@ -963,10 +920,6 @@ simple Objective-C properties.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:55.476 --> 00:13:00.646 A:middle
-you can modify everything with
-simple Objective-C properties.
 
 00:13:01.556 --> 00:13:03.526 A:middle
 For example, if you want
@@ -1044,10 +997,6 @@ to use SCNTransaction
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:56.706 --> 00:14:00.766 A:middle
-Note that here, you have
-to use SCNTransaction
 
 00:14:00.766 --> 00:14:02.156 A:middle
 and not CATransaction.
@@ -1132,9 +1081,6 @@ and rotating around your nodes.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.156 --> 00:15:00.566 A:middle
-and rotating around your nodes.
-
 00:15:01.046 --> 00:15:04.626 A:middle
 And the materials in particular
 are something very powerful.
@@ -1209,10 +1155,6 @@ texture a little bit,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.466 --> 00:16:01.696 A:middle
-to show the earth
-texture a little bit,
-
 00:16:02.036 --> 00:16:03.536 A:middle
 thanks to the ambient lighting.
 
@@ -1280,10 +1222,6 @@ or an image that is emissive.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.186 --> 00:17:03.356 A:middle
-Then the emission is a color
-or an image that is emissive.
 
 00:17:04.006 --> 00:17:05.476 A:middle
 That means that it doesn't need
@@ -1362,9 +1300,6 @@ and we'll talk about it later.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.516 --> 00:18:01.396 A:middle
-and we'll talk about it later.
-
 00:18:01.396 --> 00:18:04.736 A:middle
 But you can also use it
 to dim or tint an object.
@@ -1442,10 +1377,6 @@ assign your material
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.596 --> 00:19:00.376 A:middle
-And finally, you can
-assign your material
 
 00:19:00.376 --> 00:19:03.616 A:middle
 to your geometry to
@@ -1528,10 +1459,6 @@ necessary hooks for you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.406 --> 00:20:03.046 A:middle
-And Scene Kit provides the
-necessary hooks for you
 
 00:20:03.046 --> 00:20:06.046 A:middle
 to plug your OpenGL
@@ -1683,10 +1610,6 @@ your custom GLSL program
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.906 --> 00:22:02.256 A:middle
-This time, you can provide
-your custom GLSL program
-
 00:22:02.346 --> 00:22:03.876 A:middle
 to replace Scene Kit's shaders.
 
@@ -1763,10 +1686,6 @@ and managing the texture.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.106 --> 00:23:01.616 A:middle
-computing the lighting,
-and managing the texture.
-
 00:23:02.306 --> 00:23:05.386 A:middle
 So that's for these reasons
 that we introduce the concept
@@ -1837,10 +1756,6 @@ you want with GLSL.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.846 --> 00:24:01.976 A:middle
-and modify it the way
-you want with GLSL.
 
 00:24:01.976 --> 00:24:05.036 A:middle
 For example here, to do a
@@ -1913,10 +1828,6 @@ flakes by modifying the emission
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.596 --> 00:25:03.416 A:middle
-So it generates some random
-flakes by modifying the emission
 
 00:25:03.416 --> 00:25:05.266 A:middle
 and diffuse property
@@ -1991,10 +1902,6 @@ that does an x-ray effect.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.606 --> 00:26:01.086 A:middle
-and here, a fragment modifier
-that does an x-ray effect.
-
 00:26:02.376 --> 00:26:05.786 A:middle
 And this is done simply
 by changing the opacity
@@ -2061,10 +1968,6 @@ own uniform in your GLSL code.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:56.106 --> 00:27:01.736 A:middle
-that you can even declare your
-own uniform in your GLSL code.
 
 00:27:02.206 --> 00:27:04.886 A:middle
 And these uniforms are
@@ -2221,9 +2124,6 @@ the map is folded like this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.726 --> 00:29:01.346 A:middle
-the map is folded like this.
-
 00:29:01.996 --> 00:29:05.076 A:middle
 I can also use Target B
 to fold the map like this.
@@ -2365,10 +2265,6 @@ of a node and move the joints.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.936 --> 00:31:08.316 A:middle
-dynamically set the skeleton
-of a node and move the joints.
 
 00:31:08.316 --> 00:31:08.383 A:middle
 [ Pause ]
@@ -2515,10 +2411,6 @@ CIFilter, a glow filter.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.346 --> 00:33:03.366 A:middle
-This can be done using a
-CIFilter, a glow filter.
-
 00:33:04.386 --> 00:33:08.116 A:middle
 If I remove the filter
 from one node and apply it
@@ -2581,10 +2473,6 @@ really useful for 3D UIs.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.636 --> 00:34:01.156 A:middle
-and we think they will be
-really useful for 3D UIs.
 
 00:34:01.281 --> 00:34:03.281 A:middle
 [ Applause ]
@@ -2651,10 +2539,6 @@ SCNTransformConstraint class
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.256 --> 00:35:02.426 A:middle
-So, Scene Kit exposes the
-SCNTransformConstraint class
-
 00:35:02.976 --> 00:35:06.066 A:middle
 to allow you to freely
 manipulate the transform
@@ -2720,10 +2604,6 @@ towards it automatically.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.556 --> 00:36:03.176 A:middle
-the arrows keep looking
-towards it automatically.
-
 00:36:03.176 --> 00:36:07.556 A:middle
 And because constraints
 apply on a node,
@@ -2786,9 +2666,6 @@ of the animation is reached.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.626 --> 00:37:00.346 A:middle
-of the animation is reached.
 
 00:37:00.456 --> 00:37:04.566 A:middle
 OK. And because animation
@@ -2857,9 +2734,6 @@ you will make an overlay appear.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:57.836 --> 00:38:00.276 A:middle
-you will make an overlay appear.
 
 00:38:01.156 --> 00:38:03.876 A:middle
 This overlay provides you
@@ -2934,10 +2808,6 @@ to be as low as possible
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.726 --> 00:39:03.196 A:middle
-We want always this numbers
-to be as low as possible
 
 00:39:03.196 --> 00:39:04.986 A:middle
 to achieve the best
@@ -3077,10 +2947,6 @@ a copied geometry,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.256 --> 00:41:00.906 A:middle
-So once you have
-a copied geometry,
-
 00:41:00.906 --> 00:41:03.336 A:middle
 you can change its materials
 
@@ -3163,9 +3029,6 @@ and they might even look better.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.726 --> 00:42:01.106 A:middle
-and they might even look better.
 
 00:42:01.776 --> 00:42:04.936 A:middle
 3D authoring tools will
@@ -3308,10 +3171,6 @@ bit expensive, so you might want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.986 --> 00:44:02.846 A:middle
-Pre-computing the mipmaps is a
-bit expensive, so you might want
 
 00:44:02.846 --> 00:44:05.956 A:middle
 to use this feature if you
@@ -3525,10 +3384,6 @@ right after the session.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.843 --> 00:47:08.736 A:middle
-So this code will be available
-right after the session.
-
 00:47:09.636 --> 00:47:14.616 A:middle
 It is made as one single
 file per slide so it's--
@@ -3579,7 +3434,4 @@ and thanks for coming.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:52.316 --> 00:48:01.230 A:middle
-[ Applause ]
 

--- a/2013/501.srt
+++ b/2013/501.srt
@@ -77,10 +77,6 @@ another experience,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.206 --> 00:01:00.886 A:middle
-to give the users
-another experience,
-
 00:01:00.976 --> 00:01:03.156 A:middle
 another way to interact
 with your game content
@@ -155,10 +151,6 @@ games to the next level.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.236 --> 00:02:00.516 A:middle
-and perhaps bringing
-games to the next level.
-
 00:02:01.546 --> 00:02:04.976 A:middle
 So, we have two parts.
 
@@ -232,9 +224,6 @@ Thank you very much.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.196 --> 00:03:00.326 A:middle
-&gt;&gt; Thanks Jacques.
 
 00:03:01.506 --> 00:03:02.436 A:middle
 Good afternoon everybody.
@@ -319,10 +308,6 @@ knowing that it will work
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.186 --> 00:04:02.426 A:middle
-And buy with confidence
-knowing that it will work
-
 00:04:02.426 --> 00:04:06.046 A:middle
 with all your games and
 quite frankly all games
@@ -403,10 +388,6 @@ which I'll be going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.196 --> 00:05:01.866 A:middle
-We've defined three
-which I'll be going
-
 00:05:01.866 --> 00:05:03.996 A:middle
 into in the next
 couple of slides.
@@ -482,10 +463,6 @@ definitely been a topic
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.516 --> 00:06:01.246 A:middle
-and D-pads have they're
-definitely been a topic
 
 00:06:01.246 --> 00:06:03.686 A:middle
 that were-- has required a lot
@@ -565,10 +542,6 @@ form-fitting standard gamepad.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.586 --> 00:07:02.346 A:middle
-What you see here is a
-form-fitting standard gamepad.
-
 00:07:03.206 --> 00:07:05.016 A:middle
 So, let me explain the
 terminology a little bit.
@@ -644,10 +617,6 @@ pause button there
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.596 --> 00:08:02.006 A:middle
-You also see a little
-pause button there
 
 00:08:02.006 --> 00:08:03.816 A:middle
 which will be present in
@@ -796,10 +765,6 @@ may actually be interested
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.296 --> 00:10:00.386 A:middle
-So, some of you in the audience
-may actually be interested
-
 00:10:00.386 --> 00:10:02.466 A:middle
 in making MFi game controllers.
 
@@ -878,10 +843,6 @@ certification then you will get
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.666 --> 00:11:01.066 A:middle
-Once your product passes
-certification then you will get
-
 00:11:01.066 --> 00:11:05.856 A:middle
 to-- go to market and use
 those logos compatibility icons
@@ -953,10 +914,6 @@ they're right there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.436 --> 00:12:00.666 A:middle
-You know, get started
-they're right there.
 
 00:12:01.306 --> 00:12:04.976 A:middle
 And quite frankly we can't
@@ -1038,10 +995,6 @@ controller or controllers it has
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:57.006 --> 00:13:00.376 A:middle
-So, once your game knows which
-controller or controllers it has
 
 00:13:00.566 --> 00:13:03.486 A:middle
 to access how do you actually
@@ -1205,10 +1158,6 @@ index which is surfaced
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:54.976 --> 00:15:00.076 A:middle
-And also gives you the player
-index which is surfaced
-
 00:15:00.286 --> 00:15:03.906 A:middle
 in the physical controller
 via the player indicator LEDs.
@@ -1288,9 +1237,6 @@ that method set up controllers.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.966 --> 00:16:01.736 A:middle
-that method set up controllers.
-
 00:16:02.606 --> 00:16:04.186 A:middle
 The first thing we
 do at the top of set
@@ -1365,10 +1311,6 @@ we have GCController did
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.476 --> 00:17:01.066 A:middle
-when a controller disconnects
-we have GCController did
 
 00:17:01.066 --> 00:17:02.446 A:middle
 disconnect notification.
@@ -1452,10 +1394,6 @@ and don't have to--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.656 --> 00:18:01.966 A:middle
-to your game first
-and don't have to--
-
 00:18:01.966 --> 00:18:04.646 A:middle
 or rather they can
 jump into the game
@@ -1532,10 +1470,6 @@ discovery process the discovery
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.336 --> 00:19:03.276 A:middle
-So, as you kickoff the wireless
-discovery process the discovery
 
 00:19:03.276 --> 00:19:05.296 A:middle
 is happening asynchronously
@@ -1626,9 +1560,6 @@ way to cancel it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.346 --> 00:20:00.906 A:middle
-way to cancel it.
-
 00:20:02.256 --> 00:20:04.826 A:middle
 And you do that again
 by calling stop wireless
@@ -1702,10 +1633,6 @@ and disconnecting inside
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.006 --> 00:21:01.666 A:middle
-for controllers connecting
-and disconnecting inside
 
 00:21:01.666 --> 00:21:03.066 A:middle
 of application did
@@ -1789,10 +1716,6 @@ a standard gamepad profile.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.876 --> 00:22:02.136 A:middle
-So, the standard gamepad has
-a standard gamepad profile.
-
 00:22:03.156 --> 00:22:09.626 A:middle
 And the two extended gamepads
 share a single profile
@@ -1855,10 +1778,6 @@ you can see the extra properties
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:55.896 --> 00:23:01.366 A:middle
-And here highlighted in yellow
-you can see the extra properties
 
 00:23:01.366 --> 00:23:03.156 A:middle
 on the extended gamepad profile.
@@ -2008,10 +1927,6 @@ game developers to use these
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:56.066 --> 00:25:00.116 A:middle
-And we give you options as
-game developers to use these
-
 00:25:00.116 --> 00:25:01.516 A:middle
 in a way that suits your game.
 
@@ -2091,10 +2006,6 @@ we actually read the values off
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.736 --> 00:26:02.876 A:middle
-Now, let's talk about how do
-we actually read the values off
 
 00:26:02.876 --> 00:26:04.226 A:middle
 of these controller inputs.
@@ -2176,10 +2087,6 @@ a lot of useful things
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.736 --> 00:27:01.996 A:middle
-You can use this for
-a lot of useful things
 
 00:27:01.996 --> 00:27:04.166 A:middle
 like recording button input.
@@ -2335,10 +2242,6 @@ registered on specific elements
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.186 --> 00:29:01.256 A:middle
-Now, handlers can be
-registered on specific elements
-
 00:29:01.466 --> 00:29:02.896 A:middle
 such as individual buttons.
 
@@ -2420,10 +2323,6 @@ that handler to each
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.266 --> 00:30:00.896 A:middle
-And then we assign
-that handler to each
-
 00:30:00.896 --> 00:30:01.976 A:middle
 of the four face buttons.
 
@@ -2503,10 +2402,6 @@ value change handlers
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.746 --> 00:31:01.496 A:middle
-If you have setup
-value change handlers
 
 00:31:01.496 --> 00:31:03.446 A:middle
 for those they are
@@ -2594,10 +2489,6 @@ collecting snapshots each frame
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.546 --> 00:32:02.336 A:middle
-as your polling you could be
-collecting snapshots each frame
-
 00:32:03.046 --> 00:32:05.906 A:middle
 or inside your value change
 handlers you could be collecting
@@ -2672,10 +2563,6 @@ initialize a snapshot object
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:56.986 --> 00:33:01.306 A:middle
-And then we go ahead and
-initialize a snapshot object
-
 00:33:01.426 --> 00:33:04.686 A:middle
 with that using our
 initWithSnapshotData method.
@@ -2735,9 +2622,6 @@ Let's take the navigation first.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.106 --> 00:34:01.366 A:middle
-Let's take the navigation first.
-
 00:34:02.966 --> 00:34:05.876 A:middle
 With touch controls the player
 can either move the characters
@@ -2783,10 +2667,6 @@ player can still use the touch
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:56.896 --> 00:35:00.876 A:middle
-In complicated situations the
-player can still use the touch
 
 00:35:00.876 --> 00:35:04.046 A:middle
 control and move individual
@@ -2932,10 +2812,6 @@ buttons too, right and left.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:56.386 --> 00:37:00.116 A:middle
-and of course the shoulder
-buttons too, right and left.
-
 00:37:00.756 --> 00:37:03.946 A:middle
 And that's how easy that is.
 
@@ -3014,9 +2890,6 @@ button is pressed.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.836 --> 00:38:00.666 A:middle
-button is pressed.
-
 00:38:00.936 --> 00:38:06.966 A:middle
 This block is run and we toggle
 the pause state of the game.
@@ -3092,10 +2965,6 @@ game you might check if any
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:57.876 --> 00:39:02.346 A:middle
-In a multiple controller
-game you might check if any
 
 00:39:02.346 --> 00:39:05.146 A:middle
 of the currently connected
@@ -3256,10 +3125,6 @@ for a touch base game.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.166 --> 00:41:01.426 A:middle
-This is entirely appropriate
-for a touch base game.
-
 00:41:01.426 --> 00:41:04.796 A:middle
 But with a controller connected
 the controller already has a
@@ -3331,10 +3196,6 @@ tactile feedback of the buttons
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:56.516 --> 00:42:01.316 A:middle
-like precise inputs filling the
-tactile feedback of the buttons
 
 00:42:01.316 --> 00:42:03.056 A:middle
 in the controllers

--- a/2013/502.srt
+++ b/2013/502.srt
@@ -67,9 +67,6 @@ Where is My Water, Tiny Wings,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.196 --> 00:01:00.036 A:middle
-Where is My Water, Tiny Wings,
-
 00:01:01.286 --> 00:01:02.876 A:middle
 I'm sure you're all
 aware of these games.
@@ -138,10 +135,6 @@ expect from the Sprite engine
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.686 --> 00:02:00.746 A:middle
-It has features that you would
-expect from the Sprite engine
 
 00:02:00.856 --> 00:02:02.556 A:middle
 like Sprites animating
@@ -234,10 +227,6 @@ you can apply core image effects
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:56.686 --> 00:03:00.026 A:middle
-So you can have video sprites,
-you can apply core image effects
 
 00:03:00.426 --> 00:03:02.016 A:middle
 to your whole scene
@@ -333,10 +322,6 @@ we'll also show you physics.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.856 --> 00:04:01.186 A:middle
-that you can apply and
-we'll also show you physics.
-
 00:04:02.346 --> 00:04:04.726 A:middle
 In the second session,
 we're going to focus
@@ -419,10 +404,6 @@ keyboard and mouse to go around.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:57.336 --> 00:05:02.066 A:middle
-and OS X and you can use the
-keyboard and mouse to go around.
 
 00:05:02.396 --> 00:05:05.636 A:middle
 So, we have an archer here who's
@@ -511,10 +492,6 @@ with the basics.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.646 --> 00:06:01.786 A:middle
-So I'm going to start
-with the basics.
-
 00:06:02.416 --> 00:06:06.566 A:middle
 There's three basic parts to any
 Sprite Kit game and not consists
@@ -585,10 +562,6 @@ our background image or trees
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.196 --> 00:07:03.566 A:middle
-such as shapes or images like
-our background image or trees
 
 00:07:03.626 --> 00:07:05.676 A:middle
 or the character
@@ -672,10 +645,6 @@ game loop kicks in.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.496 --> 00:08:00.706 A:middle
-the basic Sprite Kit
-game loop kicks in.
 
 00:08:01.606 --> 00:08:03.546 A:middle
 And so this is the sequence
@@ -761,10 +730,6 @@ I've got some fireballs lying
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:57.096 --> 00:09:00.246 A:middle
-So if I have a game where maybe
-I've got some fireballs lying
 
 00:09:00.246 --> 00:09:03.326 A:middle
 across the screen and I'm doing
@@ -853,10 +818,6 @@ through a lot of the headers.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.986 --> 00:10:02.226 A:middle
-and we're going to go
-through a lot of the headers.
 
 00:10:02.626 --> 00:10:04.806 A:middle
 But first, I want to
@@ -1002,10 +963,6 @@ here, that's what we set
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.776 --> 00:12:01.106 A:middle
-So we have our gray screen
-here, that's what we set
-
 00:12:01.106 --> 00:12:02.246 A:middle
 for our background color.
 
@@ -1090,10 +1047,6 @@ base class, SKNode.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.676 --> 00:13:01.366 A:middle
-We'll start with the
-base class, SKNode.
 
 00:13:02.026 --> 00:13:03.936 A:middle
 SKNode has no inherent size
@@ -1180,10 +1133,6 @@ textures for a minute.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.696 --> 00:14:02.166 A:middle
-So, let's talk about
-textures for a minute.
-
 00:14:03.416 --> 00:14:07.856 A:middle
 Textures are how SpriteKit
 represents bitmap--
@@ -1256,10 +1205,6 @@ really cheap, SpriteKit's going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.476 --> 00:15:01.626 A:middle
-that subregion and it's actually
-really cheap, SpriteKit's going
 
 00:15:01.626 --> 00:15:03.366 A:middle
 to take care all the
@@ -1350,10 +1295,6 @@ color and a texture set
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.566 --> 00:16:02.256 A:middle
-So, if you have both a
-color and a texture set
-
 00:16:02.666 --> 00:16:05.206 A:middle
 on your SpriteNode, you
 can control the mixing
@@ -1431,10 +1372,6 @@ do in your game.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:56.206 --> 00:17:00.596 A:middle
-that you want to
-do in your game.
 
 00:17:01.016 --> 00:17:03.686 A:middle
 So, we want to take
@@ -1523,10 +1460,6 @@ to the fully featured
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.466 --> 00:18:02.986 A:middle
-to the fully featured
-2D particle system.
-
 00:18:03.116 --> 00:18:05.606 A:middle
 We support all of the basic
 functionality that you know
@@ -1614,10 +1547,6 @@ many things you can surround
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.296 --> 00:19:01.146 A:middle
-There're just really so
-many things you can surround
 
 00:19:01.146 --> 00:19:02.676 A:middle
 and just tweak these
@@ -1714,9 +1643,6 @@ function for you to get video
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.606 --> 00:20:00.806 A:middle
-function for you to get video
-
 00:20:00.806 --> 00:20:01.976 A:middle
 from a file directly
 into your game.
@@ -1811,10 +1737,6 @@ display dynamic geometric shapes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:56.646 --> 00:21:00.656 A:middle
-ShapeNodes are a great way to
-display dynamic geometric shapes
-
 00:21:00.656 --> 00:21:02.986 A:middle
 within your game, we've
 made it really easy
@@ -1897,10 +1819,6 @@ in your game as a sprite.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:57.196 --> 00:22:00.346 A:middle
-to have single line text
-in your game as a sprite.
 
 00:22:00.806 --> 00:22:04.316 A:middle
 And we support all the system
@@ -1988,10 +1906,6 @@ really cool to allow you
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.816 --> 00:23:00.676 A:middle
-image, we thought it'd be
-really cool to allow you
-
 00:23:00.676 --> 00:23:02.776 A:middle
 to apply our vast library
 
@@ -2076,10 +1990,6 @@ of superfast masking
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:57.716 --> 00:24:00.656 A:middle
-We also support a form
-of superfast masking
 
 00:24:00.656 --> 00:24:03.076 A:middle
 in Sprite Kit using
@@ -2169,10 +2079,6 @@ action system for Sprite Kit,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:57.216 --> 00:25:00.596 A:middle
-So, when we went to design the
-action system for Sprite Kit,
-
 00:25:00.986 --> 00:25:02.526 A:middle
 we want it to be super simple,
 
@@ -2259,10 +2165,6 @@ those on my nodes?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:55.886 --> 00:26:00.726 A:middle
-and how do I run
-those on my nodes?
 
 00:26:00.896 --> 00:26:04.176 A:middle
 I just tell my SpriteNode
@@ -2352,10 +2254,6 @@ they'll run immediately
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:56.996 --> 00:27:00.246 A:middle
-So, I mentioned the actions,
-they'll run immediately
-
 00:27:00.246 --> 00:27:01.166 A:middle
 when you put them on the node
 
@@ -2436,9 +2334,6 @@ of all of its components.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.736 --> 00:28:01.186 A:middle
-of all of its components.
 
 00:28:01.186 --> 00:28:04.176 A:middle
 Now, groups and sequences
@@ -2524,10 +2419,6 @@ animation one second from now,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.666 --> 00:29:02.286 A:middle
-So if I want to kick off in
-animation one second from now,
-
 00:29:02.666 --> 00:29:03.726 A:middle
 I'll create a sequence,
 
@@ -2600,10 +2491,6 @@ follow that path.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.276 --> 00:30:00.286 A:middle
-for the sprite to
-follow that path.
 
 00:30:00.286 --> 00:30:02.126 A:middle
 And by default we'll
@@ -2712,10 +2599,6 @@ built up a sequence
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.316 --> 00:31:01.076 A:middle
-So, if I already
-built up a sequence
-
 00:31:01.076 --> 00:31:05.136 A:middle
 that has my fadeout animation
 for any of these characters
@@ -2807,10 +2690,6 @@ control of the sounds.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.566 --> 00:32:01.896 A:middle
-for more fine grain
-control of the sounds.
 
 00:32:01.936 --> 00:32:03.786 A:middle
 But this is a fantastic
@@ -2915,10 +2794,6 @@ that aren't even in your game.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.546 --> 00:33:01.276 A:middle
-You can even animate things
-that aren't even in your game.
-
 00:33:01.276 --> 00:33:05.286 A:middle
 If I wanted to automatically
 swirl around the emission point
@@ -3009,10 +2884,6 @@ set it on the node.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.376 --> 00:34:01.456 A:middle
-that node and simply
-set it on the node.
-
 00:34:02.186 --> 00:34:03.086 A:middle
 It's one property you set
 
@@ -3099,10 +2970,6 @@ physics will immediately start
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.386 --> 00:35:01.806 A:middle
-on my SpriteNode and then
-physics will immediately start
-
 00:35:02.316 --> 00:35:02.916 A:middle
 running on there.
 
@@ -3186,10 +3053,6 @@ add the nodes to my scene,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.526 --> 00:36:00.326 A:middle
-and now this time when I
-add the nodes to my scene,
 
 00:36:00.326 --> 00:36:01.466 A:middle
 you'll see they're
@@ -3279,10 +3142,6 @@ colliding 'cause we've already
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.636 --> 00:37:02.196 A:middle
-when any two bodies are
-colliding 'cause we've already
-
 00:37:02.196 --> 00:37:04.936 A:middle
 had to figure this out to
 calculate the collisions.
@@ -3361,10 +3220,6 @@ something cool with that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.336 --> 00:38:04.186 A:middle
-and then I can go up and do
-something cool with that.
 
 00:38:04.406 --> 00:38:06.636 A:middle
 By default, you'll be
@@ -3453,10 +3308,6 @@ with anyone,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.146 --> 00:39:00.336 A:middle
-So, if I don't collide
-with anyone,
 
 00:39:00.336 --> 00:39:02.306 A:middle
 the physics bodies will
@@ -3563,10 +3414,6 @@ I can apply damage,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.106 --> 00:40:01.896 A:middle
-of the heroes so that
-I can apply damage,
-
 00:40:01.936 --> 00:40:03.626 A:middle
 change the life counters,
 stuff like that.
@@ -3644,10 +3491,6 @@ notified whenever they intersect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.896 --> 00:41:03.806 A:middle
-I'm also interested in being
-notified whenever they intersect
 
 00:41:04.076 --> 00:41:05.056 A:middle
 with the hero characters.
@@ -3739,10 +3582,6 @@ by taking an existing texture
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.676 --> 00:42:03.436 A:middle
-to any texture in your game
-by taking an existing texture
-
 00:42:03.436 --> 00:42:06.236 A:middle
 and running it through a
 filter to create a new one.
@@ -3832,7 +3671,4 @@ Thank you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.016 --> 00:43:05.616 A:middle
-[ Silence ]
 

--- a/2013/503.srt
+++ b/2013/503.srt
@@ -70,10 +70,6 @@ on both iOS 7 and Mac OS X,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.646 --> 00:01:03.266 A:middle
-the framework is available
-on both iOS 7 and Mac OS X,
-
 00:01:03.416 --> 00:01:06.936 A:middle
 they allow you to build once and
 deploy it to multiple devices
@@ -147,10 +143,6 @@ this talk to show you how quick
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.666 --> 00:02:00.576 A:middle
-from the Adventure demo in
-this talk to show you how quick
 
 00:02:00.576 --> 00:02:03.386 A:middle
 and easy it is to
@@ -232,10 +224,6 @@ about 1,700 art files to load.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:57.506 --> 00:03:01.366 A:middle
-of artwork files and we have
-about 1,700 art files to load.
-
 00:03:02.036 --> 00:03:03.806 A:middle
 We have a lot of
 sound files to load
@@ -313,10 +301,6 @@ as fast they can.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.296 --> 00:04:00.356 A:middle
-and get them loaded
-as fast they can.
-
 00:04:01.546 --> 00:04:04.236 A:middle
 Once we have these assets
 in memory, we will go ahead
@@ -388,9 +372,6 @@ into the Adventure Game.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.516 --> 00:05:00.586 A:middle
-into the Adventure Game.
 
 00:05:01.226 --> 00:05:02.906 A:middle
 So, the Adventure
@@ -470,10 +451,6 @@ simulating all the physics.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.016 --> 00:06:01.046 A:middle
-we wait until we finish
-simulating all the physics.
-
 00:06:02.236 --> 00:06:05.146 A:middle
 So, if I'm walking from A to
 B, there happen to be a wall
@@ -551,10 +528,6 @@ the background tiles,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.486 --> 00:07:00.496 A:middle
-If you just look at
-the background tiles,
-
 00:07:01.046 --> 00:07:05.856 A:middle
 the level itself is a 4K x
 4K tile map that gets divided
@@ -631,10 +604,6 @@ Texture Atlas for all of them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.156 --> 00:08:01.176 A:middle
-and the game actually used
-Texture Atlas for all of them.
 
 00:08:01.456 --> 00:08:03.766 A:middle
 Character animations are
@@ -794,10 +763,6 @@ minimize the amount of overhead
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.966 --> 00:10:01.366 A:middle
-into a single draw call to
-minimize the amount of overhead
-
 00:10:01.366 --> 00:10:03.516 A:middle
 for the GL render script change.
 
@@ -866,10 +831,6 @@ to your animation frame
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.036 --> 00:11:02.096 A:middle
-to add transparency borders
-to your animation frame
 
 00:11:02.096 --> 00:11:04.996 A:middle
 so that you make sure the
@@ -961,10 +922,6 @@ a folder into your project
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.876 --> 00:12:03.776 A:middle
-It's just a matter of dragging
-a folder into your project
-
 00:12:03.836 --> 00:12:05.036 A:middle
 and you'll have your
 Texture Atlas.
@@ -1040,10 +997,6 @@ texture and the plist file.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:57.536 --> 00:13:00.606 A:middle
-which is the Texture Atlas
-texture and the plist file.
 
 00:13:00.606 --> 00:13:03.226 A:middle
 And plist file, you can
@@ -1128,10 +1081,6 @@ iPhone 2X, iPad, iPad 2X
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.586 --> 00:14:02.636 A:middle
-Mac OS 2X, iPhone,
-iPhone 2X, iPad, iPad 2X
-
 00:14:02.636 --> 00:14:05.136 A:middle
 and the new iPhone
 5 resolution format.
@@ -1211,10 +1160,6 @@ leave it and put it in."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.086 --> 00:15:01.646 A:middle
-OK, let's rotate it,
-leave it and put it in."
-
 00:15:01.756 --> 00:15:04.066 A:middle
 We trimmed the transparent
 edges, so you don't have
@@ -1290,10 +1235,6 @@ memory savings.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.936 --> 00:16:00.276 A:middle
-and also have some
-memory savings.
 
 00:16:00.276 --> 00:16:03.216 A:middle
 So, if you look at the animation
@@ -1453,10 +1394,6 @@ file name, you don't have
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.596 --> 00:18:01.536 A:middle
-You just reference its loose
-file name, you don't have
-
 00:18:01.536 --> 00:18:04.016 A:middle
 to worry about which
 Texture Atlas it is in.
@@ -1537,10 +1474,6 @@ precedents over Texture Atlas.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.076 --> 00:19:00.406 A:middle
-loose files will have
-precedents over Texture Atlas.
 
 00:19:00.976 --> 00:19:03.236 A:middle
 So, having environment
@@ -1626,10 +1559,6 @@ an environment Texture Atlas.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.756 --> 00:20:03.636 A:middle
-the Class Initializer initialize
-an environment Texture Atlas.
 
 00:20:03.956 --> 00:20:06.056 A:middle
 We get number of
@@ -1762,9 +1691,6 @@ just build and run that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.516 --> 00:22:02.676 A:middle
-[ Pause ]
-
 00:22:03.176 --> 00:22:03.876 A:middle
 There you go.
 
@@ -1838,10 +1764,6 @@ animation into our scene.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:56.346 --> 00:23:01.726 A:middle
-Let's drag in a Boss-- a packet
-animation into our scene.
 
 00:23:01.876 --> 00:23:03.986 A:middle
 So make sure to copy
@@ -1966,10 +1888,6 @@ show you the Build options.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.156 --> 00:26:01.606 A:middle
-So now, I would like to
-show you the Build options.
-
 00:26:01.976 --> 00:26:04.576 A:middle
 So if you go to Build
 settings and just make sure,
@@ -2055,10 +1973,6 @@ large number of small particles
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.056 --> 00:27:00.776 A:middle
-that usually people found a very
-large number of small particles
-
 00:27:00.776 --> 00:27:03.356 A:middle
 on the screen and
 similarly it's a lifetime
@@ -2134,10 +2048,6 @@ demo from [inaudible] DC 2012
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.486 --> 00:28:02.516 A:middle
-So here, we have a trees
-demo from [inaudible] DC 2012
-
 00:28:02.516 --> 00:28:04.676 A:middle
 which was created using
 a development version
@@ -2197,10 +2107,6 @@ heavily used for Adventure.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.156 --> 00:29:02.096 A:middle
-So the particle system is being
-heavily used for Adventure.
 
 00:29:02.676 --> 00:29:05.416 A:middle
 So the leaves, the
@@ -2277,10 +2183,6 @@ very time consuming therefore we
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.676 --> 00:30:03.776 A:middle
-But the [inaudible] property is
-very time consuming therefore we
 
 00:30:03.776 --> 00:30:05.896 A:middle
 build a particle
@@ -2436,10 +2338,6 @@ on a scale of sequence
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:57.636 --> 00:32:00.586 A:middle
-and you can just set directly
-on a scale of sequence
-
 00:32:01.016 --> 00:32:05.766 A:middle
 and it will be affecting the
 scale throughout its lifetime.
@@ -2507,10 +2405,6 @@ NSKeyedUnarchiver and just say,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:54.836 --> 00:33:00.576 A:middle
-So what we do is we use
-NSKeyedUnarchiver and just say,
 
 00:33:00.576 --> 00:33:04.786 A:middle
 we want to unarchive BossDamage,
@@ -2593,10 +2487,6 @@ start a quick demo
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:56.966 --> 00:34:01.516 A:middle
-So with this, I will
-start a quick demo
-
 00:34:01.516 --> 00:34:02.906 A:middle
 of using a particle system.
 
@@ -2654,9 +2544,6 @@ Use NSKeyed--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.516 --> 00:35:06.336 A:middle
-[ Pause ]
-
 00:35:06.836 --> 00:35:11.076 A:middle
 -- Unarchive with file,
 that's where we're looking for
@@ -2695,9 +2582,6 @@ This is what the error is.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.516 --> 00:36:09.296 A:middle
-[ Pause ]
 
 00:36:09.796 --> 00:36:12.076 A:middle
 All right, so every
@@ -2764,10 +2648,6 @@ value is a little bit flat,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.926 --> 00:37:04.616 A:middle
-And how about we-- now the Y
-value is a little bit flat,
-
 00:37:04.866 --> 00:37:05.806 A:middle
 let's go ahead and stretch
 
@@ -2832,10 +2712,6 @@ the particle will finish.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:57.486 --> 00:38:02.366 A:middle
-I spawned 200 particles and
-the particle will finish.
 
 00:38:02.606 --> 00:38:05.746 A:middle
 So, let's-- we can set
@@ -2999,10 +2875,6 @@ a sub class of SKNode,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:58.946 --> 00:40:01.076 A:middle
-in the game is really
-a sub class of SKNode,
-
 00:40:01.076 --> 00:40:01.966 A:middle
 it's a good way of doing it.
 
@@ -3091,10 +2963,6 @@ object which is the roots
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.926 --> 00:41:01.856 A:middle
-We have our little root
-object which is the roots
-
 00:41:01.856 --> 00:41:04.196 A:middle
 of the actual ParallaxNode
 and as our object moves
@@ -3179,10 +3047,6 @@ and how it's actually set up,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.736 --> 00:42:01.386 A:middle
-So, if we look at the SKNode
-and how it's actually set up,
-
 00:42:01.386 --> 00:42:04.006 A:middle
 you can see that the SKNode is,
 you know, at the bottom there,
@@ -3266,10 +3130,6 @@ character approaches that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.196 --> 00:43:01.696 A:middle
-the trees fade as the
-character approaches that.
 
 00:43:01.696 --> 00:43:02.466 A:middle
 So how do we do that?
@@ -3370,9 +3230,6 @@ on black, he can move around.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.846 --> 00:44:00.646 A:middle
-on black, he can move around.
-
 00:44:00.926 --> 00:44:03.106 A:middle
 My guy is standing
 on red, he stops.
@@ -3458,10 +3315,6 @@ and that's full lines of code.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:57.416 --> 00:45:03.146 A:middle
-There is a little bit of set up
-and that's full lines of code.
 
 00:45:03.616 --> 00:45:05.616 A:middle
 So we have a rectangle
@@ -3556,10 +3409,6 @@ know, Graeme will give me a PNG
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.936 --> 00:46:06.196 A:middle
-that's awesome, because, you
-know, Graeme will give me a PNG
-
 00:46:06.196 --> 00:46:08.446 A:middle
 that is the right
 size, the right bit up,
@@ -3638,10 +3487,6 @@ the whole ocean, you know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.836 --> 00:47:01.086 A:middle
-of the ocean, don't build
-the whole ocean, you know,
 
 00:47:01.086 --> 00:47:03.346 A:middle
 just get what you need
@@ -3723,10 +3568,6 @@ sequential PNGs to a folder.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:56.436 --> 00:48:00.516 A:middle
-in Maya, frame by frame out as
-sequential PNGs to a folder.
-
 00:48:01.016 --> 00:48:04.316 A:middle
 And so this was our-- our fix,
 
@@ -3801,10 +3642,6 @@ that wind that I was talking
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.536 --> 00:49:00.186 A:middle
-This was kind of-- this is
-that wind that I was talking
 
 00:49:00.186 --> 00:49:03.336 A:middle
 about where we have-- it's a
@@ -3894,10 +3731,6 @@ things, I just want to make game
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:57.456 --> 00:50:00.166 A:middle
-You don't think that these
-things, I just want to make game
-
 00:50:00.166 --> 00:50:01.286 A:middle
 and pull the structure.
 
@@ -3985,10 +3818,6 @@ tool of communication.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.466 --> 00:51:02.796 A:middle
-to us is an invaluable
-tool of communication.
-
 00:51:02.796 --> 00:51:07.086 A:middle
 It allows us to iterate back and
 forth with you when you give us
@@ -4062,10 +3891,6 @@ into groups and so forth,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.316 --> 00:52:01.546 A:middle
-for you and puts things nicely
-into groups and so forth,
 
 00:52:01.546 --> 00:52:04.156 A:middle
 resources, but that is not
@@ -4146,10 +3971,6 @@ by four because you never know
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:55.656 --> 00:53:00.186 A:middle
-and then we pad our revision
-by four because you never know
 
 00:53:00.186 --> 00:53:04.696 A:middle
 when you're going to have 9,999
@@ -4237,10 +4058,6 @@ we do every single day.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:59.896 --> 00:54:04.016 A:middle
-in my life and that's what
-we do every single day.
-
 00:54:05.336 --> 00:54:06.456 A:middle
 So, let's go over
 our lessons again.
@@ -4311,10 +4128,6 @@ of just hardly any resource used
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.406 --> 00:55:03.336 A:middle
-or really great looking game out
-of just hardly any resource used
 
 00:55:03.336 --> 00:55:07.756 A:middle
 at all, you know, well first off
@@ -4393,9 +4206,6 @@ to the disk or to the iCloud
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:59.046 --> 00:56:00.566 A:middle
-to the disk or to the iCloud
-
 00:56:00.646 --> 00:56:02.356 A:middle
 over the network,
 however you want.
@@ -4467,10 +4277,6 @@ some tiles on there,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:59.306 --> 00:57:01.536 A:middle
-So if user drag and drop
-some tiles on there,
 
 00:57:01.536 --> 00:57:03.766 A:middle
 you can make it the
@@ -4557,10 +4363,6 @@ this how far I'm hitting
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:57:58.116 --> 00:58:00.776 A:middle
-from their mistakes, "Hey,
-this how far I'm hitting
-
 00:58:00.776 --> 00:58:02.256 A:middle
 and this is the projectile
 for that."
@@ -4638,10 +4440,6 @@ for a one line that UI allow you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:58:58.356 --> 00:59:02.826 A:middle
-So, we do provide a SKLabelNode
-for a one line that UI allow you
 
 00:59:02.826 --> 00:59:06.656 A:middle
 to animate that before any
@@ -4731,10 +4529,6 @@ and you have, therefore,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:59:58.406 --> 01:00:01.646 A:middle
-You just drag a folder in
-and you have, therefore,
-
 01:00:01.646 --> 01:00:03.236 A:middle
 you have your Texture Atlas.
 
@@ -4813,10 +4607,6 @@ the fundamental building block
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-01:00:55.136 --> 01:01:00.086 A:middle
-Once if you treat scenes as
-the fundamental building block
 
 01:01:00.146 --> 01:01:03.256 A:middle
 for your games, you can

--- a/2013/504.srt
+++ b/2013/504.srt
@@ -83,10 +83,6 @@ as well as on OS X.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.126 --> 00:01:02.896 A:middle
-on their iOS devices
-as well as on OS X.
-
 00:01:03.516 --> 00:01:06.556 A:middle
 So we've-- when I
 asked you what's new
@@ -366,10 +362,6 @@ action method,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.656 --> 00:04:01.846 A:middle
-Well, in your target
-action method,
-
 00:04:01.846 --> 00:04:04.406 A:middle
 the first thing you're going to
 do is grab the shared instance
@@ -469,10 +461,6 @@ and get right back to it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.106 --> 00:05:02.476 A:middle
-dismiss when you need to,
-and get right back to it.
-
 00:05:02.826 --> 00:05:04.406 A:middle
 So really, that's
 all that's changed
@@ -553,9 +541,6 @@ to 500 maximum leaderboards.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:58.776 --> 00:06:00.536 A:middle
-to 500 maximum leaderboards.
 
 00:06:01.406 --> 00:06:03.346 A:middle
 And now, with Leaderboard Sets,
@@ -650,9 +635,6 @@ also have 499 other leaderboards
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.926 --> 00:07:02.106 A:middle
-also have 499 other leaderboards
-
 00:07:02.316 --> 00:07:03.486 A:middle
 that you've made
 within your game.
@@ -737,10 +719,6 @@ could actually put this single
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:57.296 --> 00:08:02.126 A:middle
-So let's consider how we
-could actually put this single
-
 00:08:02.126 --> 00:08:04.206 A:middle
 leaderboard into various sets
 
@@ -818,10 +796,6 @@ upon the set
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:57.586 --> 00:09:00.786 A:middle
-And moreover, depending
-upon the set
 
 00:09:00.786 --> 00:09:02.486 A:middle
 that a leaderboard
@@ -907,9 +881,6 @@ we only have to call it medium
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.746 --> 00:10:01.116 A:middle
-we only have to call it medium
-
 00:10:01.166 --> 00:10:03.516 A:middle
 because it's obvious it's the
 medium level of difficulty
@@ -992,10 +963,6 @@ order to use Leaderboard Sets
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.436 --> 00:11:00.056 A:middle
-up in iTunes Connect in
-order to use Leaderboard Sets
 
 00:11:00.136 --> 00:11:02.096 A:middle
 and start organizing
@@ -1088,10 +1055,6 @@ create a leaderboard set ID.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.586 --> 00:12:04.246 A:middle
-you're going to have to
-create a leaderboard set ID.
-
 00:12:04.486 --> 00:12:08.486 A:middle
 Just like leaderboards, you have
 to create a unique identifier
@@ -1163,10 +1126,6 @@ Planet set just Water Planet,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.956 --> 00:13:00.226 A:middle
-We're going to name this Water
-Planet set just Water Planet,
 
 00:13:00.226 --> 00:13:01.586 A:middle
 liked we talked about
@@ -1249,10 +1208,6 @@ string that's going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.196 --> 00:14:00.796 A:middle
-the English language
-string that's going
 
 00:14:00.796 --> 00:14:02.006 A:middle
 to be displayed to your players.
@@ -1344,10 +1299,6 @@ in the iTunes Connect overview,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.266 --> 00:15:02.066 A:middle
-Now we didn't talk about this
-in the iTunes Connect overview,
 
 00:15:02.516 --> 00:15:05.946 A:middle
 but just like how leaderboards
@@ -1443,10 +1394,6 @@ is called, we can take one
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:57.796 --> 00:16:00.276 A:middle
-So when this completion handler
-is called, we can take one
-
 00:16:00.276 --> 00:16:01.576 A:middle
 of the sets that
 we've been given back.
@@ -1538,10 +1485,6 @@ handler is called back,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.906 --> 00:17:00.926 A:middle
-And once this completion
-handler is called back,
-
 00:17:00.926 --> 00:17:03.036 A:middle
 you can use it just like
 any other image asset
@@ -1623,10 +1566,6 @@ score 5,000 points, let's say,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:56.756 --> 00:18:00.276 A:middle
-then tomorrow, when they
-score 5,000 points, let's say,
 
 00:18:00.606 --> 00:18:04.916 A:middle
 5,000 isn't better than 10,000,
@@ -1718,10 +1657,6 @@ rankings for your chess game
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.656 --> 00:19:01.216 A:middle
-You could do things like power
-rankings for your chess game
-
 00:19:01.216 --> 00:19:03.376 A:middle
 or your legendary
 RPG Heroes game.
@@ -1806,10 +1741,6 @@ to low to high,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.016 --> 00:20:02.296 A:middle
-If you say set this
-to low to high,
-
 00:20:02.436 --> 00:20:03.746 A:middle
 then the lowest scores are going
 
@@ -1891,10 +1822,6 @@ player happens to win,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.176 --> 00:21:02.106 A:middle
-in a match and the low-rank
-player happens to win,
 
 00:21:02.356 --> 00:21:04.496 A:middle
 then the low-rank player's
@@ -2064,10 +1991,6 @@ iTunes Connect.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.596 --> 00:23:00.846 A:middle
-that you set up on
-iTunes Connect.
-
 00:23:01.666 --> 00:23:05.206 A:middle
 We're deprecating this in favor
 of the identifier property.
@@ -2150,10 +2073,6 @@ new leaderboard features today,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.476 --> 00:24:02.206 A:middle
-So we've talked a lot about
-new leaderboard features today,
 
 00:24:02.206 --> 00:24:04.416 A:middle
 Leaderboard Sets, to
@@ -2245,10 +2164,6 @@ a score, let's say,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.706 --> 00:25:02.196 A:middle
-So when you submit
-a score, let's say,
-
 00:25:02.946 --> 00:25:04.546 A:middle
 to the Game Center system,
 
@@ -2330,10 +2245,6 @@ submissions make it over,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.226 --> 00:26:00.726 A:middle
-to go offline before these
-submissions make it over,
 
 00:26:01.916 --> 00:26:04.456 A:middle
 gamed is going to immediately go
@@ -2601,10 +2512,6 @@ six top players or however many
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:57.566 --> 00:29:00.876 A:middle
-I don't think, you know, the
-six top players or however many
-
 00:29:00.876 --> 00:29:03.686 A:middle
 in this game happened to
 have earned in 64 max,
@@ -2692,10 +2599,6 @@ coding or configuration steps.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:57.736 --> 00:30:00.836 A:middle
-You don't have to do any sort of
-coding or configuration steps.
-
 00:30:01.096 --> 00:30:03.216 A:middle
 If your game is running
 on iOS 7, we've gotten
@@ -2775,10 +2678,6 @@ just not going to be visible
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.236 --> 00:31:01.476 A:middle
-that score submission, it's
-just not going to be visible
 
 00:31:01.476 --> 00:31:02.946 A:middle
 to other players of the game
@@ -2862,9 +2761,6 @@ and OS X with iTunes Connect
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.946 --> 00:32:00.476 A:middle
-and OS X with iTunes Connect
 
 00:32:00.476 --> 00:32:04.256 A:middle
 to help limit cheating is a
@@ -2967,10 +2863,6 @@ Leaderboard Configuration screen
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.366 --> 00:33:03.226 A:middle
-within iTunes Connect on the
-Leaderboard Configuration screen
-
 00:33:03.476 --> 00:33:07.706 A:middle
 in order to filter out
 anybody who's exploiting issues
@@ -3046,10 +2938,6 @@ those leaderboard scores
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.896 --> 00:34:02.716 A:middle
-to either meet or beat
-those leaderboard scores
 
 00:34:02.886 --> 00:34:04.736 A:middle
 or to earn those achievements
@@ -3217,10 +3105,6 @@ with the same gameplay context
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:55.836 --> 00:36:00.076 A:middle
-as she's earned that score
-with the same gameplay context
-
 00:36:00.076 --> 00:36:01.516 A:middle
 that Tom used to earn his score?
 
@@ -3308,10 +3192,6 @@ around with.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.946 --> 00:37:00.436 A:middle
-that Alice has raced
-around with.
-
 00:37:00.536 --> 00:37:03.946 A:middle
 So at the end of Alice's
 play through, right,
@@ -3397,10 +3277,6 @@ model Alice just used
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.916 --> 00:38:01.236 A:middle
-to match the car
-model Alice just used
 
 00:38:01.236 --> 00:38:02.156 A:middle
 to race around the track.
@@ -3492,9 +3368,6 @@ Really, it's all up to you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.426 --> 00:39:00.806 A:middle
-Really, it's all up to you.
 
 00:39:02.796 --> 00:39:05.276 A:middle
 A new feature that we
@@ -3670,10 +3543,6 @@ achievement, not part way.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:56.796 --> 00:41:00.096 A:middle
-to 100 percent complete
-achievement, not part way.
-
 00:41:00.676 --> 00:41:04.586 A:middle
 And then, to get this
 UIViewController
@@ -3765,10 +3634,6 @@ you just need to present it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.586 --> 00:42:02.246 A:middle
-of the UIViewController,
-you just need to present it
-
 00:42:02.246 --> 00:42:04.806 A:middle
 like you would any other UI
 view controller within your app.
@@ -3850,10 +3715,6 @@ over to the new API
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.386 --> 00:43:00.006 A:middle
-to consider moving
-over to the new API
 
 00:43:00.216 --> 00:43:02.826 A:middle
 because if you were
@@ -3947,10 +3808,6 @@ big topic of the day--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.616 --> 00:44:00.766 A:middle
-Let's move on to the next
-big topic of the day--
-
 00:44:01.276 --> 00:44:03.526 A:middle
 handling events relevant
 to the local player.
@@ -4035,10 +3892,6 @@ or some matchmaking invite,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.306 --> 00:45:01.046 A:middle
-maybe a turn-based invite
-or some matchmaking invite,
-
 00:45:01.866 --> 00:45:03.706 A:middle
 that's going to be channeled
 through the local player.
@@ -4121,10 +3974,6 @@ Listener for GK Matchmaking,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:56.956 --> 00:46:00.476 A:middle
-and GK Invite Event
-Listener for GK Matchmaking,
 
 00:46:00.696 --> 00:46:02.426 A:middle
 real-time matchmaking callbacks.
@@ -4211,10 +4060,6 @@ dispatch to your listener or all
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:57.936 --> 00:47:01.156 A:middle
-it'll have that event to
-dispatch to your listener or all
-
 00:47:01.156 --> 00:47:06.326 A:middle
 of the listeners that are
 capable of handling that event.
@@ -4292,10 +4137,6 @@ within the Game Center app,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.086 --> 00:48:01.796 A:middle
-or they tap a play bubble
-within the Game Center app,
 
 00:48:02.446 --> 00:48:04.166 A:middle
 or if they tap a play bubble
@@ -4386,10 +4227,6 @@ there with the challenge message
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.106 --> 00:49:00.116 A:middle
-to show Alice's picture right
-there with the challenge message
 
 00:49:00.116 --> 00:49:01.166 A:middle
 that she happened to define.
@@ -4564,10 +4401,6 @@ game to 500 leaderboards.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.066 --> 00:51:02.046 A:middle
-that you can use within your
-game to 500 leaderboards.
-
 00:51:02.466 --> 00:51:04.446 A:middle
 And you can impose a
 hierarchical structure
@@ -4654,10 +4487,6 @@ have a lot of questions.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:58.076 --> 00:52:00.516 A:middle
-and that means that you probably
-have a lot of questions.
-
 00:52:01.046 --> 00:52:02.936 A:middle
 So Allan Schaffer,
 he's our Graphics
@@ -4742,7 +4571,4 @@ It's been a pleasure.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:53.016 --> 00:53:02.436 A:middle
-[ Silence ]
 

--- a/2013/505.srt
+++ b/2013/505.srt
@@ -65,9 +65,6 @@ to graphics hardware.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.056 --> 00:01:00.006 A:middle
-to graphics hardware.
-
 00:01:00.486 --> 00:01:02.196 A:middle
 This enables a lot
 of flexibility
@@ -141,10 +138,6 @@ talk about is instancing,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.446 --> 00:02:00.956 A:middle
-The first feature I'll
-talk about is instancing,
 
 00:02:01.416 --> 00:02:03.996 A:middle
 and we support two
@@ -220,10 +213,6 @@ considerable needed
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:57.996 --> 00:03:02.326 A:middle
-However, there's still
-considerable needed
-
 00:03:02.326 --> 00:03:06.086 A:middle
 to put vertices into the
 pipe and spit out pixels.
@@ -294,10 +283,6 @@ your buffers to the front
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.636 --> 00:04:01.686 A:middle
-Just blit what's already in
-your buffers to the front
 
 00:04:02.386 --> 00:04:03.746 A:middle
 or don't even blit at all
@@ -462,10 +447,6 @@ drawing that gear.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.966 --> 00:06:00.526 A:middle
-of my gear, and then
-drawing that gear.
 
 00:06:01.746 --> 00:06:06.076 A:middle
 That's 100 uniform sets and 100
@@ -683,10 +664,6 @@ number of values per element.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:56.956 --> 00:09:01.736 A:middle
-and the number of scalars or
-number of values per element.
-
 00:09:02.526 --> 00:09:07.206 A:middle
 We do this for our per vertex
 position here, and, again,
@@ -749,10 +726,6 @@ in glDrawArrarys.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.956 --> 00:10:00.776 A:middle
-It's the same as
-in glDrawArrarys.
 
 00:10:02.526 --> 00:10:08.486 A:middle
 The second or last argument
@@ -944,9 +917,6 @@ Here's the second method.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.336 --> 00:13:01.596 A:middle
-Here's the second method.
-
 00:13:02.796 --> 00:13:05.716 A:middle
 This is using the
 instance ID parameter.
@@ -1017,10 +987,6 @@ the next instance,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.666 --> 00:14:01.996 A:middle
-It's incremented for
-the next instance,
-
 00:14:02.266 --> 00:14:08.476 A:middle
 and we submit all the vertices
 using the value of one.
@@ -1087,9 +1053,6 @@ to give us the y position.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.246 --> 00:15:00.926 A:middle
-to give us the y position.
 
 00:15:01.376 --> 00:15:05.426 A:middle
 Now we have an instance
@@ -1166,10 +1129,6 @@ alternative to uniforms.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.176 --> 00:16:00.776 A:middle
-You can also use it as an
-alternative to uniforms.
-
 00:16:02.126 --> 00:16:05.916 A:middle
 Uniforms have a much smaller
 data store whereas textures has
@@ -1239,10 +1198,6 @@ the X and Z values
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.026 --> 00:17:03.046 A:middle
-And so we overwrite
-the X and Z values
 
 00:17:03.046 --> 00:17:04.826 A:middle
 with the X and Z positions.
@@ -1319,10 +1274,6 @@ limited to 128 uniform,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.186 --> 00:18:01.416 A:middle
-Whereas uniform arrays are
-limited to 128 uniform,
-
 00:18:02.226 --> 00:18:06.506 A:middle
 that's four values per uniform,
 
@@ -1393,10 +1344,6 @@ with the texture,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.246 --> 00:19:00.486 A:middle
-Anything you can do
-with the texture,
 
 00:19:00.486 --> 00:19:03.766 A:middle
 you can do with a vertex
@@ -1474,9 +1421,6 @@ maybe 18 in some case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.436 --> 00:20:00.086 A:middle
-maybe 18 in some case.
-
 00:20:00.086 --> 00:20:03.406 A:middle
 That's alright, I guess.
 
@@ -1545,10 +1489,6 @@ all of the rotations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:55.676 --> 00:21:00.006 A:middle
-This is due to our pre-computing
-all of the rotations
 
 00:21:00.006 --> 00:21:02.686 A:middle
 and position of values
@@ -1629,10 +1569,6 @@ matrix
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.426 --> 00:22:00.586 A:middle
-We then apply a translation
-matrix
-
 00:22:00.956 --> 00:22:04.276 A:middle
 that gives us the
 position of the asteroid.
@@ -1706,10 +1642,6 @@ glVertexAttribDivisor call,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.706 --> 00:23:03.306 A:middle
-up the vertex array with the
-glVertexAttribDivisor call,
-
 00:23:03.666 --> 00:23:06.226 A:middle
 and pass the parameters
 down for each asteroid,
@@ -1782,10 +1714,6 @@ faster than computing on the GPU
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:57.666 --> 00:24:01.166 A:middle
-Instance arrays is generally
-faster than computing on the GPU
-
 00:24:01.446 --> 00:24:03.776 A:middle
 since you can save
 cycles on the GPU.
@@ -1848,9 +1776,6 @@ of data inside of a texture.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:58.766 --> 00:25:00.286 A:middle
-of data inside of a texture.
 
 00:25:00.286 --> 00:25:04.096 A:middle
 So this is really cool
@@ -1935,10 +1860,6 @@ features are supported
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.636 --> 00:26:02.616 A:middle
-These extensions and these
-features are supported
-
 00:26:02.616 --> 00:26:04.996 A:middle
 on all iOS 7 devices.
 
@@ -2002,10 +1923,6 @@ an inverse curve
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.226 --> 00:27:00.346 A:middle
-by basically applying
-an inverse curve
-
 00:27:00.346 --> 00:27:02.986 A:middle
 so that the darker colors
 get a little bit more weight
@@ -2065,10 +1982,6 @@ except for the iPhone 4.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:55.866 --> 00:28:00.636 A:middle
-on all iOS 7 devices
-except for the iPhone 4.
 
 00:28:01.086 --> 00:28:04.026 A:middle
 This is a great new feature.
@@ -2140,10 +2053,6 @@ rendering engines.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:59.596 --> 00:29:01.896 A:middle
-start adding to your
-rendering engines.
 
 00:29:02.666 --> 00:29:08.046 A:middle
 And, fortunately, Apple provides
@@ -2219,10 +2128,6 @@ just rendered,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.876 --> 00:30:00.736 A:middle
-and whatever you've
-just rendered,
-
 00:30:00.736 --> 00:30:04.496 A:middle
 the results of last draw call
 you've made, shows up in green.
@@ -2295,10 +2200,6 @@ all of the information
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.636 --> 00:31:01.746 A:middle
-And so now I can look at
-all of the information
 
 00:31:01.746 --> 00:31:03.586 A:middle
 that pertains to
@@ -2373,9 +2274,6 @@ your rendering.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.086 --> 00:32:03.166 A:middle
-[ Applause ]
-
 00:32:03.666 --> 00:32:05.596 A:middle
 So this allows you to experiment
 
@@ -2441,10 +2339,6 @@ and figure out what bottlenecks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:57.446 --> 00:33:01.096 A:middle
-of experiments on your frame
-and figure out what bottlenecks
 
 00:33:01.096 --> 00:33:03.676 A:middle
 that you've got, whether you're
@@ -2525,9 +2419,6 @@ and you can immediately fix it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.986 --> 00:34:00.166 A:middle
-[ Applause ]
-
 00:34:00.166 --> 00:34:02.906 A:middle
 We also have the OpenGL
 ES Analyzer instrument,
@@ -2590,10 +2481,6 @@ an excellent means
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.126 --> 00:35:00.526 A:middle
-that really provide
-an excellent means
 
 00:35:00.526 --> 00:35:02.226 A:middle
 for debugging your rendering.
@@ -2667,9 +2554,6 @@ of the GPU architecture now.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:56.606 --> 00:36:01.396 A:middle
-of the GPU architecture now.
-
 00:36:01.616 --> 00:36:07.666 A:middle
 All of the iOS GPU's are
 tile-based deferred renderers.
@@ -2740,10 +2624,6 @@ that developers can do
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.346 --> 00:37:02.296 A:middle
-There are certain operations
-that developers can do
 
 00:37:02.296 --> 00:37:04.626 A:middle
 that can prevent
@@ -2821,10 +2701,6 @@ transformed, as I mentioned,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.596 --> 00:38:02.446 A:middle
-The vertices are shaded and
-transformed, as I mentioned,
-
 00:38:02.686 --> 00:38:04.676 A:middle
 and stored out to
 unified memory.
@@ -2889,10 +2765,6 @@ and fragment shading to occur
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.036 --> 00:39:03.986 A:middle
-This allows rasterization
-and fragment shading to occur
 
 00:39:03.986 --> 00:39:07.586 A:middle
 on the GPU in little tile-sized
@@ -2959,10 +2831,6 @@ embedded memory, as I said.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.176 --> 00:40:02.606 A:middle
-The rasterizer uses tile size
-embedded memory, as I said.
 
 00:40:03.226 --> 00:40:06.006 A:middle
 Now if there is data already
@@ -3037,10 +2905,6 @@ texture, render to a new buffer
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:58.226 --> 00:41:02.516 A:middle
-For instance, if we render to a
-texture, render to a new buffer
 
 00:41:02.516 --> 00:41:04.086 A:middle
 or a new texture,
@@ -3120,10 +2984,6 @@ assigned to the tile,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.116 --> 00:42:01.646 A:middle
-The GPU reads the triangles
-assigned to the tile,
-
 00:42:01.806 --> 00:42:04.406 A:middle
 and it computes the X
 and Y pixel coordinates
@@ -3202,9 +3062,6 @@ Loss of hidden surface removal.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.256 --> 00:43:00.746 A:middle
-Loss of hidden surface removal.
-
 00:43:01.586 --> 00:43:03.756 A:middle
 It's really costly
 to enable blending
@@ -3282,10 +3139,6 @@ algorithm is allowed to work,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:57.596 --> 00:44:00.666 A:middle
-if the hidden surface removal
-algorithm is allowed to work,
-
 00:44:01.056 --> 00:44:04.466 A:middle
 we only need to run the fragment
 shader on each pixel once.
@@ -3357,10 +3210,6 @@ a logical buffer store.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:57.286 --> 00:45:00.036 A:middle
-to the user, and that requires
-a logical buffer store.
 
 00:45:01.636 --> 00:45:03.256 A:middle
 However, you can
@@ -3437,10 +3286,6 @@ resolved, much smaller tile
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.716 --> 00:46:03.506 A:middle
-What you need is the
-resolved, much smaller tile
 
 00:46:04.396 --> 00:46:06.566 A:middle
 that you can store
@@ -3529,10 +3374,6 @@ perfereable ways to use them.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.376 --> 00:47:02.776 A:middle
-but there are some
-perfereable ways to use them.
-
 00:47:02.936 --> 00:47:05.606 A:middle
 First of all, draw all your
 triangles using discard
@@ -3612,10 +3453,6 @@ render buffer switches,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.926 --> 00:48:01.166 A:middle
-Also avoid frequent
-render buffer switches,
-
 00:48:01.476 --> 00:48:02.926 A:middle
 which can cause tile thrashing.
 
@@ -3692,10 +3529,6 @@ or dependent read.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.706 --> 00:49:02.096 A:middle
-or a dependent sample
-or dependent read.
-
 00:49:03.776 --> 00:49:07.706 A:middle
 Here's a more devious example,
 a much less obvious example
@@ -3763,10 +3596,6 @@ from a vec4 to two vec2s.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:56.796 --> 00:50:01.076 A:middle
-to be converted first
-from a vec4 to two vec2s.
 
 00:50:01.076 --> 00:50:02.756 A:middle
 This is happening
@@ -3851,10 +3680,6 @@ possible, put it in a uniform
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:55.756 --> 00:51:00.486 A:middle
-Do it in the vertex shader if
-possible, put it in a uniform
-
 00:51:00.486 --> 00:51:02.266 A:middle
 or put it in the vertex array.
 
@@ -3929,10 +3754,6 @@ and fragments simultaneously.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:58.866 --> 00:52:01.966 A:middle
-It can process multiple vertices
-and fragments simultaneously.
-
 00:52:03.106 --> 00:52:05.946 A:middle
 We need a special
 branch mode for execution
@@ -3997,10 +3818,6 @@ the GPU as quick as possible
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:55.886 --> 00:53:00.336 A:middle
-You also really want to get to
-the GPU as quick as possible
 
 00:53:00.336 --> 00:53:02.526 A:middle
 and minimize the CPU overhead.
@@ -4081,10 +3898,6 @@ there are some algorithms
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:58.316 --> 00:54:07.756 A:middle
-And what you can do is
-there are some algorithms
-
 00:54:07.996 --> 00:54:09.326 A:middle
 such as shadowing state.
 
@@ -4155,10 +3968,6 @@ convert to hardware state.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.856 --> 00:55:04.076 A:middle
-to do some calculations to
-convert to hardware state.
 
 00:55:04.956 --> 00:55:08.646 A:middle
 So minimize the number
@@ -4312,10 +4121,6 @@ technologies evangelist,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:56:58.306 --> 00:57:00.816 A:middle
-our graphics and games
-technologies evangelist,
-
 00:57:01.226 --> 00:57:03.086 A:middle
 and there's some
 excellent documentation
@@ -4406,10 +4211,6 @@ investigations.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:57:59.196 --> 00:58:01.546 A:middle
-and in your performance
-investigations.
 
 00:58:01.946 --> 00:58:04.226 A:middle
 The GPU tools really

--- a/2013/506.srt
+++ b/2013/506.srt
@@ -179,10 +179,6 @@ to be ideal solution
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.026 --> 00:02:00.436 A:middle
-And we think it's going
-to be ideal solution
-
 00:02:00.526 --> 00:02:04.076 A:middle
 in multiplayer allows, you know,
 up to 16 players to take turns
@@ -275,10 +271,6 @@ send it back to you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.856 --> 00:03:00.966 A:middle
-and then Meg can
-send it back to you.
 
 00:03:02.176 --> 00:03:05.226 A:middle
 And this will proceed however
@@ -378,10 +370,6 @@ if hey, this person is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.986 --> 00:04:01.756 A:middle
-So, this is where you know,
-if hey, this person is
-
 00:04:01.756 --> 00:04:04.736 A:middle
 on auto-match, he's invited,
 he's actively playing,
@@ -464,9 +452,6 @@ Gameplay as well as invitations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.446 --> 00:05:01.926 A:middle
-Gameplay as well as invitations
 
 00:05:01.926 --> 00:05:04.266 A:middle
 in auto-matching is fully
@@ -551,9 +536,6 @@ And finally, we give time outs.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.016 --> 00:06:03.156 A:middle
-And finally, we give time outs.
 
 00:06:03.226 --> 00:06:06.196 A:middle
 You can specify a time
@@ -644,10 +626,6 @@ notify Meg who can then pull
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.216 --> 00:07:02.366 A:middle
-and we automatically will
-notify Meg who can then pull
 
 00:07:02.366 --> 00:07:04.096 A:middle
 down the turn data
@@ -747,10 +725,6 @@ guy is taking his turn.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.236 --> 00:08:01.026 A:middle
-hey, you know, this
-guy is taking his turn.
-
 00:08:01.026 --> 00:08:02.236 A:middle
 I don't want to show you
 what he's done, you know,
@@ -835,10 +809,6 @@ peer-to-peer game,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.556 --> 00:09:01.196 A:middle
-when they're playing
-peer-to-peer game,
 
 00:09:01.196 --> 00:09:03.286 A:middle
 you're playing one game
@@ -1033,9 +1003,6 @@ and show the live updates.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.006 --> 00:11:00.946 A:middle
-and show the live updates.
-
 00:11:00.946 --> 00:11:03.846 A:middle
 You can make it feel
 like it's a live game.
@@ -1205,10 +1172,6 @@ your code and catch those
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.366 --> 00:13:00.926 A:middle
-of mistakes that you may making
-your code and catch those
-
 00:13:00.926 --> 00:13:03.846 A:middle
 in sandbox before you go
 live and I hopefully be able
@@ -1305,10 +1268,6 @@ that your player sent,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.846 --> 00:14:01.926 A:middle
-It may be an invitation
-that your player sent,
-
 00:14:02.336 --> 00:14:04.466 A:middle
 you'll know who it is but
 they haven't actually gotten
@@ -1404,10 +1363,6 @@ inviting friends
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.866 --> 00:15:01.536 A:middle
-to creating matches
-inviting friends
-
 00:15:01.596 --> 00:15:04.376 A:middle
 and listening available matches
 and allowing management of this,
@@ -1497,10 +1452,6 @@ the completed section
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.116 --> 00:16:01.506 A:middle
-and just put it into
-the completed section
-
 00:16:01.506 --> 00:16:03.896 A:middle
 of the other list and make it so
 they can remove it if they want.
@@ -1586,10 +1537,6 @@ match and allows someone
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.316 --> 00:17:03.286 A:middle
-This is how to create a
-match and allows someone
 
 00:17:03.286 --> 00:17:04.695 A:middle
 to invite their friends
@@ -1775,9 +1722,6 @@ from the users match list.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.866 --> 00:19:01.576 A:middle
-from the users match list.
-
 00:19:02.866 --> 00:19:04.946 A:middle
 And then alternatively you
 can use the view controller.
@@ -1867,10 +1811,6 @@ the middle of their turn.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.686 --> 00:20:00.086 A:middle
-to where they were in
-the middle of their turn.
-
 00:20:00.086 --> 00:20:00.976 A:middle
 You can save the enemy at state.
 
@@ -1958,9 +1898,6 @@ with the match there, right.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.486 --> 00:21:00.186 A:middle
-with the match there, right.
 
 00:21:00.186 --> 00:21:01.036 A:middle
 They've taken their turn.
@@ -2051,9 +1988,6 @@ in who the turn goes to next.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.196 --> 00:22:00.556 A:middle
-in who the turn goes to next.
 
 00:22:01.646 --> 00:22:03.136 A:middle
 The things you keep
@@ -2221,10 +2155,6 @@ on the recipient's device
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:57.246 --> 00:24:01.356 A:middle
-Game Center will use the strings
-on the recipient's device
-
 00:24:01.736 --> 00:24:04.146 A:middle
 to generate the message that
 we show in notification center
@@ -2305,10 +2235,6 @@ not have it on the device.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.136 --> 00:25:01.466 A:middle
-for the first time it may
-not have it on the device.
 
 00:25:01.466 --> 00:25:02.536 A:middle
 Their bundle's not there.
@@ -2393,10 +2319,6 @@ we're to the meat
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.696 --> 00:26:00.236 A:middle
-And then, finally
-we're to the meat
 
 00:26:00.236 --> 00:26:01.786 A:middle
 of this whole taking
@@ -2491,9 +2413,6 @@ They forget about it perhaps.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.866 --> 00:27:01.166 A:middle
-They forget about it perhaps.
-
 00:27:01.746 --> 00:27:04.636 A:middle
 Time outs and fallbacks help
 keep things moving along.
@@ -2573,10 +2492,6 @@ with some new features,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.886 --> 00:28:01.966 A:middle
-But there are cases
-with some new features,
 
 00:28:02.006 --> 00:28:05.056 A:middle
 turn-based exchanges where you
@@ -2668,10 +2583,6 @@ ended by the last person
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.636 --> 00:29:01.496 A:middle
-But ultimately the game is
-ended by the last person
-
 00:29:01.686 --> 00:29:03.896 A:middle
 to play instead of
 taking their turn.
@@ -2758,10 +2669,6 @@ of the different player,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.426 --> 00:30:01.186 A:middle
-you know the positions
-of the different player,
-
 00:30:01.216 --> 00:30:03.286 A:middle
 you'll set the outcome,
 and you can use our enums
@@ -2845,10 +2752,6 @@ you can now generate scores
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.356 --> 00:31:01.046 A:middle
-But at the end of the game
-you can now generate scores
 
 00:31:01.236 --> 00:31:03.516 A:middle
 for all the participants
@@ -3018,10 +2921,6 @@ passed, match data getting saved
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.726 --> 00:33:03.316 A:middle
-new turns, turns getting
-passed, match data getting saved
-
 00:33:03.316 --> 00:33:07.086 A:middle
 and updated, as well as match
 ended events when you're
@@ -3183,10 +3082,6 @@ for match, did become active.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.776 --> 00:35:02.376 A:middle
-player received the turn event
-for match, did become active.
-
 00:35:03.376 --> 00:35:04.926 A:middle
 So, this is you and
 get this is on invites.
@@ -3263,10 +3158,6 @@ at the new turn event.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.076 --> 00:36:01.376 A:middle
-So, let's take a look
-at the new turn event.
 
 00:36:01.466 --> 00:36:04.806 A:middle
 As I've said, this is sort of
@@ -3525,10 +3416,6 @@ the top of your screen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.896 --> 00:39:01.156 A:middle
-API and show a banner on
-the top of your screen.
-
 00:39:01.536 --> 00:39:04.166 A:middle
 You can-- put a badge
 on your UI somewhere.
@@ -3688,10 +3575,6 @@ of the game, you player,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.616 --> 00:41:01.656 A:middle
-to keep the current player
-of the game, you player,
-
 00:41:02.086 --> 00:41:04.916 A:middle
 in control of the duration
 of their term, right?
@@ -3785,10 +3668,6 @@ exchanges really help solve.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.576 --> 00:42:01.526 A:middle
-that we think turn-base
-exchanges really help solve.
-
 00:42:02.106 --> 00:42:04.696 A:middle
 And I expect that you, being
 as creative as you are,
@@ -3880,10 +3759,6 @@ integrate it into the turn,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.596 --> 00:43:01.356 A:middle
-you gather the results, you
-integrate it into the turn,
-
 00:43:01.356 --> 00:43:02.626 A:middle
 you move it on, and
 you take next turn.
@@ -3962,10 +3837,6 @@ the turn and that means
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.086 --> 00:44:02.446 A:middle
-Well, you've relinquished
-the turn and that means
 
 00:44:02.446 --> 00:44:04.776 A:middle
 that the full duration
@@ -4052,10 +3923,6 @@ classes you use for exchanges?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.016 --> 00:45:00.106 A:middle
-What are-- what are the
-classes you use for exchanges?
 
 00:45:00.176 --> 00:45:02.646 A:middle
 Well, we added a
@@ -4154,10 +4021,6 @@ and you need to resolve it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.026 --> 00:46:00.136 A:middle
-and then it will be completed
-and you need to resolve it.
-
 00:46:00.836 --> 00:46:02.426 A:middle
 So the next class, obviously,
 
@@ -4251,9 +4114,6 @@ And we like it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.116 --> 00:47:00.216 A:middle
-And we like it.
-
 00:47:00.216 --> 00:47:01.766 A:middle
 You know, the user--
 users happy with it.
@@ -4334,10 +4194,6 @@ all completed exchanges,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:57.446 --> 00:48:00.166 A:middle
-or the important one is
-all completed exchanges,
 
 00:48:00.166 --> 00:48:02.836 A:middle
 that is all the exchanges that
@@ -4430,10 +4286,6 @@ on the exchange itself.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.206 --> 00:49:00.656 A:middle
-This is an instance method
-on the exchange itself.
 
 00:49:01.036 --> 00:49:04.396 A:middle
 Each exchange gets a single
@@ -4691,10 +4543,6 @@ can save this new merged data
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:57.326 --> 00:52:00.616 A:middle
-we have this method where you
-can save this new merged data
-
 00:52:00.666 --> 00:52:01.776 A:middle
 without passing the turn.
 
@@ -4788,10 +4636,6 @@ know, what kind of we want to do
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:59.966 --> 00:53:02.866 A:middle
-So, let's look at how we, you
-know, what kind of we want to do
-
 00:53:02.866 --> 00:53:03.936 A:middle
 when we handle an exchange.
 
@@ -4876,10 +4720,6 @@ dealing with that exchange,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:57.866 --> 00:54:00.136 A:middle
-viewing that match,
-dealing with that exchange,
 
 00:54:00.876 --> 00:54:03.626 A:middle
 you need to basically, say,
@@ -4975,10 +4815,6 @@ show them, you know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:59.686 --> 00:55:02.766 A:middle
-If it's not, you know,
-show them, you know,
 
 00:55:02.766 --> 00:55:04.866 A:middle
 or clear appropriately the
@@ -5078,10 +4914,6 @@ this animation before.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:59.516 --> 00:56:01.546 A:middle
-Well, you've actually seen
-this animation before.
-
 00:56:01.546 --> 00:56:03.446 A:middle
 You get the match data, going
 
@@ -5167,10 +4999,6 @@ them handle their tie and then,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:56.466 --> 00:57:00.486 A:middle
-Send it just to those people let
-them handle their tie and then,
 
 00:57:01.206 --> 00:57:04.476 A:middle
 you know, continue and resolve

--- a/2013/507.srt
+++ b/2013/507.srt
@@ -70,10 +70,6 @@ the features.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.676 --> 00:01:02.356 A:middle
-So let's start with
-the features.
-
 00:01:03.446 --> 00:01:08.086 A:middle
 In OpenGL as of Lion we've
 had support for Core Profile
@@ -212,10 +208,6 @@ application that's been --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:57.996 --> 00:03:00.746 A:middle
-So we have here an
-application that's been --
-
 00:03:00.826 --> 00:03:03.666 A:middle
 is out on the Mac which
 is called Unigine Heaven
@@ -296,10 +288,6 @@ probably tessellate a lot more
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.546 --> 00:04:02.236 A:middle
-So closer objects you'll
-probably tessellate a lot more
-
 00:04:02.236 --> 00:04:06.416 A:middle
 than objects in the distance.
 
@@ -371,10 +359,6 @@ this data output it gets output
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.826 --> 00:05:06.726 A:middle
-And then once we have these --
-this data output it gets output
 
 00:05:06.726 --> 00:05:12.436 A:middle
 to an evaluation shader
@@ -514,10 +498,6 @@ at an actual control shader
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.896 --> 00:07:05.136 A:middle
-So let's get onto looking
-at an actual control shader
-
 00:07:05.926 --> 00:07:07.586 A:middle
 with this triangle example.
 
@@ -587,10 +567,6 @@ geometry or fragment stage.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.306 --> 00:08:02.786 A:middle
-to pass on to the
-geometry or fragment stage.
 
 00:08:03.576 --> 00:08:05.316 A:middle
 So it takes the original patch
@@ -744,10 +720,6 @@ have four sides to the quad
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.596 --> 00:10:00.336 A:middle
-to calculate because we
-have four sides to the quad
-
 00:10:00.746 --> 00:10:04.396 A:middle
 and additionally for the inner
 levels we're controlling how
@@ -817,10 +789,6 @@ arbitrary geometry.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.596 --> 00:11:00.606 A:middle
-with triangles, quads,
-arbitrary geometry.
 
 00:11:00.606 --> 00:11:02.016 A:middle
 Even like isolines.
@@ -893,10 +861,6 @@ take a little bit of overhead
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.246 --> 00:12:02.196 A:middle
-because each draw call does
-take a little bit of overhead
 
 00:12:02.716 --> 00:12:04.346 A:middle
 in order to get that to the GPU.
@@ -973,10 +937,6 @@ would pass a vertex [inaudible]
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.546 --> 00:13:01.296 A:middle
-for every one instance you
-would pass a vertex [inaudible]
-
 00:13:01.296 --> 00:13:02.346 A:middle
 divisor of one.
 
@@ -1045,10 +1005,6 @@ we pass up some data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.116 --> 00:14:01.556 A:middle
-Let's go on to how
-we pass up some data
 
 00:14:01.556 --> 00:14:04.006 A:middle
 like uniform buffer
@@ -1123,10 +1079,6 @@ defined interface where we're --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.196 --> 00:15:05.006 A:middle
-object is a CSTRUCK like layout
-defined interface where we're --
-
 00:15:05.006 --> 00:15:07.926 A:middle
 we have here of the
 layout one standard 140
@@ -1189,10 +1141,6 @@ knowing how to provide that data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:55.066 --> 00:16:00.296 A:middle
-that we have for making -- for
-knowing how to provide that data
 
 00:16:00.606 --> 00:16:04.776 A:middle
 to the proper UBO in the shader.
@@ -1270,10 +1218,6 @@ make note of is that each
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.646 --> 00:17:03.896 A:middle
-And one key point I want to
-make note of is that each
-
 00:17:03.896 --> 00:17:08.806 A:middle
 of the UBOs are limited
 to a size of about 64KB.
@@ -1334,10 +1278,6 @@ shader that's using TBO.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.806 --> 00:18:01.396 A:middle
-And here's an example
-shader that's using TBO.
 
 00:18:01.506 --> 00:18:04.386 A:middle
 So we basically have
@@ -1407,9 +1347,6 @@ to attach that buffer object
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:57.686 --> 00:19:00.226 A:middle
-to attach that buffer object
 
 00:19:00.376 --> 00:19:05.766 A:middle
 to the texture object using Tex
@@ -1486,10 +1423,6 @@ you're not stalling your CPU
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.546 --> 00:20:02.796 A:middle
-those TBOs will help you ensure
-you're not stalling your CPU
-
 00:20:02.796 --> 00:20:04.476 A:middle
 waiting for the GPU
 to complete its work.
@@ -1563,10 +1496,6 @@ modern hardware and it's --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.426 --> 00:21:03.166 A:middle
-It's available on all
-modern hardware and it's --
 
 00:21:03.166 --> 00:21:04.866 A:middle
 so check for the
@@ -1645,10 +1574,6 @@ call draw indirect.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.766 --> 00:22:01.766 A:middle
-And then finally just
-call draw indirect.
 
 00:22:01.766 --> 00:22:02.806 A:middle
 And it still takes a mode
@@ -1732,10 +1657,6 @@ are going to read out of.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.966 --> 00:23:01.676 A:middle
-for where the elements
-are going to read out of.
-
 00:23:02.196 --> 00:23:03.656 A:middle
 So we're also doing
 that binding.
@@ -1814,10 +1735,6 @@ times to be used with the --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.026 --> 00:24:01.546 A:middle
-that vertex shader five
-times to be used with the --
-
 00:24:01.546 --> 00:24:06.616 A:middle
 you don't have to link --
 you can link really quickly.
@@ -1891,10 +1808,6 @@ and the texture source.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.646 --> 00:25:00.166 A:middle
-both the rendered target
-and the texture source.
 
 00:25:00.616 --> 00:25:02.406 A:middle
 So now if you have --
@@ -1982,10 +1895,6 @@ be interpreted
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.896 --> 00:26:00.336 A:middle
-that LUNINANCE should
-be interpreted
-
 00:26:00.336 --> 00:26:02.766 A:middle
 as red, red, red one.
 
@@ -2048,10 +1957,6 @@ into your render loop
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:57.976 --> 00:27:00.356 A:middle
-It's a very simple integration
-into your render loop
 
 00:27:00.446 --> 00:27:04.786 A:middle
 and I'm going to go
@@ -2123,10 +2028,6 @@ goes into that VBO.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.416 --> 00:28:02.456 A:middle
-that -- the data that
-goes into that VBO.
-
 00:28:02.806 --> 00:28:09.106 A:middle
 Then after that we'll flush the
 CL enqueued commands in order
@@ -2185,9 +2086,6 @@ Then after I've created our --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.996 --> 00:29:00.786 A:middle
-Then after I've created our --
-
 00:29:00.976 --> 00:29:04.916 A:middle
 my context I'm going to get the
 share group from that context
@@ -2243,9 +2141,6 @@ So that's a onetime set up.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.176 --> 00:30:00.246 A:middle
-So that's a onetime set up.
 
 00:30:00.246 --> 00:30:04.746 A:middle
 And then every time we're going
@@ -2317,10 +2212,6 @@ we flush that to the GPU.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.676 --> 00:31:03.976 A:middle
-So after that's been done
-we flush that to the GPU.
 
 00:31:04.046 --> 00:31:05.946 A:middle
 The GPU starts creating
@@ -2394,10 +2285,6 @@ similar onetime setup.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.746 --> 00:32:03.606 A:middle
-So for this case we have
-similar onetime setup.
-
 00:32:03.606 --> 00:32:05.096 A:middle
 We're going to setup
 OpenGL and OpenCL
@@ -2466,10 +2353,6 @@ up with the OpenGL context
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.926 --> 00:33:03.576 A:middle
-to get CL device IDs that match
-up with the OpenGL context
 
 00:33:03.576 --> 00:33:07.326 A:middle
 that we've created and
@@ -2544,10 +2427,6 @@ the results of the draw calls
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:56.616 --> 00:34:00.816 A:middle
-in OpenCL that depends on
-the results of the draw calls
-
 00:34:01.226 --> 00:34:03.246 A:middle
 that were modifying that
 texture that we're sharing.
@@ -2614,10 +2493,6 @@ with very little cost.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.336 --> 00:35:05.066 A:middle
-and just sharing in between
-with very little cost.
-
 00:35:05.066 --> 00:35:08.536 A:middle
 And it's -- additionally
 wanted to reiterate
@@ -2683,10 +2558,6 @@ Core Profile is a profile
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.996 --> 00:36:02.826 A:middle
-So first to start out OpenGL
-Core Profile is a profile
 
 00:36:02.826 --> 00:36:05.726 A:middle
 that gives you access to
@@ -2760,10 +2631,6 @@ with Core Profile.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.266 --> 00:37:00.076 A:middle
-to get them working
-with Core Profile.
 
 00:37:00.256 --> 00:37:03.126 A:middle
 And many of these are actually
@@ -2849,10 +2716,6 @@ your own custom matrix math.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.166 --> 00:38:01.456 A:middle
-So you do have to provide
-your own custom matrix math.
-
 00:38:02.646 --> 00:38:07.126 A:middle
 And then older shaders which are
 in say 110 or 120, version 110,
@@ -2923,9 +2786,6 @@ that GLK Math provides.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.056 --> 00:39:00.356 A:middle
-that GLK Math provides.
-
 00:39:00.356 --> 00:39:07.116 A:middle
 So let's talk about creating
 that Core Profile Context.
@@ -2993,10 +2853,6 @@ to cash all your vertex data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.646 --> 00:40:02.496 A:middle
-Basically saying you need
-to cash all your vertex data
 
 00:40:02.946 --> 00:40:03.946 A:middle
 in vertex buffer objects.
@@ -3071,9 +2927,6 @@ in the Legacy profile.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.896 --> 00:41:00.296 A:middle
-in the Legacy profile.
-
 00:41:01.326 --> 00:41:06.546 A:middle
 And additionally, the
 pointers that used to exist
@@ -3138,10 +2991,6 @@ all the built in transformations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.886 --> 00:42:04.886 A:middle
-It's got the ability to replace
-all the built in transformations
 
 00:42:05.346 --> 00:42:08.596 A:middle
 that OpenGL would
@@ -3208,10 +3057,6 @@ finally gotten your value
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.846 --> 00:43:00.466 A:middle
-But when you've actually
-finally gotten your value
 
 00:43:00.466 --> 00:43:03.726 A:middle
 out of your matrix, no longer
@@ -3289,9 +3134,6 @@ That's no longer available.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.036 --> 00:44:00.726 A:middle
-That's no longer available.
-
 00:44:01.006 --> 00:44:03.306 A:middle
 Instead we're passing
 everything up as shaders
@@ -3364,10 +3206,6 @@ differences in getting it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.956 --> 00:45:02.006 A:middle
-or 120 and there's some slight
-differences in getting it
-
 00:45:02.006 --> 00:45:08.486 A:middle
 to work with 140,
 150, 330 and 410.
@@ -3429,10 +3267,6 @@ values or glUniform4fv as well
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:55.686 --> 00:46:01.626 A:middle
-glVertexAttrib4fv for constant
-values or glUniform4fv as well
 
 00:46:01.626 --> 00:46:05.346 A:middle
 for values that are not
@@ -3506,9 +3340,6 @@ in vec4 data here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.066 --> 00:47:00.526 A:middle
-in vec4 data here.
 
 00:47:00.526 --> 00:47:03.516 A:middle
 And then our varying's
@@ -3650,10 +3481,6 @@ overloads how
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.456 --> 00:49:00.416 A:middle
-And the sampler type
-overloads how
-
 00:49:00.416 --> 00:49:04.986 A:middle
 that texture call
 should be sampled from.
@@ -3722,10 +3549,6 @@ strings is slightly different.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.916 --> 00:50:02.736 A:middle
-Additionally getting extension
-strings is slightly different.
 
 00:50:03.326 --> 00:50:05.806 A:middle
 Instead of getting one huge
@@ -3796,10 +3619,6 @@ a more piecemeal approach.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.526 --> 00:51:02.446 A:middle
-For you guys I'm suggesting
-a more piecemeal approach.
-
 00:51:03.156 --> 00:51:09.126 A:middle
 So really you can do any of
 these operations by themselves
@@ -3865,10 +3684,6 @@ of calling gluPerspective
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:58.756 --> 00:52:04.056 A:middle
-So with that raw data instead
-of calling gluPerspective
-
 00:52:04.056 --> 00:52:09.156 A:middle
 for instance with the projection
 matrix instead I would have my
@@ -3928,10 +3743,6 @@ can keep your attributes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.716 --> 00:53:02.906 A:middle
-while staying in 110 you
-can keep your attributes
 
 00:53:02.906 --> 00:53:06.836 A:middle
 and replace them with generic
@@ -3999,9 +3810,6 @@ And then finally for places
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:57.156 --> 00:54:01.136 A:middle
-And then finally for places
-
 00:54:01.136 --> 00:54:06.296 A:middle
 where you may have
 fixed-function use right now you
@@ -4068,9 +3876,6 @@ in your pixel format attribute
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:54:59.176 --> 00:55:00.436 A:middle
-in your pixel format attribute
-
 00:55:01.006 --> 00:55:04.016 A:middle
 and then update your shader
 versions ideally with --
@@ -4127,9 +3932,6 @@ about OpenGL Profiler here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:58.616 --> 00:56:00.236 A:middle
-about OpenGL Profiler here.
 
 00:56:00.736 --> 00:56:04.816 A:middle
 It allows you to break on
@@ -4204,9 +4006,6 @@ at devforums.apple.com.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:56.986 --> 00:57:00.776 A:middle
-at devforums.apple.com.
 
 00:57:00.836 --> 00:57:04.806 A:middle
 And so the related sessions to

--- a/2013/508.srt
+++ b/2013/508.srt
@@ -82,9 +82,6 @@ so stick around for that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.576 --> 00:01:01.346 A:middle
-so stick around for that.
-
 00:01:03.316 --> 00:01:05.886 A:middle
 So let's first talk about
 where OpenCL is going to work.
@@ -166,10 +163,6 @@ effects everything slows down,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.426 --> 00:02:01.786 A:middle
-but once you kick on the
-effects everything slows down,
 
 00:02:01.786 --> 00:02:02.346 A:middle
 it's choppy.
@@ -275,10 +268,6 @@ a really terrible haiku.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.316 --> 00:03:00.586 A:middle
-like we always do with
-a really terrible haiku.
-
 00:03:02.036 --> 00:03:08.166 A:middle
 Pieces of data, all changing in
 the same way, few dependencies.
@@ -376,10 +365,6 @@ in Mavericks is running
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.056 --> 00:04:00.546 A:middle
-and in fact core image
-in Mavericks is running
 
 00:04:00.606 --> 00:04:02.176 A:middle
 on top of CL on the GPU.
@@ -487,10 +472,6 @@ it becomes parallel?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.196 --> 00:05:01.416 A:middle
-or change it so that
-it becomes parallel?
-
 00:05:01.756 --> 00:05:03.786 A:middle
 So let's look at an example
 of a problem like that.
@@ -590,9 +571,6 @@ so let's look at these two.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.476 --> 00:06:00.986 A:middle
-so let's look at these two.
 
 00:06:01.536 --> 00:06:03.706 A:middle
 Now, these two happen to have
@@ -702,9 +680,6 @@ to update that histogram.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.896 --> 00:07:00.116 A:middle
-to update that histogram.
-
 00:07:00.616 --> 00:07:03.426 A:middle
 And all the groups, each group
 has its own partial histogram.
@@ -801,9 +776,6 @@ in that total histogram.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.246 --> 00:08:00.236 A:middle
-in that total histogram.
-
 00:08:00.686 --> 00:08:03.096 A:middle
 Now, he's the only one
 writing to that slot,
@@ -898,10 +870,6 @@ CPU, in its memory space,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.356 --> 00:09:01.236 A:middle
-and by host I just mean your
-CPU, in its memory space,
 
 00:09:01.236 --> 00:09:03.286 A:middle
 memory that you get
@@ -998,10 +966,6 @@ get it over to the VRAM,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.996 --> 00:10:01.586 A:middle
-That makes sense, got to
-get it over to the VRAM,
-
 00:10:01.586 --> 00:10:02.566 A:middle
 get it over to the device.
 
@@ -1097,10 +1061,6 @@ scenario for the discrete GPU.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.746 --> 00:11:02.056 A:middle
-In this case this is an ideal
-scenario for the discrete GPU.
 
 00:11:02.606 --> 00:11:05.336 A:middle
 This is where you want
@@ -1292,10 +1252,6 @@ share something like the VBO
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.826 --> 00:13:02.996 A:middle
-Well, typically you would
-share something like the VBO
-
 00:13:03.246 --> 00:13:05.126 A:middle
 as a CL mem object,
 as a CL buffer.
@@ -1476,9 +1432,6 @@ IOSurface would be Gandalf.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.046 --> 00:15:00.316 A:middle
-IOSurface would be Gandalf.
-
 00:15:01.096 --> 00:15:05.426 A:middle
 It's a container for 2D image
 data, and it's really magical
@@ -1572,10 +1525,6 @@ to this checklist.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.186 --> 00:16:01.956 A:middle
-So that brings us back
-to this checklist.
 
 00:16:02.206 --> 00:16:04.256 A:middle
 So those of you who walked
@@ -1673,10 +1622,6 @@ in your loop you say
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.386 --> 00:17:00.266 A:middle
-You write a loop, and
-in your loop you say
 
 00:17:00.336 --> 00:17:02.116 A:middle
 "For My data, do this thing."
@@ -1882,10 +1827,6 @@ the kernel version
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.266 --> 00:19:01.036 A:middle
-So let's dive into
-the kernel version
-
 00:19:01.036 --> 00:19:01.966 A:middle
 of this conversion function.
 
@@ -1984,10 +1925,6 @@ And then more interestingly,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:57.406 --> 00:20:00.216 A:middle
-And then more interestingly,
-"hey, given this device,
 
 00:20:00.356 --> 00:20:02.066 A:middle
 what's the best way
@@ -2088,10 +2025,6 @@ about some practical tasks
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.676 --> 00:21:02.376 A:middle
-and today I'm going to talk
-about some practical tasks
-
 00:21:02.376 --> 00:21:06.756 A:middle
 that you can do with OpenCL,
 and I'm going to focus
@@ -2161,10 +2094,6 @@ time and reducing the amount
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.616 --> 00:22:02.076 A:middle
-of reducing that transfer
-time and reducing the amount
 
 00:22:02.076 --> 00:22:04.616 A:middle
 of copying your application
@@ -2321,10 +2250,6 @@ before, it might take the system
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:57.796 --> 00:24:02.426 A:middle
-the program hasn't ever run
-before, it might take the system
-
 00:24:02.466 --> 00:24:06.076 A:middle
 about 200 milliseconds
 to compile that CL kernel
@@ -2406,10 +2331,6 @@ file or a bitcode file,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:56.336 --> 00:25:01.296 A:middle
-with either a .cl source
-file or a bitcode file,
 
 00:25:02.326 --> 00:25:06.336 A:middle
 and you would want to
@@ -2497,10 +2418,6 @@ later on, and I want to figure
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.306 --> 00:26:05.056 A:middle
-and they started up again
-later on, and I want to figure
-
 00:26:05.056 --> 00:26:07.706 A:middle
 out if I have a cache
 file that I can load.
@@ -2578,10 +2495,6 @@ installed new graphics driver
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.956 --> 00:27:02.066 A:middle
-and the software update
-installed new graphics driver
-
 00:27:02.066 --> 00:27:05.846 A:middle
 versions and the graphics driver
 versions ended up not supporting
@@ -2655,10 +2568,6 @@ programs, the 30-line program
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.766 --> 00:28:02.246 A:middle
-to a couple different
-programs, the 30-line program
 
 00:28:02.246 --> 00:28:04.226 A:middle
 that I showed you the
@@ -2736,10 +2645,6 @@ on a configuration
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.116 --> 00:29:00.326 A:middle
-And so if you're working
-on a configuration
 
 00:29:00.326 --> 00:29:01.756 A:middle
 like this Macbook Pro Retina,
@@ -2823,10 +2728,6 @@ OpenGL application,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.056 --> 00:30:02.146 A:middle
-Now if you have an
-OpenGL application,
 
 00:30:02.466 --> 00:30:04.416 A:middle
 you probably have
@@ -2917,10 +2818,6 @@ this render has changed.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.426 --> 00:31:01.586 A:middle
-when we detect that
-this render has changed.
-
 00:31:01.856 --> 00:31:04.246 A:middle
 And so since OpenCL
 doesn't use virtual screens;
@@ -3001,10 +2898,6 @@ as well.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.636 --> 00:32:01.506 A:middle
-will handle the transition
-as well.
 
 00:32:01.506 --> 00:32:03.266 A:middle
 Also if you have
@@ -3175,9 +3068,6 @@ for transfers to complete.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.876 --> 00:34:01.146 A:middle
-for transfers to complete.
-
 00:34:01.146 --> 00:34:02.736 A:middle
 And the first thing
 I'd like to talk
@@ -3259,10 +3149,6 @@ had this set of kernels
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:56.196 --> 00:35:00.826 A:middle
-Say for example, you
-had this set of kernels
-
 00:35:00.826 --> 00:35:06.396 A:middle
 where you have a histogram
 operation and then you would
@@ -3341,10 +3227,6 @@ is a popular technique,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.526 --> 00:36:00.956 A:middle
-UseHostPointer, which
-is a popular technique,
-
 00:36:00.956 --> 00:36:03.876 A:middle
 you have to make sure that
 the UseHostPointer address
@@ -3421,10 +3303,6 @@ move those pieces of data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.546 --> 00:37:00.656 A:middle
-about 2 milliseconds to
-move those pieces of data
 
 00:37:00.656 --> 00:37:03.116 A:middle
 to the device and 6 milliseconds
@@ -3504,10 +3382,6 @@ could also do the --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.706 --> 00:38:01.086 A:middle
-between each frame, it
-could also do the --
 
 00:38:01.166 --> 00:38:04.716 A:middle
 it could also write for
@@ -3596,10 +3470,6 @@ I'd probably have a relatively
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:57.526 --> 00:39:01.906 A:middle
-In a sort of practical system
-I'd probably have a relatively
-
 00:39:01.906 --> 00:39:04.176 A:middle
 much smaller pool of buffers
 that I'd work on, much smaller
@@ -3678,10 +3548,6 @@ and for isolating a problem
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.716 --> 00:40:02.536 A:middle
-It's great for debugging
-and for isolating a problem
 
 00:40:02.536 --> 00:40:07.946 A:middle
 in your code, but it'll create
@@ -3767,10 +3633,6 @@ about a couple mechanisms
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.116 --> 00:41:01.476 A:middle
-And lastly, we talked
-about a couple mechanisms
-
 00:41:01.476 --> 00:41:04.636 A:middle
 that are available to
 decrease the overhead of having
@@ -3852,10 +3714,6 @@ what we've done since then.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:57.436 --> 00:42:00.176 A:middle
-This year I want to talk about
-what we've done since then.
 
 00:42:00.316 --> 00:42:01.586 A:middle
 We obviously didn't
@@ -3958,10 +3816,6 @@ it took us a little while
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.126 --> 00:43:00.536 A:middle
-If you got a new card,
-it took us a little while
 
 00:43:00.536 --> 00:43:01.206 A:middle
 to catch up with you.
@@ -4067,10 +3921,6 @@ heavy problem for us.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.356 --> 00:44:00.506 A:middle
-That was a pretty
-heavy problem for us.
-
 00:44:00.506 --> 00:44:02.516 A:middle
 We have a lot of kernels that
 run really well on images,
@@ -4174,10 +4024,6 @@ CC we've added a few effects.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:57.506 --> 00:45:00.936 A:middle
-So this year with Premiere Pro
-CC we've added a few effects.
-
 00:45:00.936 --> 00:45:03.706 A:middle
 Now, this doesn't really
 look like a big list.
@@ -4270,10 +4116,6 @@ a demo in a minute,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.396 --> 00:46:00.576 A:middle
-that I'll show you in
-a demo in a minute,
 
 00:46:00.626 --> 00:46:03.846 A:middle
 and that just changes the
@@ -4369,10 +4211,6 @@ done with our initial port
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:57.816 --> 00:47:00.816 A:middle
-So last year, after we were
-done with our initial port
 
 00:47:00.816 --> 00:47:03.696 A:middle
 and all the engineers took
@@ -4472,10 +4310,6 @@ make sense for our users,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.086 --> 00:48:01.156 A:middle
-We're waiting for that to
-make sense for our users,
-
 00:48:01.156 --> 00:48:04.586 A:middle
 but we did go to do multiple
 GPU support, and that's very,
@@ -4561,10 +4395,6 @@ footage, we're mixing DNHXD,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.306 --> 00:49:02.106 A:middle
-We're mixing Canon 5 Vmark 2
-footage, we're mixing DNHXD,
-
 00:49:02.286 --> 00:49:06.586 A:middle
 pro res, red, red epic, 54K,
 all on this timeline here.
@@ -4643,10 +4473,6 @@ clip in the timeline.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.286 --> 00:50:01.056 A:middle
-This isn't a single
-clip in the timeline.
 
 00:50:01.306 --> 00:50:03.056 A:middle
 This is a clip composite
@@ -4734,10 +4560,6 @@ complex descriptions
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:59.786 --> 00:51:02.746 A:middle
-So looks are very
-complex descriptions
 
 00:51:02.746 --> 00:51:06.266 A:middle
 of what you can do
@@ -4834,10 +4656,6 @@ going to give it back to Abe.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:56.256 --> 00:52:07.626 A:middle
-So thank you very much, and I'm
-going to give it back to Abe.
-
 00:52:07.626 --> 00:52:07.693 A:middle
 [ Applause ]
 
@@ -4904,7 +4722,4 @@ for your attention.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:48.156 --> 00:53:02.400 A:middle
-[ Applause ]
 

--- a/2013/509.srt
+++ b/2013/509.srt
@@ -75,10 +75,6 @@ we're going to be talking
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.676 --> 00:01:00.556 A:middle
-So, the key concepts
-we're going to be talking
-
 00:01:00.556 --> 00:01:03.226 A:middle
 about today are going to be how
 
@@ -166,10 +162,6 @@ Tone then running it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.696 --> 00:02:00.586 A:middle
-running it through Sepia
-Tone then running it
 
 00:02:00.586 --> 00:02:03.716 A:middle
 to a Hue Adjustment Filter to
@@ -260,10 +252,6 @@ little bit last year at WWDC
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.976 --> 00:03:04.476 A:middle
-which we first used a
-little bit last year at WWDC
-
 00:03:04.476 --> 00:03:09.616 A:middle
 and now we actually
 have fully vague version
@@ -333,10 +321,6 @@ a newsprint type dot pattern,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:56.966 --> 00:04:02.796 A:middle
-turns the video into a-- like
-a newsprint type dot pattern,
 
 00:04:02.796 --> 00:04:04.476 A:middle
 we can adjust the
@@ -425,10 +409,6 @@ much requested feature.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.306 --> 00:05:01.786 A:middle
-So, this has been a
-much requested feature.
 
 00:05:01.786 --> 00:05:04.716 A:middle
 We showed this last year a
@@ -519,10 +499,6 @@ also have a CIImage that comes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.756 --> 00:06:02.996 A:middle
-of some sort and-- or you can
-also have a CIImage that comes
 
 00:06:02.996 --> 00:06:04.316 A:middle
 from the output of a CIFilter.
@@ -684,10 +660,6 @@ ICC based colored profile using
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.816 --> 00:08:03.836 A:middle
-workflow or you can support any
-ICC based colored profile using
-
 00:08:04.216 --> 00:08:06.076 A:middle
 the CG color space graph object.
 
@@ -755,10 +727,6 @@ some great benefits out of that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.046 --> 00:09:00.066 A:middle
-of that today 'cause we got
-some great benefits out of that.
 
 00:09:00.696 --> 00:09:03.446 A:middle
 For a wide variety of operations
@@ -845,10 +813,6 @@ take these filter operations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.276 --> 00:10:01.596 A:middle
-And what it will do is it will
-take these filter operations
 
 00:10:01.596 --> 00:10:04.316 A:middle
 that we've done and it
@@ -943,10 +907,6 @@ wide but hundred of pixels tall
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:56.976 --> 00:11:00.736 A:middle
-It's actually hundreds of pixels
-wide but hundred of pixels tall
-
 00:11:01.056 --> 00:11:03.866 A:middle
 and that requires a lot
 of fetching from an image.
@@ -1026,10 +986,6 @@ little bit more detail
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.016 --> 00:12:00.316 A:middle
-like to give you a
-little bit more detail
 
 00:12:00.316 --> 00:12:02.416 A:middle
 on those built-on filters
@@ -1129,10 +1085,6 @@ or distortion effects.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.236 --> 00:13:00.396 A:middle
-into either geometry adjustments
-or distortion effects.
-
 00:13:01.366 --> 00:13:04.766 A:middle
 And for example, one of these
 is a fun effect called twirl
@@ -1216,10 +1168,6 @@ and vertical convolution
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.856 --> 00:14:02.586 A:middle
-We've also added a horizontal
-and vertical convolution
-
 00:14:02.586 --> 00:14:04.686 A:middle
 which is useful if your
 convolution is a separable
@@ -1289,10 +1237,6 @@ and produces output image--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.616 --> 00:15:00.026 A:middle
-that it takes input images
-and produces output image--
 
 00:15:00.026 --> 00:15:04.416 A:middle
 out data and we've had this
@@ -1384,10 +1328,6 @@ them in a robust way
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.146 --> 00:16:00.226 A:middle
-so that we can implement
-them in a robust way
 
 00:16:00.446 --> 00:16:03.736 A:middle
 and have them be useful to a
@@ -1494,10 +1434,6 @@ filters to an image.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.966 --> 00:17:01.056 A:middle
-and we've applied multiple
-filters to an image.
-
 00:17:01.956 --> 00:17:03.766 A:middle
 The other things that's
 important and great to keep
@@ -1576,10 +1512,6 @@ useful for this goal.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.046 --> 00:18:00.266 A:middle
-in iOS 7 to be particularly
-useful for this goal.
 
 00:18:01.736 --> 00:18:02.536 A:middle
 So how does this work?
@@ -1675,10 +1607,6 @@ method is create an instance
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.366 --> 00:19:01.776 A:middle
-all it does in its output image
-method is create an instance
-
 00:19:01.776 --> 00:19:03.776 A:middle
 of the filter for CIColor matrix
 
@@ -1758,10 +1686,6 @@ our intermediate buffers are
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.166 --> 00:20:02.636 A:middle
-our intermediate buffers are
-8-bit buffers for these type
-
 00:20:02.636 --> 00:20:04.996 A:middle
 of operations when they-- and
 they can only represent values
@@ -1833,10 +1757,6 @@ tilt my head, you can see the--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:57.786 --> 00:21:02.696 A:middle
-You can see my glasses and as I
-tilt my head, you can see the--
 
 00:21:02.696 --> 00:21:03.916 A:middle
 or you can see the
@@ -1915,10 +1835,6 @@ another great use
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.496 --> 00:22:00.486 A:middle
-All right, so there's
-another great use
 
 00:22:00.486 --> 00:22:03.516 A:middle
 for creating your own
@@ -2003,10 +1919,6 @@ but you want to specify them
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:56.466 --> 00:23:00.236 A:middle
-And you can have other inputs
-but you want to specify them
-
 00:23:00.716 --> 00:23:06.796 A:middle
 at setup time before you
 pass it in the Sprite Kit.
@@ -2082,10 +1994,6 @@ we use inside the Fun
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.026 --> 00:24:02.106 A:middle
-and this is the case that
-we use inside the Fun
 
 00:24:02.106 --> 00:24:03.136 A:middle
 House application.
@@ -2170,10 +2078,6 @@ hundreds of properties.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:56.526 --> 00:25:00.196 A:middle
-It contains, for some image,
-hundreds of properties.
 
 00:25:00.646 --> 00:25:01.646 A:middle
 The one that I want to call
@@ -2262,10 +2166,6 @@ use an IOSurface object
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.276 --> 00:26:01.806 A:middle
-On OS X, you want to
-use an IOSurface object
-
 00:26:01.806 --> 00:26:04.176 A:middle
 to represent this
 data and on iOS,
@@ -2342,10 +2242,6 @@ can prevent some clipping errors
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:57.716 --> 00:27:01.116 A:middle
-which is generic RGB and this
-can prevent some clipping errors
 
 00:27:01.286 --> 00:27:04.106 A:middle
 to the color matrix operations.
@@ -2437,10 +2333,6 @@ method which we can use
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.096 --> 00:28:02.876 A:middle
-there's an assets library
-method which we can use
-
 00:28:02.876 --> 00:28:06.056 A:middle
 to write the JPEG into
 that library roll.
@@ -2510,10 +2402,6 @@ effect that's desired
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.836 --> 00:29:01.296 A:middle
-it will perform the filter
-effect that's desired
 
 00:29:01.716 --> 00:29:04.236 A:middle
 and because the image is being
@@ -2678,10 +2566,6 @@ is another interesting thing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:57.786 --> 00:31:00.116 A:middle
-to a CVPixelBufferFef, and this
-is another interesting thing
-
 00:31:00.116 --> 00:31:03.076 A:middle
 that we talked about and show
 in the Fun House application
@@ -2773,10 +2657,6 @@ it comes time to render,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.216 --> 00:32:00.366 A:middle
-We look later on it-- when
-it comes time to render,
 
 00:32:00.626 --> 00:32:02.986 A:middle
 we have a callback
@@ -2941,10 +2821,6 @@ every time you render it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.476 --> 00:34:00.466 A:middle
-to creat a CIContext
-every time you render it,
-
 00:34:00.516 --> 00:34:02.556 A:middle
 much better to create
 it once and reuse it.
@@ -3025,10 +2901,6 @@ asset library, you can say,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.416 --> 00:35:01.716 A:middle
-for a library from your
-asset library, you can say,
 
 00:35:01.716 --> 00:35:04.056 A:middle
 I want a full screen image
@@ -3125,10 +2997,6 @@ language has some really great
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.146 --> 00:36:01.686 A:middle
-the Core Image kernel
-language has some really great
-
 00:36:01.686 --> 00:36:02.796 A:middle
 advantages though.
 
@@ -3222,10 +3090,6 @@ and interesting effects
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.426 --> 00:37:01.006 A:middle
-in order to create new
-and interesting effects
-
 00:37:01.006 --> 00:37:02.186 A:middle
 which we wouldn't be able
 
@@ -3317,9 +3181,6 @@ it's no longer black.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.956 --> 00:38:00.846 A:middle
-it's no longer black.
-
 00:38:00.846 --> 00:38:02.106 A:middle
 It has-- it's colorful.
 
@@ -3406,10 +3267,6 @@ do the exact same thing
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.486 --> 00:39:01.366 A:middle
-and then we're going to
-do the exact same thing
 
 00:39:01.396 --> 00:39:02.256 A:middle
 in the Y direction.
@@ -3504,10 +3361,6 @@ our original image,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.176 --> 00:40:00.856 A:middle
-to subtract from
-our original image,
 
 00:40:00.916 --> 00:40:03.596 A:middle
 and we'll get our dehazed image.
@@ -3676,10 +3529,6 @@ we're going to import an image
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.556 --> 00:42:00.446 A:middle
-So, first thing is first,
-we're going to import an image
 
 00:42:00.446 --> 00:42:03.476 A:middle
 with the URL, so we just create,
@@ -3870,10 +3719,6 @@ from the IOSurfaces
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.536 --> 00:44:02.566 A:middle
-to share all the data
-from the IOSurfaces
-
 00:44:02.566 --> 00:44:06.466 A:middle
 that we created with OpenGL.
 
@@ -3960,10 +3805,6 @@ one more IOSurface based
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:56.986 --> 00:45:00.556 A:middle
-And then we're going to need
-one more IOSurface based
 
 00:45:00.946 --> 00:45:03.526 A:middle
 ClMemObjectfor our final output
@@ -4053,10 +3894,6 @@ source code for the filter
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:57.356 --> 00:46:00.846 A:middle
-So, that's the entire
-source code for the filter
 
 00:46:00.846 --> 00:46:01.966 A:middle
 that we're going
@@ -4155,10 +3992,6 @@ we perform our For loop
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.276 --> 00:47:02.986 A:middle
-to opaque white, and then
-we perform our For loop
-
 00:47:02.986 --> 00:47:04.466 A:middle
 which searches in this
 case from left to right.
@@ -4242,10 +4075,6 @@ other approaches, and this ended
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.876 --> 00:48:00.886 A:middle
-And we've tried a bunch of
-other approaches, and this ended
 
 00:48:00.886 --> 00:48:02.276 A:middle
 up being as fast it gets.
@@ -4333,9 +4162,6 @@ and ask OpenCL to run.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:58.286 --> 00:49:00.916 A:middle
-and ask OpenCL to run.
 
 00:49:01.416 --> 00:49:02.656 A:middle
 So, as we saw earlier,
@@ -4519,10 +4345,6 @@ similar effect to what we did
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.336 --> 00:51:01.606 A:middle
-to basically give us a very
-similar effect to what we did
-
 00:51:01.606 --> 00:51:03.996 A:middle
 when we asked for clamp to
 edge 'cause we don't want
@@ -4599,10 +4421,6 @@ or CIContext draw image,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:56.506 --> 00:52:00.646 A:middle
-to do is call context
-or CIContext draw image,
 
 00:52:00.646 --> 00:52:04.346 A:middle
 our final image at a certain
@@ -4789,10 +4607,6 @@ with Core Image as well.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:59.826 --> 00:54:01.166 A:middle
-about how you could do that
-with Core Image as well.
 
 00:54:02.666 --> 00:54:06.156 A:middle
 So, some additional information,

--- a/2013/600.srt
+++ b/2013/600.srt
@@ -76,9 +76,6 @@ and greatest WebKit changes.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.616 --> 00:01:01.066 A:middle
-and greatest WebKit changes.
-
 00:01:01.656 --> 00:01:06.116 A:middle
 You're probably wondering
 what we've been up to.
@@ -245,10 +242,6 @@ very fundamental
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.786 --> 00:03:01.736 A:middle
-Columns are obviously
-very fundamental
-
 00:03:01.736 --> 00:03:04.286 A:middle
 in Print Media Designs so
 if you want your platform
@@ -328,10 +321,6 @@ layout specification.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.346 --> 00:04:01.226 A:middle
-in the W3C's multi-column
-layout specification.
 
 00:04:01.926 --> 00:04:05.586 A:middle
 Having a way to create rich
@@ -419,10 +408,6 @@ incredibly simple.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.316 --> 00:05:01.276 A:middle
-So, the syntax is
-incredibly simple.
-
 00:05:01.276 --> 00:05:03.906 A:middle
 All I have to do is to start
 laying out into columns is
@@ -506,10 +491,6 @@ really long UIWebView
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.896 --> 00:06:00.686 A:middle
-So, if we take this
-really long UIWebView
 
 00:06:00.686 --> 00:06:03.486 A:middle
 and set pagination parameters
@@ -600,9 +581,6 @@ This property-- excuse me,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.206 --> 00:07:01.026 A:middle
-This property-- excuse me,
-
 00:07:01.646 --> 00:07:04.506 A:middle
 this property takes an
 enumeration as a value.
@@ -690,10 +668,6 @@ whether those styles are honored
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.066 --> 00:08:03.686 A:middle
-of this property will determine
-whether those styles are honored
-
 00:08:03.686 --> 00:08:04.506 A:middle
 or ignored.
 
@@ -769,10 +743,6 @@ define the content that you want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.046 --> 00:09:01.556 A:middle
-of your markup is being used to
-define the content that you want
 
 00:09:01.556 --> 00:09:02.776 A:middle
 to flow through that layout.
@@ -867,10 +837,6 @@ these regions then instead
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:57.606 --> 00:10:00.286 A:middle
-that is meant to flow through
-these regions then instead
-
 00:10:00.286 --> 00:10:03.516 A:middle
 of laying out just in a normal
 document flow like this,
@@ -964,10 +930,6 @@ a shared class name
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.836 --> 00:11:00.846 A:middle
-I've also given them
-a shared class name
-
 00:11:01.046 --> 00:11:02.186 A:middle
 so that they can share the CSS
 
@@ -1058,10 +1020,6 @@ based on which region
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:57.416 --> 00:12:00.116 A:middle
-as it you can style content
-based on which region
-
 00:12:00.116 --> 00:12:01.196 A:middle
 that it's flowing through.
 
@@ -1146,10 +1104,6 @@ interactive region state mode
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.716 --> 00:13:02.856 A:middle
-So, I prepared for you an
-interactive region state mode
-
 00:13:02.926 --> 00:13:06.726 A:middle
 to show you how flexible and
 powerful CSS regions are.
@@ -1214,10 +1168,6 @@ region indicate the order,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.086 --> 00:14:02.666 A:middle
-The numbers on each
-region indicate the order,
 
 00:14:02.666 --> 00:14:04.926 A:middle
 the content flow
@@ -1286,10 +1236,6 @@ content reflows from one region
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.516 --> 00:15:03.866 A:middle
-To make it even clearer how the
-content reflows from one region
 
 00:15:03.866 --> 00:15:08.326 A:middle
 to another, pay attention as
@@ -1415,10 +1361,6 @@ manage and as the size
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:56.996 --> 00:17:00.926 A:middle
-It's very easy to
-manage and as the size
-
 00:17:00.926 --> 00:17:03.186 A:middle
 of the viewport changes,
 all you have
@@ -1486,10 +1428,6 @@ it back to Beth,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.076 --> 00:18:01.536 A:middle
-So, before I turn
-it back to Beth,
-
 00:18:02.146 --> 00:18:06.196 A:middle
 I'd like to show you a
 page that I've prepared
@@ -1544,10 +1482,6 @@ that contains our entire text
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:54.756 --> 00:19:01.276 A:middle
-We have our section here
-that contains our entire text
 
 00:19:01.576 --> 00:19:04.726 A:middle
 and the text is simply
@@ -1620,9 +1554,6 @@ Flexible boxes are defined
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.946 --> 00:20:00.526 A:middle
-Flexible boxes are defined
 
 00:20:00.526 --> 00:20:03.906 A:middle
 in the W3Cs Flexible
@@ -1710,10 +1641,6 @@ we will be improving
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.816 --> 00:21:02.306 A:middle
-that's the version that
-we will be improving
 
 00:21:02.306 --> 00:21:03.796 A:middle
 and maintaining going forward.
@@ -1804,10 +1731,6 @@ the smaller window size,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.456 --> 00:22:00.766 A:middle
-All right, first of all at
-the smaller window size,
-
 00:22:00.766 --> 00:22:03.386 A:middle
 we can clearly see that
 there are three boxes
@@ -1897,9 +1820,6 @@ up until a certain point
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.176 --> 00:23:00.496 A:middle
-up until a certain point
 
 00:23:00.696 --> 00:23:03.266 A:middle
 at which time it's
@@ -1994,9 +1914,6 @@ to either flex or inline flex.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.366 --> 00:24:00.986 A:middle
-to either flex or inline flex.
 
 00:24:01.436 --> 00:24:03.586 A:middle
 And now, it will indicate
@@ -2178,10 +2095,6 @@ are no other growing elements
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.106 --> 00:26:01.556 A:middle
-But in this example, there
-are no other growing elements
-
 00:26:01.556 --> 00:26:05.806 A:middle
 so we'll take all of
 the space for itself.
@@ -2268,9 +2181,6 @@ to center something.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.506 --> 00:27:00.436 A:middle
-to center something.
 
 00:27:00.996 --> 00:27:02.386 A:middle
 As I'm sure you all
@@ -2359,9 +2269,6 @@ over how things are positioned,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.966 --> 00:28:02.276 A:middle
-over how things are positioned,
 
 00:28:02.686 --> 00:28:04.446 A:middle
 aligned items in
@@ -2548,10 +2455,6 @@ for our Play and Pause button.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.746 --> 00:30:02.416 A:middle
-And here I have some controls
-for our Play and Pause button.
-
 00:30:02.416 --> 00:30:03.976 A:middle
 Custom controls are
 really powerful.
@@ -2647,10 +2550,6 @@ the network.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.896 --> 00:31:02.016 A:middle
-or when one has left
-the network.
 
 00:31:02.366 --> 00:31:05.116 A:middle
 And it's also guaranteed--
@@ -2748,10 +2647,6 @@ on that button.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.046 --> 00:32:00.536 A:middle
-for the click event
-on that button.
 
 00:32:00.886 --> 00:32:02.326 A:middle
 And whenever that
@@ -2922,10 +2817,6 @@ set of CSS properties
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.756 --> 00:34:00.686 A:middle
-There are a limited
-set of CSS properties
-
 00:34:00.686 --> 00:34:02.386 A:middle
 that you can use
 to style captions.
@@ -2995,10 +2886,6 @@ in Italian.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.656 --> 00:35:04.086 A:middle
-and I also have captions
-in Italian.
 
 00:35:04.086 --> 00:35:08.086 A:middle
 The system will remember the
@@ -3124,10 +3011,6 @@ one corresponds to one line
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.056 --> 00:37:03.306 A:middle
-Each entry of the VTT file is
-one corresponds to one line
-
 00:37:03.306 --> 00:37:05.296 A:middle
 of the caption and
 for each one--
@@ -3190,10 +3073,6 @@ separately individual elements
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.446 --> 00:38:03.376 A:middle
-You can also style
-separately individual elements
 
 00:38:03.376 --> 00:38:05.416 A:middle
 of the captions by
@@ -3364,10 +3243,6 @@ chance to browse the web
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.256 --> 00:41:03.696 A:middle
-So, if you had a
-chance to browse the web
-
 00:41:03.696 --> 00:41:06.476 A:middle
 with Safari 7 yet, you
 may have noticed the text
@@ -3455,10 +3330,6 @@ here on the left to have F and I
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.676 --> 00:42:01.746 A:middle
-So, FI is a classic example
-here on the left to have F and I
-
 00:42:01.746 --> 00:42:04.616 A:middle
 as two separate glyphs and
 on the right is a glyph
@@ -3543,10 +3414,6 @@ text will take up less space.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:56.396 --> 00:43:01.026 A:middle
-and ligatures are enabled,
-text will take up less space.
-
 00:43:01.026 --> 00:43:04.836 A:middle
 So, if you were expecting your
 text in your app or your website
@@ -3626,10 +3493,6 @@ or I'm setting something to be
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.486 --> 00:44:02.246 A:middle
-or I'm setting something to be
-100 percent minus 80 pixels.
-
 00:44:02.696 --> 00:44:05.486 A:middle
 Our clients at Apple have
 already started using this
@@ -3706,10 +3569,6 @@ cool new CSS features.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:55.516 --> 00:45:00.566 A:middle
-OK. So, those are two
-cool new CSS features.
 
 00:45:00.566 --> 00:45:02.036 A:middle
 There are so many more I wish
@@ -3799,10 +3658,6 @@ that will let you store paths
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.766 --> 00:46:02.786 A:middle
-So, this is a great new API
-that will let you store paths
-
 00:46:02.786 --> 00:46:05.466 A:middle
 as variables up until now
 if you were creating paths
@@ -3882,10 +3737,6 @@ then you may have seen a session
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:57.076 --> 00:47:00.736 A:middle
-if you were at WWDC last year,
-then you may have seen a session
 
 00:47:00.986 --> 00:47:05.196 A:middle
 that we gave all about higher
@@ -3973,10 +3824,6 @@ confused and sad
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.366 --> 00:48:02.416 A:middle
-Well, people got
-confused and sad
-
 00:48:02.776 --> 00:48:05.126 A:middle
 and that was definitely
 not our goal.
@@ -4055,10 +3902,6 @@ some confusion by getting rid
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.486 --> 00:49:01.976 A:middle
-that hopefully we've cleared up
-some confusion by getting rid
 
 00:49:01.976 --> 00:49:06.486 A:middle
 of the auto doubling that
@@ -4148,10 +3991,6 @@ on a specific size.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.916 --> 00:50:01.976 A:middle
-for if you were depending
-on a specific size.
 
 00:50:02.446 --> 00:50:05.446 A:middle
 Another change that we made is
@@ -4246,10 +4085,6 @@ transition as we call it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:58.496 --> 00:51:02.576 A:middle
-that we've unprefixed
-transition as we call it.
 
 00:51:02.576 --> 00:51:05.666 A:middle
 The transition specification
@@ -4350,10 +4185,6 @@ and our devices.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:59.366 --> 00:52:01.076 A:middle
-with our platform
-and our devices.
-
 00:52:01.076 --> 00:52:03.726 A:middle
 I think that the AirPlay
 API and our support
@@ -4440,10 +4271,6 @@ tips and tricks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.376 --> 00:53:00.526 A:middle
-of other really great
-tips and tricks
 
 00:53:00.566 --> 00:53:03.186 A:middle
 for having a really

--- a/2013/601.srt
+++ b/2013/601.srt
@@ -71,10 +71,6 @@ entire professional career.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.906 --> 00:01:00.386 A:middle
-with Web Technologies my
-entire professional career.
-
 00:01:01.396 --> 00:01:04.756 A:middle
 And some may not
 remember that time,
@@ -163,10 +159,6 @@ great if you could stay
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.266 --> 00:02:00.996 A:middle
-because wouldn't it be
-great if you could stay
 
 00:02:00.996 --> 00:02:02.346 A:middle
 in the same tool at all times?
@@ -262,10 +254,6 @@ you cross your fingers,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.146 --> 00:03:01.966 A:middle
-And so you keep going,
-you cross your fingers,
-
 00:03:02.376 --> 00:03:05.116 A:middle
 you finally get there,
 and unfortunately,
@@ -341,10 +329,6 @@ inspect pages on iOS devices is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.256 --> 00:04:03.096 A:middle
-And so, the way we can remotely
-inspect pages on iOS devices is
 
 00:04:03.096 --> 00:04:07.126 A:middle
 that you can just run Safari
@@ -432,10 +416,6 @@ going to walk you through it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.416 --> 00:05:01.536 A:middle
-into this user interface and I'm
-going to walk you through it,
-
 00:05:01.536 --> 00:05:03.516 A:middle
 give you a little
 guidance to show you how
@@ -511,10 +491,6 @@ not on by default in Safari.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.216 --> 00:06:02.356 A:middle
-Okay, so Web Inspector is
-not on by default in Safari.
 
 00:06:02.526 --> 00:06:03.696 A:middle
 It's a developer tool
@@ -668,10 +644,6 @@ to find specific WebViews
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.756 --> 00:08:03.326 A:middle
-to drill into this menu
-to find specific WebViews
-
 00:08:03.326 --> 00:08:04.966 A:middle
 that you can inspect
 on this device.
@@ -758,10 +730,6 @@ select the HTML
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.866 --> 00:09:02.436 A:middle
-Web Inspector will
-select the HTML
-
 00:09:02.436 --> 00:09:03.636 A:middle
 of the page you're inspecting
 
@@ -845,10 +813,6 @@ image, the content here changes.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.836 --> 00:10:01.396 A:middle
-So for example, if I pick an
-image, the content here changes.
 
 00:10:02.046 --> 00:10:07.336 A:middle
 If I pick a piece of JavaScript,
@@ -1010,10 +974,6 @@ Quick Console on and off
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.786 --> 00:12:02.056 A:middle
-And you can toggle this
-Quick Console on and off
 
 00:12:02.226 --> 00:12:03.626 A:middle
 by just using the Escape key.
@@ -1201,10 +1161,6 @@ so you always have a quick idea
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.806 --> 00:14:02.636 A:middle
-And these are always available,
-so you always have a quick idea
-
 00:14:02.636 --> 00:14:05.156 A:middle
 of how many resources you're
 dealing with, the complete sizes
@@ -1300,10 +1256,6 @@ buttons to the left
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.796 --> 00:15:01.666 A:middle
-And when we toggle the
-buttons to the left
-
 00:15:01.666 --> 00:15:03.326 A:middle
 to control the Navigation
 Sidebar,
@@ -1382,10 +1334,6 @@ just for this demo.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.916 --> 00:16:01.816 A:middle
-and open a page I created
-just for this demo.
 
 00:16:02.376 --> 00:16:03.916 A:middle
 Well, that page may
@@ -1469,10 +1417,6 @@ portrait kind of experience.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.936 --> 00:17:01.826 A:middle
-It's landscape and I want a
-portrait kind of experience.
 
 00:17:02.086 --> 00:17:04.246 A:middle
 So, what can I do
@@ -1566,10 +1510,6 @@ want to add a blur filter
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.666 --> 00:18:02.596 A:middle
-and because eventually we'll
-want to add a blur filter
-
 00:18:02.596 --> 00:18:05.526 A:middle
 to that image so that it
 looks like an iOS 7 kind
@@ -1652,10 +1592,6 @@ to use Command-Z to undo
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:57.956 --> 00:19:01.106 A:middle
-Just to show you, I'm going
-to use Command-Z to undo
 
 00:19:01.356 --> 00:19:02.766 A:middle
 because we support
@@ -1750,10 +1686,6 @@ like to use that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.666 --> 00:20:00.976 A:middle
-and I think I just
-like to use that.
 
 00:20:01.796 --> 00:20:04.786 A:middle
 So again, this is just
@@ -1850,10 +1782,6 @@ can go back and correct
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.686 --> 00:21:00.276 A:middle
-like that is something you
-can go back and correct
-
 00:21:00.276 --> 00:21:02.286 A:middle
 if it was not what you wanted.
 
@@ -1939,10 +1867,6 @@ need to touch on the body
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.456 --> 00:22:00.336 A:middle
-That's just something I
-need to touch on the body
 
 00:22:00.696 --> 00:22:03.426 A:middle
 and I can edit the style
@@ -2037,10 +1961,6 @@ and then it will move it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.856 --> 00:23:03.056 A:middle
-and then it will move it
-480 pixels to the left.
-
 00:23:03.526 --> 00:23:06.476 A:middle
 That was great with the previous
 version of the site that we had.
@@ -2124,10 +2044,6 @@ a DOM tree, use the arrow keys
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:57.296 --> 00:24:00.546 A:middle
-So here again, I'm going to use
-a DOM tree, use the arrow keys
 
 00:24:00.546 --> 00:24:02.896 A:middle
 to navigate until I find
@@ -2224,9 +2140,6 @@ It's a lot more revealing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.326 --> 00:25:00.726 A:middle
-It's a lot more revealing.
-
 00:25:00.866 --> 00:25:01.566 A:middle
 We're getting there.
 
@@ -2312,10 +2225,6 @@ press H to turn it back on.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:57.496 --> 00:26:00.246 A:middle
-Let's go back to the Menu,
-press H to turn it back on.
 
 00:26:00.986 --> 00:26:03.336 A:middle
 It's almost right but
@@ -2505,10 +2414,6 @@ immediately in Web Inspector.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.146 --> 00:28:01.906 A:middle
-to inspect and it revealed
-immediately in Web Inspector.
-
 00:28:02.616 --> 00:28:05.526 A:middle
 And another way you can do it is
 to do it the other way around.
@@ -2599,9 +2504,6 @@ and Safari on iOS and iOS 7.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:59.606 --> 00:29:01.396 A:middle
-and Safari on iOS and iOS 7.
 
 00:29:01.686 --> 00:29:03.666 A:middle
 The session was named "What's
@@ -2703,10 +2605,6 @@ iOS app is to have as little
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.036 --> 00:30:02.556 A:middle
-or your web content in your
-iOS app is to have as little
 
 00:30:02.556 --> 00:30:03.976 A:middle
 and as few resources
@@ -2891,10 +2789,6 @@ that for the Timeline's panel
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:58.136 --> 00:32:01.516 A:middle
-Well, the reason it is empty is
-that for the Timeline's panel
-
 00:32:01.516 --> 00:32:04.746 A:middle
 to load with useful
 content, WebKit needs
@@ -2995,10 +2889,6 @@ three different categories.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.966 --> 00:33:03.346 A:middle
-at the top are split in
-three different categories.
-
 00:33:03.826 --> 00:33:07.776 A:middle
 There's first, network request
 in blue, layout and rendering
@@ -3082,10 +2972,6 @@ a 3G network on this computer,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:56.886 --> 00:34:00.996 A:middle
-that I'm actually simulating
-a 3G network on this computer,
 
 00:34:01.306 --> 00:34:03.926 A:middle
 so that it doesn't looks
@@ -3173,10 +3059,6 @@ is latency, and it's just
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.556 --> 00:35:00.696 A:middle
-The transparent section
-is latency, and it's just
 
 00:35:00.696 --> 00:35:02.706 A:middle
 so much more than the
@@ -3348,10 +3230,6 @@ overview of the timeline
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.376 --> 00:37:00.676 A:middle
-Okay, so that was a brief
-overview of the timeline
-
 00:37:00.676 --> 00:37:01.916 A:middle
 for networking resources.
 
@@ -3435,10 +3313,6 @@ loads as fast as possible.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:57.716 --> 00:38:00.596 A:middle
-so that your initial content
-loads as fast as possible.
 
 00:38:01.056 --> 00:38:03.886 A:middle
 And to validate that technique,
@@ -3537,10 +3411,6 @@ is wanted to go further
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.726 --> 00:39:01.456 A:middle
-And what I did here is that
-is wanted to go further
-
 00:39:01.456 --> 00:39:05.296 A:middle
 in the iOS 7 experience
 and provide a new header
@@ -3620,10 +3490,6 @@ animation going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.366 --> 00:40:00.246 A:middle
-And so, we have an
-animation going
 
 00:40:00.246 --> 00:40:00.976 A:middle
 as soon as we add this class.
@@ -3723,10 +3589,6 @@ know there's an error.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.496 --> 00:41:00.516 A:middle
-So, it's red, letting me
-know there's an error.
-
 00:41:00.976 --> 00:41:03.646 A:middle
 And what's really cool about
 any kind of source we show
@@ -3815,10 +3677,6 @@ brace, we actually need to save
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.536 --> 00:42:01.976 A:middle
-that when we add our closing
-brace, we actually need to save
-
 00:42:01.976 --> 00:42:04.696 A:middle
 that file for-- in order to
 be able to reload the page
@@ -3902,10 +3760,6 @@ out what's going on.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.896 --> 00:43:00.216 A:middle
-so we can figure
-out what's going on.
 
 00:43:00.306 --> 00:43:02.436 A:middle
 So, I'm going to bring
@@ -4169,10 +4023,6 @@ click on trailers,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.056 --> 00:46:00.706 A:middle
-I'm just going to
-click on trailers,
-
 00:46:01.666 --> 00:46:04.676 A:middle
 and as soon as I click it,
 again, I will break in the code.
@@ -4252,10 +4102,6 @@ figure out what it may--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:59.056 --> 00:47:01.616 A:middle
-within the console to
-figure out what it may--
 
 00:47:01.616 --> 00:47:03.826 A:middle
 what the property that I was
@@ -4338,10 +4184,6 @@ something that we didn't do.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.476 --> 00:48:00.476 A:middle
-Well, I'll start with
-something that we didn't do.
 
 00:48:00.626 --> 00:48:03.006 A:middle
 You'll notice we
@@ -4431,10 +4273,6 @@ context and figure
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:58.426 --> 00:49:00.406 A:middle
-to in this current
-context and figure
 
 00:49:00.406 --> 00:49:03.406 A:middle
 out what right code would
@@ -4538,10 +4376,6 @@ JavaScript code in real time
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.356 --> 00:50:02.486 A:middle
-And finally, we just debug the
-JavaScript code in real time
-
 00:50:02.486 --> 00:50:05.346 A:middle
 within Web Inspector by just
 using the great debugging tools
@@ -4640,10 +4474,6 @@ find us on IRC as well.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:58.906 --> 00:51:01.146 A:middle
-interactively, you can
-find us on IRC as well.
 
 00:51:01.146 --> 00:51:02.846 A:middle
 We hang out at irc.freenode.net,

--- a/2013/602.srt
+++ b/2013/602.srt
@@ -86,10 +86,6 @@ our multi-mic platforms
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.436 --> 00:01:00.456 A:middle
-that you'd like to use on
-our multi-mic platforms
-
 00:01:00.996 --> 00:01:03.426 A:middle
 and on devices that support
 it such as the iPhone 5.
@@ -185,10 +181,6 @@ algorithm
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.396 --> 00:02:00.066 A:middle
-But a less CPU intensive
-algorithm
 
 00:02:00.066 --> 00:02:02.036 A:middle
 for those less importance
@@ -294,10 +286,6 @@ go in and change your mind
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.726 --> 00:03:01.976 A:middle
-However, if you'd like to
-go in and change your mind
-
 00:03:01.976 --> 00:03:03.206 A:middle
 at a later time,
 you can always go
@@ -390,10 +378,6 @@ time today going over any
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.976 --> 00:04:00.116 A:middle
-We're not going to spend anymore
-time today going over any
 
 00:04:00.116 --> 00:04:01.446 A:middle
 of these topics in
@@ -501,10 +485,6 @@ platform for the evolution
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.296 --> 00:05:00.026 A:middle
-and should provide for a stable
-platform for the evolution
-
 00:05:00.026 --> 00:05:00.796 A:middle
 of the feature over time.
 
@@ -589,10 +569,6 @@ of the built-in instruments
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.056 --> 00:06:01.736 A:middle
-But instead of using one
-of the built-in instruments
-
 00:06:01.736 --> 00:06:05.946 A:middle
 in GarageBand, I want to use
 an instrument, on the system
@@ -667,9 +643,6 @@ record over the top of it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:54.356 --> 00:07:01.376 A:middle
-[ Music ]
 
 00:07:01.876 --> 00:07:03.236 A:middle
 Brilliant musical passage.
@@ -937,10 +910,6 @@ applications is that the host is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.536 --> 00:11:01.556 A:middle
-between these two
-applications is that the host is
-
 00:11:01.556 --> 00:11:04.066 A:middle
 where we ultimately
 want the audio coming
@@ -1022,10 +991,6 @@ that sampler application,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.106 --> 00:12:01.656 A:middle
-So for example, with
-that sampler application,
-
 00:12:01.656 --> 00:12:04.106 A:middle
 the host could have been
 actually sending the MIDI nodes
@@ -1104,10 +1069,6 @@ of Inter-App Audio,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.016 --> 00:13:00.196 A:middle
-But for the-- the purposes
-of Inter-App Audio,
-
 00:13:01.176 --> 00:13:04.206 A:middle
 the host engine connects
 to a node application
@@ -1179,10 +1140,6 @@ gets redirected to the host
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.206 --> 00:14:04.536 A:middle
-and the nodes AURemoteIO unit
-gets redirected to the host
-
 00:14:04.596 --> 00:14:06.226 A:middle
 so the node's communication
 
@@ -1252,10 +1209,6 @@ and may wish to present itself
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.316 --> 00:15:01.966 A:middle
-multiple sets of capabilities
-and may wish to present itself
 
 00:15:02.096 --> 00:15:03.996 A:middle
 in multiple ways to hosts.
@@ -1333,10 +1286,6 @@ while only sending the audio
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.976 --> 00:16:02.736 A:middle
-from the underlying AURemoteIO
-while only sending the audio
 
 00:16:02.736 --> 00:16:03.736 A:middle
 output to the host.
@@ -1419,10 +1368,6 @@ applications need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:58.626 --> 00:17:00.676 A:middle
-Both host and node
-applications need
-
 00:17:00.676 --> 00:17:04.185 A:middle
 to have a new entitlement called
 "inter-app-audio" and this--
@@ -1500,10 +1445,6 @@ of registering one's self
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.876 --> 00:18:01.656 A:middle
-So, there's two pieces
-of registering one's self
 
 00:18:01.656 --> 00:18:02.766 A:middle
 for a node application.
@@ -1585,9 +1526,6 @@ and the version number.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.946 --> 00:19:01.056 A:middle
-and the version number.
-
 00:19:01.656 --> 00:19:04.186 A:middle
 So, that completely
 describes the AudioComponent
@@ -1653,10 +1591,6 @@ the component description
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:56.736 --> 00:20:00.086 A:middle
-that it just created with
-the component description
 
 00:20:00.086 --> 00:20:02.356 A:middle
 that was published in
@@ -1733,10 +1667,6 @@ Info.plist entry and the call
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:55.666 --> 00:21:00.306 A:middle
-And so, you can see then why the
-Info.plist entry and the call
 
 00:21:00.306 --> 00:21:04.636 A:middle
 to AudioOutputUnitPublish
@@ -1815,10 +1745,6 @@ will yield in turn each
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.906 --> 00:22:02.936 A:middle
-repeatedly and that
-will yield in turn each
 
 00:22:02.936 --> 00:22:05.166 A:middle
 of the AudioComponents
@@ -1901,10 +1827,6 @@ the nodes that it's found.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.126 --> 00:23:01.486 A:middle
-of storing information about
-the nodes that it's found.
-
 00:23:02.436 --> 00:23:05.686 A:middle
 And it calls this class
 RemoteAU and it stores away
@@ -1975,10 +1897,6 @@ table view and present the user
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:56.146 --> 00:24:00.216 A:middle
-from which we can drive a
-table view and present the user
-
 00:24:00.216 --> 00:24:05.306 A:middle
 with a choice of node
 applications to deal with.
@@ -2046,10 +1964,6 @@ selected one of them
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:58.256 --> 00:25:01.656 A:middle
-and maybe the user has
-selected one of them
 
 00:25:01.656 --> 00:25:03.246 A:middle
 and in the host application now,
@@ -2131,10 +2045,6 @@ hardware sample rate is what
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.806 --> 00:26:04.036 A:middle
-So, to be absolutely sure the
-hardware sample rate is what
-
 00:26:04.036 --> 00:26:07.156 A:middle
 it's supposed to be, we should
 be making our audio session
@@ -2204,10 +2114,6 @@ audio stream basic description
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.136 --> 00:27:00.896 A:middle
-Now, we have built up an
-audio stream basic description
 
 00:27:00.896 --> 00:27:02.906 A:middle
 and we can use
@@ -2359,10 +2265,6 @@ property again.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:57.796 --> 00:29:00.416 A:middle
-You can use the MakeConnection
-property again.
-
 00:29:01.146 --> 00:29:04.846 A:middle
 If however you're pulling
 audio into a custom engine,
@@ -2438,10 +2340,6 @@ audio unit there.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.596 --> 00:30:01.326 A:middle
-there's still an
-audio unit there.
-
 00:30:01.426 --> 00:30:05.356 A:middle
 You can make API calls on
 it but they won't crash
@@ -2514,9 +2412,6 @@ In the case of inter-app audio,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.986 --> 00:31:01.496 A:middle
-In the case of inter-app audio,
 
 00:31:01.886 --> 00:31:05.146 A:middle
 the system at this point is
@@ -2596,10 +2491,6 @@ done using Apple AudioUnits.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.036 --> 00:32:03.166 A:middle
-if you can get your work
-done using Apple AudioUnits.
-
 00:32:03.166 --> 00:32:06.506 A:middle
 So, the green box, the
 green dotted lines--
@@ -2674,10 +2565,6 @@ of stuff about how we--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:57.916 --> 00:33:03.126 A:middle
-OK. So, that's a bunch
-of stuff about how we--
 
 00:33:03.286 --> 00:33:06.116 A:middle
 a host application
@@ -2826,10 +2713,6 @@ property just as I described
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.036 --> 00:35:01.166 A:middle
-for the IsInterAppConnected
-property just as I described
-
 00:35:01.526 --> 00:35:03.086 A:middle
 for host applications earlier.
 
@@ -2914,10 +2797,6 @@ AudioOutputUnitGetHostIcon.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.186 --> 00:36:00.286 A:middle
-there's a new API called
-AudioOutputUnitGetHostIcon.
 
 00:36:03.546 --> 00:36:07.036 A:middle
 Pertaining further to the
@@ -3070,10 +2949,6 @@ your output has been redirected
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:56.566 --> 00:38:00.126 A:middle
-from the microphone even while
-your output has been redirected
-
 00:38:00.126 --> 00:38:01.346 A:middle
 to the host application.
 
@@ -3147,10 +3022,6 @@ side of things,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.936 --> 00:39:00.926 A:middle
-OK. Back on the host
-side of things,
 
 00:39:01.706 --> 00:39:04.496 A:middle
 there are a few considerations
@@ -3228,10 +3099,6 @@ for remote instrument
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:57.726 --> 00:40:01.746 A:middle
-Now, this of course, is
-for remote instrument
-
 00:40:01.816 --> 00:40:03.806 A:middle
 and remote music effect nodes.
 
@@ -3305,10 +3172,6 @@ host application can send
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.416 --> 00:41:00.276 A:middle
-So, let's look at how a
-host application can send
 
 00:41:00.276 --> 00:41:01.246 A:middle
 MIDI events.
@@ -3394,10 +3257,6 @@ schedule our MIDI events
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.446 --> 00:42:03.006 A:middle
-scheduling then we have to
-schedule our MIDI events
-
 00:42:03.006 --> 00:42:05.536 A:middle
 on the same thread that
 were rendering the audio,
@@ -3476,10 +3335,6 @@ there's an AUGraph API
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.846 --> 00:43:03.306 A:middle
-So, the way to do this,
-there's an AUGraph API
 
 00:43:03.306 --> 00:43:06.296 A:middle
 that lets you get called
@@ -3563,10 +3418,6 @@ save it up in a local structure
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.526 --> 00:44:02.376 A:middle
-and typically, you would just
-save it up in a local structure
-
 00:44:02.976 --> 00:44:06.616 A:middle
 and use it the next
 time you render a buffer
@@ -3642,9 +3493,6 @@ and synchronize to that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.846 --> 00:45:00.016 A:middle
-and synchronize to that.
-
 00:45:00.266 --> 00:45:04.976 A:middle
 We'll look at how the host can
 communicate its musical position
@@ -3716,10 +3564,6 @@ musical location information
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:55.116 --> 00:46:01.016 A:middle
-There's also some more detailed
-musical location information
 
 00:46:01.016 --> 00:46:03.816 A:middle
 supplied by the host such as
@@ -3794,10 +3638,6 @@ full of function pointers.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:57.926 --> 00:47:01.076 A:middle
-It will receive that structure
-full of function pointers.
-
 00:47:01.076 --> 00:47:02.656 A:middle
 They won't actually
 point to functions
@@ -3866,9 +3706,6 @@ on a non-render thread.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.526 --> 00:48:00.796 A:middle
-on a non-render thread.
 
 00:48:01.456 --> 00:48:05.176 A:middle
 Okay, so that's the
@@ -3947,10 +3784,6 @@ have some standard looking
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:56.666 --> 00:49:00.116 A:middle
-where our node applications
-have some standard looking
 
 00:49:00.116 --> 00:49:01.166 A:middle
 transport controls.
@@ -4037,10 +3870,6 @@ a block called the listenerBlock
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:57.006 --> 00:50:00.046 A:middle
-So, to do that, the host creates
-a block called the listenerBlock
-
 00:50:01.766 --> 00:50:06.016 A:middle
 and in that block, the host
 simply takes the incoming
@@ -4118,10 +3947,6 @@ to be giving you is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:59.066 --> 00:51:00.936 A:middle
-The first demo I'm going
-to be giving you is
 
 00:51:00.936 --> 00:51:05.616 A:middle
 of a host application connecting
@@ -4206,10 +4031,6 @@ playing the keys.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:55.466 --> 00:52:00.556 A:middle
-to the sampler by
-playing the keys.
 
 00:52:00.686 --> 00:52:01.436 A:middle
 [Music] Totally awesome.
@@ -4298,10 +4119,6 @@ message to the host.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:59.346 --> 00:53:01.816 A:middle
-so I'm sending a remote
-message to the host.
-
 00:53:02.876 --> 00:53:06.836 A:middle
 [Music] I'm going
 to stop recoding
@@ -4373,9 +4190,6 @@ It shows you all of the effects
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:59.316 --> 00:54:00.786 A:middle
-It shows you all of the effects
 
 00:54:00.786 --> 00:54:02.746 A:middle
 that are installed
@@ -4459,10 +4273,6 @@ any node AudioUnits
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:54:59.296 --> 00:55:02.096 A:middle
-the system will uninitialize
-any node AudioUnits
-
 00:55:02.096 --> 00:55:02.956 A:middle
 that you have open.
 
@@ -4534,9 +4344,6 @@ So in general, it's simplest
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:58.346 --> 00:56:00.016 A:middle
-So in general, it's simplest
 
 00:56:00.016 --> 00:56:03.026 A:middle
 to dispose your entire audio
@@ -4698,10 +4505,6 @@ to node applications.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:57:58.846 --> 00:58:01.856 A:middle
-Hosts create connections
-to node applications.
-
 00:58:03.166 --> 00:58:06.946 A:middle
 Once that connection is up, host
 and node apps can stream audio
@@ -4786,10 +4589,6 @@ you're going to make.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:58:58.156 --> 00:59:01.296 A:middle
-to the great music apps
-you're going to make.
 
 00:59:01.846 --> 00:59:05.416 A:middle
 On to some housekeeping matters

--- a/2013/603.srt
+++ b/2013/603.srt
@@ -143,10 +143,6 @@ massive breakthrough.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.766 --> 00:02:00.386 A:middle
-That was really a
-massive breakthrough.
-
 00:02:00.776 --> 00:02:04.616 A:middle
 And we thought that while doing
 this would probably gather a
@@ -219,10 +215,6 @@ you through one major change
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.996 --> 00:03:02.816 A:middle
-And so, I'd like to walk
-you through one major change
 
 00:03:02.816 --> 00:03:05.476 A:middle
 that we've made and
@@ -316,10 +308,6 @@ your resources on your page,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.336 --> 00:04:00.976 A:middle
-we'll give you information about
-your resources on your page,
 
 00:04:01.186 --> 00:04:04.446 A:middle
 the number of resources
@@ -502,10 +490,6 @@ inspection tweaking then we'll
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.516 --> 00:06:01.176 A:middle
-The first one would be
-inspection tweaking then we'll
-
 00:06:01.176 --> 00:06:03.886 A:middle
 go and take a look
 at the performance
@@ -596,10 +580,6 @@ the best experience possible
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.646 --> 00:07:01.376 A:middle
-to make sure that we had
-the best experience possible
 
 00:07:01.376 --> 00:07:04.146 A:middle
 for styles editing and we have
@@ -696,10 +676,6 @@ and we've also made it better
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.136 --> 00:08:02.406 A:middle
-you can't miss it, and what it--
-and we've also made it better
-
 00:08:02.406 --> 00:08:05.436 A:middle
 such that when you press
 that button, it will look
@@ -790,10 +766,6 @@ Inspector was actually something
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.786 --> 00:09:03.986 A:middle
-that may look great in Web
-Inspector was actually something
-
 00:09:03.986 --> 00:09:06.206 A:middle
 that came through
 looking horrible before.
@@ -878,10 +850,6 @@ very simple photo gallery.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.756 --> 00:10:00.286 A:middle
-As you can see, it's a
-very simple photo gallery.
 
 00:10:01.056 --> 00:10:03.086 A:middle
 I have pictures of
@@ -994,10 +962,6 @@ Enter and start typing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.956 --> 00:11:02.676 A:middle
-I can click anywhere, press
-Enter and start typing.
-
 00:11:03.486 --> 00:11:05.026 A:middle
 So because you want to
 just stick to the top,
@@ -1079,10 +1043,6 @@ going to fit the layout.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.866 --> 00:12:00.236 A:middle
-of this property is
-going to fit the layout.
 
 00:12:00.726 --> 00:12:02.196 A:middle
 So this is the a lot
@@ -1183,9 +1143,6 @@ You'll see this fit in directly
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.646 --> 00:13:00.896 A:middle
-You'll see this fit in directly
-
 00:13:00.986 --> 00:13:03.656 A:middle
 into that note in
 the content view.
@@ -1268,10 +1225,6 @@ a little jumpy.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.126 --> 00:14:00.806 A:middle
-But this is a little,
-a little jumpy.
 
 00:14:01.076 --> 00:14:03.216 A:middle
 So let's go back to our style
@@ -1443,10 +1396,6 @@ simply press Command S,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.846 --> 00:16:02.896 A:middle
-But now in Safari 7, I can
-simply press Command S,
-
 00:16:04.366 --> 00:16:05.776 A:middle
 save the file up to my disk.
 
@@ -1519,10 +1468,6 @@ want to tune the transition
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.576 --> 00:17:00.736 A:middle
-of demo like this when we
-want to tune the transition
 
 00:17:00.966 --> 00:17:03.676 A:middle
 and the transformer applied to
@@ -1598,10 +1543,6 @@ section, performance analysis.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:56.576 --> 00:18:00.686 A:middle
-So now let's move on to the next
-section, performance analysis.
 
 00:18:01.606 --> 00:18:04.486 A:middle
 And we're going to focus
@@ -1680,10 +1621,6 @@ that we want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.796 --> 00:19:01.356 A:middle
-and we have controls
-that we want
 
 00:19:01.356 --> 00:19:03.216 A:middle
 to customize on top
@@ -1770,10 +1707,6 @@ something else drawn on top
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.846 --> 00:20:02.516 A:middle
-in this case are video, and
-something else drawn on top
-
 00:20:02.516 --> 00:20:04.856 A:middle
 of it, that piece
 of content laid
@@ -1856,9 +1789,6 @@ as soon as you exit this room.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.686 --> 00:21:00.486 A:middle
-as soon as you exit this room.
 
 00:21:01.826 --> 00:21:03.816 A:middle
 OK, so let's go back
@@ -2041,9 +1971,6 @@ at the bottom of the panel.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.016 --> 00:23:00.106 A:middle
-at the bottom of the panel.
-
 00:23:00.106 --> 00:23:02.496 A:middle
 So you can just take
 a look at that number
@@ -2126,10 +2053,6 @@ effect without having
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.846 --> 00:24:02.376 A:middle
-So I can create interesting
-effect without having
 
 00:24:02.376 --> 00:24:03.536 A:middle
 to change the DOM structure.
@@ -2224,10 +2147,6 @@ Web Inspector to jump
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.036 --> 00:25:00.576 A:middle
-over the place in
-Web Inspector to jump
-
 00:25:00.576 --> 00:25:03.346 A:middle
 to the associated content and
 clicking on it will take you
@@ -2320,10 +2239,6 @@ that's in a layer,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.986 --> 00:26:00.936 A:middle
-out over another element
-that's in a layer,
-
 00:26:00.976 --> 00:26:02.176 A:middle
 it needs to be in its own layer.
 
@@ -2414,10 +2329,6 @@ the new screen size.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.796 --> 00:27:01.626 A:middle
-in fact adjust to
-the new screen size.
 
 00:27:02.326 --> 00:27:03.826 A:middle
 But in terms of performance,
@@ -2521,10 +2432,6 @@ hide the timeline side panel
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.956 --> 00:28:01.696 A:middle
-I'm going to go ahead and
-hide the timeline side panel
-
 00:28:01.696 --> 00:28:03.046 A:middle
 so we get a little
 bit more room here.
@@ -2612,10 +2519,6 @@ let's go ahead and focus
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.416 --> 00:29:01.326 A:middle
-on against some layout, but
-let's go ahead and focus
-
 00:29:01.326 --> 00:29:02.716 A:middle
 on what's going on with styles.
 
@@ -2701,10 +2604,6 @@ let's go ahead, and it seems
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:56.426 --> 00:30:00.336 A:middle
-So you'll notice, line 58,
-let's go ahead, and it seems
 
 00:30:00.336 --> 00:30:01.616 A:middle
 that I'm inquiring
@@ -2804,10 +2703,6 @@ of the function.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.976 --> 00:31:00.246 A:middle
-at the beginning
-of the function.
-
 00:31:00.816 --> 00:31:05.306 A:middle
 I'm going to put
 a console timeEnd
@@ -2890,10 +2785,6 @@ get that timing function
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.086 --> 00:32:01.656 A:middle
-As you'll notice, we immediately
-get that timing function
 
 00:32:01.656 --> 00:32:04.826 A:middle
 so we can see that the
@@ -2981,9 +2872,6 @@ So I'm going to just do that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.616 --> 00:33:01.966 A:middle
-So I'm going to just do that.
 
 00:33:03.826 --> 00:33:08.316 A:middle
 And by doing this,
@@ -3073,10 +2961,6 @@ some CSS transforms.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.936 --> 00:34:01.976 A:middle
-when we're doing
-some CSS transforms.
-
 00:34:02.086 --> 00:34:04.956 A:middle
 And in fact, to do all
 the layouts of the photos,
@@ -3165,10 +3049,6 @@ composited for each photos.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.986 --> 00:35:01.136 A:middle
-there are being layers
-composited for each photos.
 
 00:35:01.986 --> 00:35:03.376 A:middle
 This is sort of unexpected.
@@ -3362,10 +3242,6 @@ ahead in the Resources,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.356 --> 00:37:00.076 A:middle
-So I'm going to go
-ahead in the Resources,
-
 00:37:00.076 --> 00:37:03.406 A:middle
 Open photo.js, and here we go.
 
@@ -3445,10 +3321,6 @@ try to shuffle again
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.376 --> 00:38:00.246 A:middle
-Let's go ahead and
-try to shuffle again
 
 00:38:00.786 --> 00:38:03.156 A:middle
 and make sure that's still
@@ -3545,9 +3417,6 @@ Web Inspector is the only tool
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.746 --> 00:39:00.146 A:middle
-Web Inspector is the only tool
-
 00:39:00.146 --> 00:39:04.586 A:middle
 that let's you check
 performance-related issues
@@ -3619,10 +3488,6 @@ great improvements we've made
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.006 --> 00:40:01.436 A:middle
-And Andreas also showcased some
-great improvements we've made
 
 00:40:01.436 --> 00:40:01.956 A:middle
 to the timelines panel.
@@ -3700,10 +3565,6 @@ and console.timeEnd methods
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.966 --> 00:41:01.266 A:middle
-Andreas used a console time
-and console.timeEnd methods
 
 00:41:01.626 --> 00:41:02.696 A:middle
 to time a code segment.
@@ -3804,10 +3665,6 @@ up by taking a look
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.926 --> 00:42:00.856 A:middle
-Now let's wrap this
-up by taking a look
-
 00:42:00.856 --> 00:42:03.366 A:middle
 at debugging in Web Inspector.
 
@@ -3900,9 +3757,6 @@ So let's do just that.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.886 --> 00:43:01.346 A:middle
-So let's do just that.
 
 00:43:01.556 --> 00:43:02.626 A:middle
 Now you'll notice
@@ -3998,10 +3852,6 @@ to the element before you click
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.616 --> 00:44:01.036 A:middle
-So clearly we add eventless near
-to the element before you click
-
 00:44:01.036 --> 00:44:04.216 A:middle
 on it, and in the function
 handler, we're trying
@@ -4094,10 +3944,6 @@ about what the problem is.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.486 --> 00:45:01.176 A:middle
-So, I can't really get a sense
-about what the problem is.
 
 00:45:01.766 --> 00:45:04.016 A:middle
 So let's close this.
@@ -4198,10 +4044,6 @@ keyword refers to the element
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:57.736 --> 00:46:00.086 A:middle
-So in this case, this
-keyword refers to the element
-
 00:46:00.546 --> 00:46:03.066 A:middle
 that we clicked on, not the
 object that contains the method.
@@ -4279,10 +4121,6 @@ getting the right data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.866 --> 00:47:00.706 A:middle
-that we're either not
-getting the right data
 
 00:47:00.886 --> 00:47:02.196 A:middle
 or not running it correctly.
@@ -4364,9 +4202,6 @@ So as I start autocompleting,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.986 --> 00:48:01.386 A:middle
-So as I start autocompleting,
 
 00:48:01.706 --> 00:48:03.516 A:middle
 you'll see there's info
@@ -4459,9 +4294,6 @@ So, this is a common scenario
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.686 --> 00:49:00.946 A:middle
-So, this is a common scenario
 
 00:49:00.946 --> 00:49:02.786 A:middle
 where sometimes data might
@@ -4630,10 +4462,6 @@ that I don't want to have
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.436 --> 00:51:01.976 A:middle
-But the problem here is
-that I don't want to have
-
 00:51:01.976 --> 00:51:04.876 A:middle
 to run this debugger for
 every single comment.
@@ -4719,10 +4547,6 @@ text "Too Much Fun".
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:58.496 --> 00:52:00.986 A:middle
-So in this case we have
-text "Too Much Fun".
-
 00:52:01.446 --> 00:52:04.456 A:middle
 So let's select that.
 
@@ -4803,10 +4627,6 @@ specific that you want to find.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:59.226 --> 00:53:02.066 A:middle
-to only the problem that
-specific that you want to find.
 
 00:53:02.786 --> 00:53:06.176 A:middle
 So, using the popovers, we can
@@ -4897,10 +4717,6 @@ the way you can always track
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:56.446 --> 00:54:01.526 A:middle
-So, the debugger sidebar is
-the way you can always track
-
 00:54:01.896 --> 00:54:05.676 A:middle
 where your breakpoints are,
 what this data's recall stack is
@@ -4984,10 +4800,6 @@ look at productivity,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:57.526 --> 00:55:00.416 A:middle
-And again, taking a
-look at productivity,
 
 00:55:00.696 --> 00:55:01.766 A:middle
 there are some Command Line APIs
@@ -5080,10 +4892,6 @@ going to nightly.webkit.org
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:55:58.236 --> 00:56:00.876 A:middle
-with Web Inspector by
-going to nightly.webkit.org
 
 00:56:00.876 --> 00:56:02.986 A:middle
 and you can download the

--- a/2013/604.srt
+++ b/2013/604.srt
@@ -257,10 +257,6 @@ we will not charge you more
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.226 --> 00:04:03.426 A:middle
-So you can bid your CPC and
-we will not charge you more
-
 00:04:03.426 --> 00:04:07.256 A:middle
 than that, or if you know
 roughly what you would pay
@@ -331,10 +327,6 @@ Apple design beautiful templates
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:55.076 --> 00:05:00.526 A:middle
-Or you can use many of the
-Apple design beautiful templates
 
 00:05:00.796 --> 00:05:02.326 A:middle
 for your ads.
@@ -428,9 +420,6 @@ which app you want to promote.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.816 --> 00:06:01.356 A:middle
-which app you want to promote.
-
 00:06:01.926 --> 00:06:02.916 A:middle
 All of your Apps are here.
 
@@ -516,10 +505,6 @@ your campaign to run,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.426 --> 00:07:01.116 A:middle
-Basically, when your want
-your campaign to run,
 
 00:07:01.586 --> 00:07:04.126 A:middle
 you can time your campaign to
@@ -613,9 +598,6 @@ and 50 cents as a CPA goal.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.146 --> 00:08:00.596 A:middle
-and 50 cents as a CPA goal.
 
 00:08:01.436 --> 00:08:02.626 A:middle
 You can hit this
@@ -778,10 +760,6 @@ this is your final review,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.766 --> 00:10:00.986 A:middle
-Within the Campaign Summary,
-this is your final review,
 
 00:10:01.196 --> 00:10:01.956 A:middle
 make sure everything is OK.
@@ -1032,10 +1010,6 @@ for advertising.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.656 --> 00:13:01.036 A:middle
-These are basic options
-for advertising.
-
 00:13:01.366 --> 00:13:03.586 A:middle
 On the right hand
 side, you can--
@@ -1107,10 +1081,6 @@ games, you can do that here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.096 --> 00:14:02.056 A:middle
-and shown preference for
-games, you can do that here.
 
 00:14:02.936 --> 00:14:07.216 A:middle
 Or let's say your game
@@ -1188,10 +1158,6 @@ a productivity app
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:59.546 --> 00:15:02.076 A:middle
-For Clara, which is
-a productivity app
 
 00:15:02.076 --> 00:15:04.726 A:middle
 and fairly broad
@@ -1350,10 +1316,6 @@ of the campaign, sorry.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.756 --> 00:17:02.266 A:middle
-campaign-- for the duration
-of the campaign, sorry.
-
 00:17:02.756 --> 00:17:07.016 A:middle
 And now we're answering
 the question what price?
@@ -1423,10 +1385,6 @@ you've chosen, the duration
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.636 --> 00:18:01.316 A:middle
-So the targeting that
-you've chosen, the duration
 
 00:18:01.316 --> 00:18:03.366 A:middle
 that you've chosen, the
@@ -1503,10 +1461,6 @@ access to creative agencies
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:56.356 --> 00:19:01.326 A:middle
-But many of you might not have
-access to creative agencies
 
 00:19:01.586 --> 00:19:03.666 A:middle
 and may not want to spend
@@ -1585,10 +1539,6 @@ appears on the devices.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.766 --> 00:20:00.976 A:middle
-you can see how your ad
-appears on the devices.
-
 00:20:01.046 --> 00:20:01.836 A:middle
 Pretty powerful.
 
@@ -1664,10 +1614,6 @@ Dashboard and drill downs.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:56.816 --> 00:21:00.506 A:middle
-So we provide you a
-Dashboard and drill downs.
 
 00:21:01.016 --> 00:21:05.366 A:middle
 Dashboard gives you, on the
@@ -1752,10 +1698,6 @@ managing performance.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.516 --> 00:22:01.906 A:middle
-and give us a demo of
-managing performance.
 
 00:22:02.306 --> 00:22:02.776 A:middle
 Vineet?
@@ -1859,10 +1801,6 @@ you can quickly drill in.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.076 --> 00:23:01.616 A:middle
-So from the Dashboard,
-you can quickly drill in.
-
 00:23:02.226 --> 00:23:04.376 A:middle
 Let's take a look at
 this campaign and see
@@ -1948,10 +1886,6 @@ with your campaign.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.736 --> 00:24:01.366 A:middle
-that you have associated
-with your campaign.
 
 00:24:02.036 --> 00:24:03.336 A:middle
 We have multiple banners
@@ -2048,10 +1982,6 @@ the numbers for your campaign,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.466 --> 00:25:00.186 A:middle
-Up at the top, you actually see
-the numbers for your campaign,
 
 00:25:00.316 --> 00:25:01.716 A:middle
 the full lifetime
@@ -2229,10 +2159,6 @@ remember what Marigold Promo
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:57.596 --> 00:27:00.066 A:middle
-You could-- If you don't
-remember what Marigold Promo
-
 00:27:00.066 --> 00:27:02.476 A:middle
 [phonetic] actually relates
 to, you can click on I icon
@@ -2324,10 +2250,6 @@ taking it away from the spend
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.726 --> 00:28:01.446 A:middle
-to these two lines perhaps
-taking it away from the spend
-
 00:28:01.446 --> 00:28:03.546 A:middle
 from some of the lines that
 are not performing as well.
@@ -2411,10 +2333,6 @@ iTunes connect mobile
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.076 --> 00:29:00.866 A:middle
-Many of you perhaps use
-iTunes connect mobile
 
 00:29:00.866 --> 00:29:03.826 A:middle
 for managing your apps on
@@ -2576,10 +2494,6 @@ see some basic information
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.416 --> 00:31:01.906 A:middle
-At the top you will see-- again,
-see some basic information
-
 00:31:02.326 --> 00:31:05.996 A:middle
 about this campaign, the name,
 the flight dates, the status.
@@ -2730,10 +2644,6 @@ spend in relation to the budget,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:57.936 --> 00:33:00.596 A:middle
-You will be able to see the
-spend in relation to the budget,
-
 00:33:01.056 --> 00:33:03.926 A:middle
 the average CPC,
 CPA and downloads.
@@ -2819,10 +2729,6 @@ want to continue.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.746 --> 00:34:00.336 A:middle
-It'll ask us if we
-want to continue.
 
 00:34:00.536 --> 00:34:02.926 A:middle
 Yes. And now the
@@ -2912,10 +2818,6 @@ may not be sufficient
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.836 --> 00:35:01.996 A:middle
-It's saying a bid amount
-may not be sufficient
-
 00:35:02.056 --> 00:35:03.486 A:middle
 to reach our campaign goal.
 
@@ -3002,10 +2904,6 @@ all the values and you want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.226 --> 00:36:02.236 A:middle
-When you're satisfied with
-all the values and you want
-
 00:36:02.346 --> 00:36:05.246 A:middle
 to save it, just
 touch the Done button
@@ -3075,10 +2973,6 @@ have Mark Malone, the wonderful,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.436 --> 00:37:02.326 A:middle
-And for more information you
-have Mark Malone, the wonderful,
 
 00:37:02.816 --> 00:37:04.546 A:middle
 for any questions

--- a/2013/605.srt
+++ b/2013/605.srt
@@ -111,10 +111,6 @@ you to create books
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.746 --> 00:01:00.796 A:start
-with that will enable
-you to create books
-
 00:01:00.796 --> 00:01:02.196 A:start
 in a very efficient manner.
 
@@ -205,10 +201,6 @@ this point, of 22,000 titles
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.436 --> 00:02:01.746 A:start
-We have an excess, I think at
-this point, of 22,000 titles
 
 00:02:02.206 --> 00:02:04.596 A:start
 on the bookstore today,
@@ -306,10 +298,6 @@ of a title, but whatever.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.586 --> 00:03:04.046 A:start
-it's-that's a bald face lie
-of a title, but whatever.
-
 00:03:04.396 --> 00:03:07.976 A:start
 Core-- Core Class Life
 Science, our course E.
@@ -393,10 +381,6 @@ view point of the band.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.556 --> 00:04:01.976 A:start
-behind the scenes kind of
-view point of the band.
-
 00:04:02.656 --> 00:04:06.206 A:start
 Linda McCartney's photographic,
 just published by Taschen,
@@ -479,10 +463,6 @@ the message out on the iPad,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:57.716 --> 00:05:03.266 A:start
-And now, you're not just getting
-the message out on the iPad,
 
 00:05:03.406 --> 00:05:05.286 A:start
 you're also getting
@@ -577,10 +557,6 @@ are all searchable.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.186 --> 00:06:01.196 A:start
-Obviously the books
-are all searchable.
-
 00:06:01.796 --> 00:06:04.836 A:start
 I can sort them in
 different ways,
@@ -663,10 +639,6 @@ out evidence that you built
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.956 --> 00:07:03.726 A:start
-and it's a good place to call
-out evidence that you built
 
 00:07:03.726 --> 00:07:07.036 A:start
 for one platform and you get
@@ -763,10 +735,6 @@ edge experience--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.766 --> 00:08:00.436 A:start
-So it's an edge to
-edge experience--
-
 00:08:00.436 --> 00:08:02.016 A:start
 to full bleed experience
 for media.
@@ -854,10 +822,6 @@ Mars over the years.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.086 --> 00:09:00.256 A:start
-that have spotted
-Mars over the years.
-
 00:09:01.016 --> 00:09:04.046 A:start
 Next, I want to show
 you an example
@@ -941,10 +905,6 @@ and impactful and no reason--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:56.156 --> 00:10:00.316 A:start
-It's really quite beautiful
-and impactful and no reason--
 
 00:10:01.406 --> 00:10:02.626 A:start
 well, they have every reason,
@@ -1046,10 +1006,6 @@ it's brought full-screen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.886 --> 00:11:02.066 A:start
-You can click on an image,
-it's brought full-screen.
-
 00:11:02.066 --> 00:11:03.856 A:start
 You can examine it
 in full glory.
@@ -1141,9 +1097,6 @@ I'm going to close this guy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.426 --> 00:12:00.916 A:start
-I'm going to close this guy.
-
 00:12:01.136 --> 00:12:03.916 A:start
 Now I'm going to show Richard
 Feynman's Six Easy Pieces,
@@ -1225,10 +1178,6 @@ for all audio links.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.526 --> 00:13:02.586 A:start
-But that's not appropriate
-for all audio links.
 
 00:13:02.906 --> 00:13:05.826 A:start
 Here, we have another
@@ -1317,10 +1266,6 @@ and click on a location
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:57.886 --> 00:14:02.856 A:start
-So I can expand in chapter
-and click on a location
 
 00:14:03.316 --> 00:14:05.316 A:start
 and I'm brought to that
@@ -1498,10 +1443,6 @@ which is awesome.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.676 --> 00:16:01.756 A:start
-I get Two Up mode
-which is awesome.
-
 00:16:02.026 --> 00:16:05.976 A:start
 And then, of course, if you want
 it all, you can have Two Up,
@@ -1658,10 +1599,6 @@ of iBooks for the Mac
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.466 --> 00:18:05.456 A:start
-So that's it for our tour
-of iBooks for the Mac
-
 00:18:05.456 --> 00:18:07.156 A:start
 and to switch back to my slides.
 
@@ -1737,10 +1674,6 @@ and drop techniques.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.046 --> 00:19:00.356 A:start
-just using basic drag
-and drop techniques.
 
 00:19:00.426 --> 00:19:02.826 A:start
 It works for single publishers.
@@ -1835,10 +1768,6 @@ using HTML widget and HTML5.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.726 --> 00:20:00.456 A:start
-when you need to, just
-using HTML widget and HTML5.
-
 00:20:00.766 --> 00:20:03.976 A:start
 As I mentioned, it's designed
 to work perfectly on the iPad.
@@ -1930,10 +1859,6 @@ books, you can layout something
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.896 --> 00:21:01.286 A:start
-But now, portrait-fixed layout
-books, you can layout something
 
 00:21:01.286 --> 00:21:02.796 A:start
 that fills a lot
@@ -2029,10 +1954,6 @@ that you're looking for.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.556 --> 00:22:00.526 A:start
-that crisp, custom look
-that you're looking for.
-
 00:22:01.076 --> 00:22:03.976 A:start
 All right.
 
@@ -2118,10 +2039,6 @@ process when you need to.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.586 --> 00:23:01.146 A:start
-of changes late in the editorial
-process when you need to.
-
 00:23:01.566 --> 00:23:06.316 A:start
 It will help support multiuser
 or collaboration workflows
@@ -2205,10 +2122,6 @@ at the UI of iBooks Author.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.966 --> 00:24:02.846 A:start
-But first, let's take a look
-at the UI of iBooks Author.
 
 00:24:03.646 --> 00:24:07.896 A:start
 So if any of you are users of
@@ -2308,9 +2221,6 @@ a section contains pages.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.906 --> 00:25:00.786 A:start
-a section contains pages.
-
 00:25:00.826 --> 00:25:04.056 A:start
 So here's the chapter,
 it's top to your item,
@@ -2395,10 +2305,6 @@ in the developer website.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.076 --> 00:26:01.566 A:start
-that's available online
-in the developer website.
 
 00:26:01.566 --> 00:26:04.066 A:start
 Next up, we have a
@@ -2492,10 +2398,6 @@ nodes contained within it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.746 --> 00:27:01.756 A:start
-it's got some special
-nodes contained within it,
-
 00:27:01.996 --> 00:27:04.016 A:start
 the top most node is our cover.
 
@@ -2567,10 +2469,6 @@ of this very same page.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.166 --> 00:28:00.006 A:start
-So this is an example
-of this very same page.
 
 00:28:00.916 --> 00:28:03.956 A:start
 It's similar and that is
@@ -2652,10 +2550,6 @@ that's being utilized
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:59.556 --> 00:29:02.206 A:start
-that this is the layout
-that's being utilized
 
 00:29:02.266 --> 00:29:04.346 A:start
 for this very page right now.
@@ -2748,10 +2642,6 @@ image it tells me a few
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.156 --> 00:30:02.096 A:start
-When I select this background
-image it tells me a few
-
 00:30:02.096 --> 00:30:03.696 A:start
 different things about
 what it set up to do.
@@ -2825,10 +2715,6 @@ how do iBooks Author know
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.786 --> 00:31:02.336 A:start
-So you might be asking yourself,
-how do iBooks Author know
 
 00:31:02.336 --> 00:31:04.186 A:start
 to make that the
@@ -2916,10 +2802,6 @@ selecting section title
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.346 --> 00:32:00.546 A:start
-to the insert panel and
-selecting section title
 
 00:32:01.686 --> 00:32:03.266 A:start
 and you're often
@@ -3065,10 +2947,6 @@ the wrong thing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:56.946 --> 00:34:00.446 A:start
-And now we have edited
-the wrong thing.
-
 00:34:00.926 --> 00:34:01.336 A:start
 That's OK.
 
@@ -3135,10 +3013,6 @@ working with the templates
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.526 --> 00:35:02.666 A:start
-And one of the benefits of
-working with the templates
 
 00:35:02.666 --> 00:35:05.546 A:start
 that we've provided
@@ -3232,9 +3106,6 @@ We will need this thing.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.996 --> 00:36:00.336 A:start
-We will need this thing.
 
 00:36:00.886 --> 00:36:04.186 A:start
 And we're going to need another
@@ -3386,9 +3257,6 @@ add our new section layout.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.296 --> 00:38:02.396 A:start
-add our new section layout.
 
 00:38:02.396 --> 00:38:04.066 A:start
 Actually, I'm not
@@ -3547,10 +3415,6 @@ the components of my book.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:57.206 --> 00:40:00.506 A:start
-field, I'm actually identifying
-the components of my book.
-
 00:40:00.506 --> 00:40:03.026 A:start
 So now if we switch back to
 our table of contents view,
@@ -3630,10 +3494,6 @@ delete this background
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.226 --> 00:41:01.596 A:start
-So if I'm going to
-delete this background
 
 00:41:01.596 --> 00:41:04.346 A:start
 and then restyle my text and
@@ -3719,10 +3579,6 @@ paragraph styles drawer
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.716 --> 00:42:00.936 A:start
-You can click to view the
-paragraph styles drawer
-
 00:42:02.066 --> 00:42:03.486 A:start
 and here you can
 see them all here.
@@ -3796,10 +3652,6 @@ new style and that's great.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:55.936 --> 00:43:03.046 A:start
-that style to we've got the
-new style and that's great.
 
 00:43:03.076 --> 00:43:03.646 A:start
 All right.
@@ -3886,9 +3738,6 @@ You can also just check this box
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:57.496 --> 00:44:00.626 A:start
-You can also just check this box
-
 00:44:00.626 --> 00:44:02.746 A:start
 which is make zoomable
 in iBooks.
@@ -3949,10 +3798,6 @@ like 2 [inaudible] 3.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:53.506 --> 00:45:01.656 A:start
-the equation is something
-like 2 [inaudible] 3.
 
 00:45:04.156 --> 00:45:04.526 A:start
 There you go.
@@ -4034,10 +3879,6 @@ drag in some text, boom;
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:53.976 --> 00:46:00.386 A:start
-So this is very simple, just
-drag in some text, boom;
 
 00:46:01.046 --> 00:46:05.396 A:start
 drag in an image, double boom.
@@ -4176,10 +4017,6 @@ the sidebar to do that?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:57.226 --> 00:48:00.786 A:start
-Did I switch over to
-the sidebar to do that?
-
 00:48:00.786 --> 00:48:01.536 A:start
 [Inaudible Response]
 
@@ -4281,9 +4118,6 @@ That's exciting enough for me.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:56.606 --> 00:49:00.606 A:start
-That's exciting enough for me.
 
 00:49:01.376 --> 00:49:03.346 A:start
 I can choose looping
@@ -4431,9 +4265,6 @@ You know, that's all it takes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.676 --> 00:51:01.426 A:start
-You know, that's all it takes
-
 00:51:01.556 --> 00:51:03.216 A:start
 to make the experience
 truly engaging.
@@ -4518,9 +4349,6 @@ So I'm going to leave it there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:58.136 --> 00:52:01.206 A:start
-So I'm going to leave it there.
 
 00:52:01.656 --> 00:52:07.586 A:start
 3D content, we support 3D that
@@ -4660,10 +4488,6 @@ default view to that view.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:57.886 --> 00:54:04.986 A:start
-So we can go from our
-default view to that view.
-
 00:54:09.976 --> 00:54:12.016 A:start
 So we've got a nice
 interpolation.
@@ -4718,10 +4542,6 @@ that one, I want Sojourner.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:57.006 --> 00:55:03.156 A:start
-Actually, I don't want
-that one, I want Sojourner.
 
 00:55:03.226 --> 00:55:05.256 A:start
 I drag over the image that
@@ -4877,10 +4697,6 @@ mode within iBooks for Mac.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:59.396 --> 00:57:03.226 A:start
-that I can't see portrait flow
-mode within iBooks for Mac.
 
 00:57:03.976 --> 00:57:12.346 A:start
 But once it builds its
@@ -5107,10 +4923,6 @@ iTunes producer to finalize
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:59:59.016 --> 01:00:01.336 A:start
-I'm now ready to go to
-iTunes producer to finalize
 
 01:00:01.406 --> 01:00:06.406 A:start
 and ship this to the

--- a/2013/606.srt
+++ b/2013/606.srt
@@ -69,10 +69,6 @@ history about QuickTime.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.456 --> 00:01:01.846 A:middle
-Let's give a bit of
-history about QuickTime.
-
 00:01:03.106 --> 00:01:06.106 A:middle
 QuickTime was a pioneering
 framework
@@ -210,10 +206,6 @@ introducing AV Kit.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:58.246 --> 00:03:00.236 A:middle
-We introduced-- we're
-introducing AV Kit.
-
 00:03:00.666 --> 00:03:03.316 A:middle
 AV Kit is the framework
 where we will put APIs
@@ -292,9 +284,6 @@ While were on the topic,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:57.876 --> 00:04:02.506 A:middle
-While were on the topic,
-
 00:04:03.726 --> 00:04:07.766 A:middle
 the QuickTime Movie file format
 is still the primary file format
@@ -362,10 +351,6 @@ kinds of modern foundations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.456 --> 00:05:02.356 A:middle
-So we built it on the same
-kinds of modern foundations
 
 00:05:02.356 --> 00:05:06.076 A:middle
 that the rest of Apple has been
@@ -437,10 +422,6 @@ are monolithic and in some
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:55.646 --> 00:06:01.506 A:middle
-And so QuickTime's APIs
-are monolithic and in some
 
 00:06:01.506 --> 00:06:04.466 A:middle
 of these cases we have taken the
@@ -527,10 +508,6 @@ ways that QuickTime could not
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.416 --> 00:07:01.776 A:middle
-of hardware acceleration in
-ways that QuickTime could not
-
 00:07:02.436 --> 00:07:03.696 A:middle
 such as video encoding.
 
@@ -615,9 +592,6 @@ So do you get the message here?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.616 --> 00:08:01.576 A:middle
-So do you get the message here?
-
 00:08:02.056 --> 00:08:04.586 A:middle
 There are lots of great
 reasons why AV Foundation is the
@@ -691,9 +665,6 @@ So QuickTime has a vast history.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.016 --> 00:09:00.886 A:middle
-So QuickTime has a vast history.
 
 00:09:00.886 --> 00:09:03.596 A:middle
 It has collected many, many
@@ -775,10 +746,6 @@ as video decoders.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.556 --> 00:10:01.296 A:middle
-to be registered
-as video decoders.
-
 00:10:01.916 --> 00:10:04.026 A:middle
 Well nowadays, we have
 the image IO Framework
@@ -851,10 +818,6 @@ a new API in Mavericks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.076 --> 00:11:01.306 A:middle
-And it's provided as
-a new API in Mavericks
 
 00:11:01.616 --> 00:11:02.966 A:middle
 so you can do the
@@ -936,10 +899,6 @@ are deprecated
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.976 --> 00:12:01.896 A:middle
-QuickTime and QTKit
-are deprecated
-
 00:12:01.896 --> 00:12:05.876 A:middle
 and we have been building a new
 media framework brick-by-brick,
@@ -1010,9 +969,6 @@ on top of AVPlayer layer?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.876 --> 00:13:01.526 A:middle
-on top of AVPlayer layer?
 
 00:13:01.836 --> 00:13:03.916 A:middle
 OK, a few.
@@ -1089,10 +1045,6 @@ of localization, accessibility,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:55.876 --> 00:14:02.196 A:middle
-And as a bonus, it takes care of
-of localization, accessibility,
-
 00:14:02.196 --> 00:14:04.756 A:middle
 high resolutions, state
 restoration and so on.
@@ -1160,9 +1112,6 @@ And then in the New sheet,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.956 --> 00:15:02.046 A:middle
-And then in the New sheet,
-
 00:15:02.046 --> 00:15:04.276 A:middle
 we set first search
 for AV Foundation.
@@ -1217,10 +1166,6 @@ and then on the right,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.216 --> 00:16:00.726 A:middle
-We remove the label
-and then on the right,
 
 00:16:00.726 --> 00:16:02.836 A:middle
 we search for AVPlayerView.
@@ -1296,10 +1241,6 @@ to our project.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.306 --> 00:17:00.206 A:middle
-AV Kit frameworks
-to our project.
 
 00:17:00.776 --> 00:17:04.616 A:middle
 Third, we'd set a-- sorry,
@@ -1377,9 +1318,6 @@ Go to File, Open.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.823 --> 00:18:03.796 A:middle
-Go to File, Open.
-
 00:18:09.296 --> 00:18:11.476 A:middle
 Select the movie, press Open.
 
@@ -1443,9 +1381,6 @@ Wasn't that easy?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:57.576 --> 00:19:00.476 A:middle
-Wasn't that easy?
 
 00:19:00.626 --> 00:19:03.046 A:middle
 So let's go one step further.
@@ -1518,10 +1453,6 @@ we implement for trim--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:57.546 --> 00:20:03.006 A:middle
-for the trim IBAction,
-we implement for trim--
 
 00:20:03.006 --> 00:20:04.506 A:middle
 playerView canBeginTrimming.
@@ -1602,10 +1533,6 @@ a few details now.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.463 --> 00:21:04.986 A:middle
-So let's talk about
-a few details now.
-
 00:21:05.666 --> 00:21:08.646 A:middle
 So how does AVPlayerView work
 
@@ -1665,10 +1592,6 @@ want to play the content
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:57.936 --> 00:22:00.396 A:middle
-However, if you really just
-want to play the content
 
 00:22:00.396 --> 00:22:02.886 A:middle
 of the movie file on disc, you
@@ -1823,10 +1746,6 @@ controlsStyle and the screenshot
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.686 --> 00:24:01.696 A:middle
-for the floating
-controlsStyle and the screenshot
-
 00:24:01.696 --> 00:24:03.546 A:middle
 on the right shows the TrimUI
 
@@ -1906,10 +1825,6 @@ to the UI takes care
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.626 --> 00:25:01.236 A:middle
-the OS X Share Button
-to the UI takes care
-
 00:25:01.236 --> 00:25:03.336 A:middle
 of everything for you.
 
@@ -1985,10 +1900,6 @@ has just one argument
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:55.906 --> 00:26:00.046 A:middle
-The CompletionHandler
-has just one argument
 
 00:26:00.046 --> 00:26:01.076 A:middle
 of type AVPlayerViewTrimResult.
@@ -2074,10 +1985,6 @@ your responsibility
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.326 --> 00:27:01.206 A:middle
-This means it is
-your responsibility
-
 00:27:01.206 --> 00:27:04.036 A:middle
 to restore the content when your
 users relaunch the applications.
@@ -2147,10 +2054,6 @@ playback and trim controls
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.226 --> 00:28:00.606 A:middle
-sorry, it provides you standard
-playback and trim controls
 
 00:28:00.606 --> 00:28:02.036 A:middle
 through the AVPlayerView.
@@ -2313,10 +2216,6 @@ version and some of the things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:57.886 --> 00:30:00.736 A:middle
-on the AV Foundations
-version and some of the things
-
 00:30:00.736 --> 00:30:01.566 A:middle
 that make that interesting.
 
@@ -2383,10 +2282,6 @@ unload the file and parse it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.566 --> 00:31:02.296 A:middle
-QuickTime and QTKit go off and
-unload the file and parse it.
 
 00:31:03.216 --> 00:31:05.506 A:middle
 With AV Foundation,
@@ -2455,10 +2350,6 @@ we have separated
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.516 --> 00:32:01.846 A:middle
-With AV Foundation,
-we have separated
 
 00:32:01.846 --> 00:32:05.786 A:middle
 out the mutable state related to
@@ -2607,10 +2498,6 @@ if you used a QTMovieView is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.636 --> 00:34:02.096 A:middle
-One thing that's different
-if you used a QTMovieView is
-
 00:34:02.336 --> 00:34:05.876 A:middle
 that the transport control
 methods are not re-exported
@@ -2677,10 +2564,6 @@ after Mavericks by default,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.065 --> 00:35:02.626 A:middle
-or after iOS 7 or on or
-after Mavericks by default,
-
 00:35:02.626 --> 00:35:08.146 A:middle
 AVPlayerLayer and AVPlayerView
 will both honor the user's
@@ -2741,10 +2624,6 @@ an asynchronous
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:54.466 --> 00:36:01.336 A:middle
-in OS 10.7 we introduced
-an asynchronous
 
 00:36:01.586 --> 00:36:03.026 A:middle
 QTExportSession API.
@@ -2821,10 +2700,6 @@ AVAssetReader output
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.126 --> 00:37:01.186 A:middle
-When you create the
-AVAssetReader output
-
 00:37:01.516 --> 00:37:03.726 A:middle
 to decode data-- to
 retrieve data from a track,
@@ -2898,10 +2773,6 @@ working on the previous frame.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.676 --> 00:38:02.936 A:middle
-in the background while you were
-working on the previous frame.
 
 00:38:05.616 --> 00:38:09.586 A:middle
 The QuickTime APIs for writing
@@ -2980,9 +2851,6 @@ in Mavericks and new in iOS 7.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.656 --> 00:39:06.066 A:middle
-in Mavericks and new in iOS 7.
-
 00:39:06.166 --> 00:39:09.336 A:middle
 Also in the session tomorrow on
 preparing and presenting media
@@ -3049,10 +2917,6 @@ tracks, writing a portion
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.956 --> 00:40:01.296 A:middle
-between the different
-tracks, writing a portion
 
 00:40:01.296 --> 00:40:05.096 A:middle
 of media data from each in turn.
@@ -3126,10 +2990,6 @@ video frames during playback,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.236 --> 00:41:02.756 A:middle
-If you wanted to get access to
-video frames during playback,
-
 00:41:03.096 --> 00:41:07.056 A:middle
 for example, to integrate them
 into a custom OpenGL rendering,
@@ -3199,10 +3059,6 @@ AVAssetReaderAudioMixOutput.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:55.776 --> 00:42:00.196 A:middle
-or onto an
-AVAssetReaderAudioMixOutput.
-
 00:42:01.086 --> 00:42:08.246 A:middle
 (It's like Dr. Seuss.)
 
@@ -3264,9 +3120,6 @@ So it can't be there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.706 --> 00:43:00.876 A:middle
-So it can't be there.
 
 00:43:00.876 --> 00:43:03.996 A:middle
 Instead, we have subclass of
@@ -3337,10 +3190,6 @@ movie's edit list can only refer
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.526 --> 00:44:04.916 A:middle
-This is because in this API, a
-movie's edit list can only refer
-
 00:44:04.916 --> 00:44:06.836 A:middle
 to that own movie's
 sample tables.
@@ -3409,10 +3258,6 @@ API is very similar.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.516 --> 00:45:03.556 A:middle
-AV Foundation's AVMetadataItem
-API is very similar.
-
 00:45:04.086 --> 00:45:05.446 A:middle
 In fact, if you look up there,
 
@@ -3478,10 +3323,6 @@ capture APIs are also broadly
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:49.723 --> 00:46:00.006 A:middle
-The QTKit and AV Foundation
-capture APIs are also broadly
 
 00:46:00.006 --> 00:46:00.606 A:middle
 very similar.
@@ -3558,10 +3399,6 @@ you have multiple video inputs,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.216 --> 00:47:02.346 A:middle
-And this is a better choice if
-you have multiple video inputs,
-
 00:47:02.346 --> 00:47:05.786 A:middle
 multiple cameras, or if
 you have multiple previews,
@@ -3633,10 +3470,6 @@ output object, we've folded all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.016 --> 00:48:02.976 A:middle
-we don't have the video preview
-output object, we've folded all
 
 00:48:02.976 --> 00:48:05.906 A:middle
 of those configuration APIs
@@ -3711,10 +3544,6 @@ get all devices, there's an API
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:58.236 --> 00:49:01.496 A:middle
-In both cases, there's an API to
-get all devices, there's an API
-
 00:49:01.496 --> 00:49:03.446 A:middle
 to get all the devices
 with particular media type.
@@ -3787,10 +3616,6 @@ other core animation layer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:58.486 --> 00:50:01.076 A:middle
-like you would with any
-other core animation layer.
 
 00:50:02.806 --> 00:50:04.906 A:middle
 So we've gone through a
@@ -3865,9 +3690,6 @@ But, in the very early 1990s,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:59.176 --> 00:51:01.466 A:middle
-But, in the very early 1990s,
 
 00:51:02.436 --> 00:51:05.016 A:middle
 doing 64-bit math
@@ -4041,10 +3863,6 @@ and that was great
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:59.436 --> 00:53:01.426 A:middle
-from movie files
-and that was great
-
 00:53:01.426 --> 00:53:03.536 A:middle
 when everything was big-endian
 and the file is big-endian,
@@ -4129,10 +3947,6 @@ Compression Manager APIs
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:57.666 --> 00:54:00.696 A:middle
-like the enhanced Image
-Compression Manager APIs
-
 00:54:00.696 --> 00:54:02.906 A:middle
 that were introduced
 in QuickTime 7,
@@ -4209,10 +4023,6 @@ the QuickTime C framework
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.796 --> 00:55:06.366 A:middle
-In summary, we are deprecating
-the QuickTime C framework
 
 00:55:06.366 --> 00:55:10.246 A:middle
 and the QTKit Objective-C
@@ -4342,10 +4152,6 @@ can send email to John Geleynse,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:58.326 --> 00:57:03.176 A:middle
-reporting mechanism, and you
-can send email to John Geleynse,
 
 00:57:03.176 --> 00:57:05.496 A:middle
 Apple's Director of

--- a/2013/607.srt
+++ b/2013/607.srt
@@ -158,10 +158,6 @@ that we've seen pages make
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:57.986 --> 00:02:01.216 A:middle
-and also some common mistakes
-that we've seen pages make
-
 00:02:01.456 --> 00:02:03.886 A:middle
 that cause them to use too much
 power than the author intended.
@@ -243,9 +239,6 @@ Well you may already know
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.536 --> 00:03:00.016 A:middle
-Well you may already know
 
 00:03:00.016 --> 00:03:03.056 A:middle
 that in Safari we actually use
@@ -520,10 +513,6 @@ much better way of keeping track
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.116 --> 00:06:00.956 A:middle
-Reading Lists because that's a
-much better way of keeping track
-
 00:06:00.956 --> 00:06:01.846 A:middle
 of all of those URL's.
 
@@ -619,10 +608,6 @@ energy saving.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.776 --> 00:07:00.296 A:middle
-so it's really great
-energy saving.
-
 00:07:00.836 --> 00:07:05.336 A:middle
 So you know why do
 we need this thing?
@@ -708,10 +693,6 @@ a page in order to see
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.216 --> 00:08:01.086 A:middle
-First of all when you visit
-a page in order to see
 
 00:08:01.086 --> 00:08:02.596 A:middle
 like an internet
@@ -801,10 +782,6 @@ we'll run as normal.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.796 --> 00:09:00.166 A:middle
-and then the plugin
-we'll run as normal.
 
 00:09:00.166 --> 00:09:02.346 A:middle
 And in many cases the
@@ -974,10 +951,6 @@ pages are using more power
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.736 --> 00:11:00.676 A:middle
-to detect whether your
-pages are using more power
-
 00:11:00.676 --> 00:11:01.346 A:middle
 than they should.
 
@@ -1139,10 +1112,6 @@ are pretty obvious
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.776 --> 00:13:00.176 A:middle
-Now hidden and visible
-are pretty obvious
 
 00:13:00.176 --> 00:13:02.066 A:middle
 but let me explain
@@ -1396,10 +1365,6 @@ Timing Spec.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.666 --> 00:16:04.186 A:middle
-in the W3C Animation
-Timing Spec.
-
 00:16:04.476 --> 00:16:07.106 A:middle
 So before requestAnimationFrame
 you probably had an animation
@@ -1494,10 +1459,6 @@ you may be familiar
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:56.016 --> 00:17:00.896 A:middle
-So requestAnimationFrame
-you may be familiar
-
 00:17:00.896 --> 00:17:02.536 A:middle
 with as WebKit
 requestAnimationFrame
@@ -1582,9 +1543,6 @@ when the user switches bases
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.856 --> 00:18:00.196 A:middle
-when the user switches bases
-
 00:18:00.196 --> 00:18:02.536 A:middle
 and the Safari window
 ends up being now visible.
@@ -1664,10 +1622,6 @@ don't know, or may not know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.376 --> 00:19:03.336 A:middle
-[laughter] So what you
-don't know, or may not know,
 
 00:19:03.336 --> 00:19:06.336 A:middle
 is that she also has a giant
@@ -1828,10 +1782,6 @@ was hidden the graph kind
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.056 --> 00:21:02.136 A:middle
-You'll also notice while it
-was hidden the graph kind
-
 00:21:02.136 --> 00:21:03.016 A:middle
 of looks broken.
 
@@ -1910,9 +1860,6 @@ Back to you, Simon.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.061 --> 00:22:01.061 A:middle
-[Applause]
 
 00:22:01.106 --> 00:22:01.546 A:middle
 &gt;&gt; Simon Fraser: Thank you, Tim.
@@ -2000,10 +1947,6 @@ closer to your web content.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.976 --> 00:23:02.256 A:middle
-in the tools that are
-closer to your web content.
 
 00:23:02.906 --> 00:23:04.896 A:middle
 There were a couple of
@@ -2100,10 +2043,6 @@ not usually the case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.436 --> 00:24:00.976 A:middle
-but that's actually
-not usually the case.
-
 00:24:01.696 --> 00:24:05.206 A:middle
 Usually the most common
 cause of badly behaving pages
@@ -2193,10 +2132,6 @@ us to eagerly do layout.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.856 --> 00:25:00.476 A:middle
-to JavaScript that force
-us to eagerly do layout.
 
 00:25:01.156 --> 00:25:02.676 A:middle
 And there's quite
@@ -2291,10 +2226,6 @@ the loop you're probably fine.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.326 --> 00:26:01.456 A:middle
-Now the first line through
-the loop you're probably fine.
-
 00:26:02.166 --> 00:26:05.356 A:middle
 But then later on in the loop
 it's common for the JavaScript
@@ -2381,10 +2312,6 @@ be able to stop painting it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.676 --> 00:27:00.856 A:middle
-up the browser is going to
-be able to stop painting it.
 
 00:27:01.456 --> 00:27:02.866 A:middle
 Well in many cases we can.
@@ -2479,10 +2406,6 @@ CSS transitions
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.286 --> 00:28:01.126 A:middle
-If you're doing animation,
-CSS transitions
 
 00:28:01.126 --> 00:28:02.196 A:middle
 and animations are always going
@@ -2584,10 +2507,6 @@ to talk about Safari Extensions.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.886 --> 00:29:08.076 A:middle
-So I would like to take a moment
-to talk about Safari Extensions.
-
 00:29:08.856 --> 00:29:12.086 A:middle
 If you are a Safari Extension
 Developer it's extremely
@@ -2654,9 +2573,6 @@ if the page is actually visible.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:57.306 --> 00:30:03.896 A:middle
-if the page is actually visible.
 
 00:30:03.896 --> 00:30:08.806 A:middle
 So I talked about two new
@@ -2749,9 +2665,6 @@ So it was very important for us
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:57.646 --> 00:31:00.226 A:middle
-So it was very important for us
-
 00:31:00.496 --> 00:31:02.766 A:middle
 that Safari had extremely
 responsive scrolling.
@@ -2842,10 +2755,6 @@ those tiles around.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.496 --> 00:32:00.696 A:middle
-but simply by moving
-those tiles around.
 
 00:32:00.696 --> 00:32:03.276 A:middle
 So the implementation is
@@ -2939,10 +2848,6 @@ go to this Safari application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.576 --> 00:33:01.626 A:middle
-But the user events initially
-go to this Safari application.
 
 00:33:01.976 --> 00:33:03.786 A:middle
 But Safari then sends
@@ -3041,10 +2946,6 @@ that the author has styled
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:57.396 --> 00:34:01.686 A:middle
-his social link aside,
-that the author has styled
-
 00:34:01.686 --> 00:34:05.556 A:middle
 with position fixed and when
 the page scrolls of course
@@ -3121,10 +3022,6 @@ behavior the browser now
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.836 --> 00:35:00.606 A:middle
-But again, this is a scrolling
-behavior the browser now
 
 00:35:00.606 --> 00:35:04.396 A:middle
 understands and we do
@@ -3212,10 +3109,6 @@ we recommend that you do that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.176 --> 00:36:05.286 A:middle
-on the body not on the HTML so
-we recommend that you do that.
-
 00:36:05.456 --> 00:36:07.306 A:middle
 Now there's something else
 when we're looking at scrolling
@@ -3297,10 +3190,6 @@ moves with the page for a bit
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:56.716 --> 00:37:01.616 A:middle
-when the page scrolls that box
-moves with the page for a bit
 
 00:37:01.616 --> 00:37:03.046 A:middle
 and then it sticks
@@ -3395,10 +3284,6 @@ form it has the WebKit prefix.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.966 --> 00:38:03.096 A:middle
-and because it's still in draw
-form it has the WebKit prefix.
-
 00:38:03.626 --> 00:38:08.346 A:middle
 And to be a little more
 technical, sticky specifies
@@ -3480,9 +3365,6 @@ out of the page.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.776 --> 00:39:00.566 A:middle
-out of the page.
-
 00:39:00.976 --> 00:39:02.866 A:middle
 And so this is exactly
 the behavior we saw
@@ -3558,10 +3440,6 @@ best possible scrolling behavior
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:57.156 --> 00:40:01.256 A:middle
-that your pages are getting the
-best possible scrolling behavior
-
 00:40:01.256 --> 00:40:01.886 A:middle
 in Safari?
 
@@ -3636,10 +3514,6 @@ that we saw which is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:56.776 --> 00:41:00.026 A:middle
-for the most common case
-that we saw which is
 
 00:41:00.026 --> 00:41:03.306 A:middle
 that almost all pages scroll by
@@ -3728,10 +3602,6 @@ kind of chunky.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.876 --> 00:42:00.096 A:middle
-that scrolling is
-kind of chunky.
-
 00:42:00.096 --> 00:42:03.616 A:middle
 It's not really super smooth
 and I can really, really feel it
@@ -3807,10 +3677,6 @@ background on an element
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.056 --> 00:43:02.726 A:middle
-in fact they do have a fixed
-background on an element
 
 00:43:02.726 --> 00:43:03.946 A:middle
 that is not a root element
@@ -3890,10 +3756,6 @@ top of the page, scroll down,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:57.416 --> 00:44:00.966 A:middle
-So you'll notice here at the
-top of the page, scroll down,
-
 00:44:00.966 --> 00:44:04.546 A:middle
 see the map and post section
 there, it's sticking to the top.
@@ -3967,10 +3829,6 @@ back in the develop menu
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.466 --> 00:45:01.106 A:middle
-And let's look one more time
-back in the develop menu
 
 00:45:01.246 --> 00:45:02.246 A:middle
 and show the web inspector
@@ -4052,10 +3910,6 @@ power efficient.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.396 --> 00:46:01.036 A:middle
-and make Safari super
-power efficient.
 
 00:46:01.506 --> 00:46:03.926 A:middle
 And we've also talked

--- a/2013/608.srt
+++ b/2013/608.srt
@@ -80,10 +80,6 @@ legislation may apply to you,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.276 --> 00:01:00.266 A:middle
-because you believe that
-legislation may apply to you,
-
 00:01:00.266 --> 00:01:03.926 A:middle
 in particular in the U.S., that
 the 21st Century Communications
@@ -173,10 +169,6 @@ options for playback -
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.756 --> 00:02:01.596 A:middle
-to select specific media
-options for playback -
-
 00:02:01.596 --> 00:02:03.436 A:middle
 we're going to talk about
 how you can do that,
@@ -264,10 +256,6 @@ Apple's foundational framework
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.066 --> 00:03:02.506 A:middle
-in the AV Foundation framework,
-Apple's foundational framework
 
 00:03:02.506 --> 00:03:04.556 A:middle
 for the control of
@@ -434,10 +422,6 @@ to be provided in text form?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:58.086 --> 00:05:00.926 A:middle
-And what information is going
-to be provided in text form?
-
 00:05:02.376 --> 00:05:04.776 A:middle
 Most content providers
 understand that even though
@@ -521,10 +505,6 @@ who's sitting in the back
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.176 --> 00:06:00.946 A:middle
-For example, imagine a user
-who's sitting in the back
-
 00:06:00.946 --> 00:06:04.226 A:middle
 of an airplane, near a noisy
 engine, and has brought an iPad
@@ -602,10 +582,6 @@ abbreviated as SDH.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.316 --> 00:07:00.086 A:middle
-or hard of hearing,
-abbreviated as SDH.
 
 00:07:00.426 --> 00:07:02.606 A:middle
 So here I've got a picture
@@ -693,10 +669,6 @@ that's more appropriate for him
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:57.816 --> 00:08:01.476 A:middle
-so the user can choose the one
-that's more appropriate for him
-
 00:08:01.476 --> 00:08:05.606 A:middle
 or her: the language that
 the text use, the features
@@ -780,10 +752,6 @@ spoken, in translation.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.926 --> 00:09:04.286 A:middle
-to hear the text, the speech
-spoken, in translation.
-
 00:09:04.516 --> 00:09:07.686 A:middle
 A re-recording of the dialog
 mixed in with the music
@@ -860,10 +828,6 @@ in iOS 7and OS X Mavericks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.746 --> 00:10:02.796 A:middle
-for accessibility options
-in iOS 7and OS X Mavericks.
 
 00:10:03.346 --> 00:10:04.986 A:middle
 If you look at system
@@ -952,10 +916,6 @@ customizable under the FCC rules
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.736 --> 00:11:01.736 A:middle
-that are supposed to be
-customizable under the FCC rules
-
 00:11:01.736 --> 00:11:04.226 A:middle
 that I mentioned in
 connection with U.S. law.
@@ -1033,10 +993,6 @@ you're an application developer
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.806 --> 00:12:01.156 A:middle
-So now that they're there, if
-you're an application developer
 
 00:12:01.156 --> 00:12:02.586 A:middle
 of course your natural
@@ -1125,10 +1081,6 @@ user's preferences trump all
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:57.596 --> 00:13:01.396 A:middle
-by the actual user, and so the
-user's preferences trump all
-
 00:13:01.396 --> 00:13:03.656 A:middle
 of the styling information
 and will be honored
@@ -1212,10 +1164,6 @@ and we'll talk about that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:57.746 --> 00:14:00.726 A:middle
-to make sure that happens,
-and we'll talk about that.
-
 00:14:02.586 --> 00:14:05.896 A:middle
 In order for you to honor
 that user preference
@@ -1296,10 +1244,6 @@ point, if you have an app
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.106 --> 00:15:01.386 A:middle
-Therefore when we get to that
-point, if you have an app
 
 00:15:01.726 --> 00:15:04.446 A:middle
 that doesn't want to offer the
@@ -1395,10 +1339,6 @@ make that selection effective.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.056 --> 00:16:02.256 A:middle
-allow the user to pick one and
-make that selection effective.
-
 00:16:02.806 --> 00:16:03.476 A:middle
 How do you do that?
 
@@ -1489,10 +1429,6 @@ probably an AVAsset initialized
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.636 --> 00:17:02.836 A:middle
-with an instance of AVAsset,
-probably an AVAsset initialized
 
 00:17:02.836 --> 00:17:05.896 A:middle
 with a URL to the file in
@@ -1585,10 +1521,6 @@ Legible characteristic.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.116 --> 00:18:00.796 A:middle
-Suppose it's the
-Legible characteristic.
-
 00:18:01.246 --> 00:18:04.316 A:middle
 I'll say, AVAsset, give me
 the media selection group
@@ -1672,10 +1604,6 @@ to implement all this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.966 --> 00:19:01.116 A:middle
-that you would use in order
-to implement all this.
-
 00:19:01.776 --> 00:19:04.906 A:middle
 Even better, we're providing a
 code sample that you can read
@@ -1754,10 +1682,6 @@ audio options available
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.316 --> 00:20:02.166 A:middle
-that shows both the
-audio options available
-
 00:20:02.616 --> 00:20:04.706 A:middle
 and the subtitle
 options available.
@@ -1827,10 +1751,6 @@ different subtitles to play.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:54.766 --> 00:21:01.136 A:middle
-and just select some
-different subtitles to play.
-
 00:21:01.796 --> 00:21:05.736 A:middle
 And now let's play the
 movie and see what we get
@@ -1888,10 +1808,6 @@ AV Media Selection Demo,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.206 --> 00:22:01.286 A:middle
-both this app, which is called
-AV Media Selection Demo,
 
 00:22:01.796 --> 00:22:05.396 A:middle
 and this movie, which my Apple
@@ -1987,9 +1903,6 @@ Several choices.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.256 --> 00:23:00.056 A:middle
-Several choices.
-
 00:23:00.676 --> 00:23:04.136 A:middle
 You can choose HTML5 and
 its support for text tracks.
@@ -2076,10 +1989,6 @@ different resource from that
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.836 --> 00:24:02.126 A:middle
-the subtitles, is a
-different resource from that
-
 00:24:02.356 --> 00:24:04.236 A:middle
 that carries the
 audio and the video.
@@ -2159,10 +2068,6 @@ you would give it a kind
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:58.266 --> 00:25:01.136 A:middle
-for translation purposes
-you would give it a kind
 
 00:25:01.136 --> 00:25:05.216 A:middle
 of "subtitles", so that's
@@ -2249,10 +2154,6 @@ there's no need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.866 --> 00:26:00.586 A:middle
-Well as I mentioned
-there's no need
-
 00:26:00.586 --> 00:26:03.476 A:middle
 to modify the main media
 resource that's played
@@ -2329,10 +2230,6 @@ HTML5-compliant user agent
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.836 --> 00:27:02.526 A:middle
-implicitly you require an
-HTML5-compliant user agent
 
 00:27:02.526 --> 00:27:05.926 A:middle
 to be available to present that
@@ -2412,10 +2309,6 @@ renditions, audio, subtitles,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.666 --> 00:28:03.536 A:middle
-You can have multiple video
-renditions, audio, subtitles,
-
 00:28:03.536 --> 00:28:07.096 A:middle
 and, now for the first time
 in iOS 7 and OS X Mavericks,
@@ -2494,10 +2387,6 @@ accessibility characteristics.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.526 --> 00:29:02.116 A:middle
-that these subtitles have the
-accessibility characteristics.
 
 00:29:02.696 --> 00:29:06.146 A:middle
 Those are, "transcribes spoken
@@ -2584,10 +2473,6 @@ able to configure the display
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.346 --> 00:30:00.926 A:middle
-We want the software to be
-able to configure the display
 
 00:30:00.926 --> 00:30:03.796 A:middle
 of the item to honor those
@@ -2676,9 +2561,6 @@ making this declaration for,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.996 --> 00:31:00.396 A:middle
-making this declaration for,
-
 00:31:00.766 --> 00:31:03.496 A:middle
 closed-caption channel
 1, 2, 3 or 4.
@@ -2760,10 +2642,6 @@ media are greatly appreciated
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.656 --> 00:32:02.646 A:middle
-that take the form of audio
-media are greatly appreciated
 
 00:32:02.646 --> 00:32:03.276 A:middle
 when present.
@@ -2848,10 +2726,6 @@ specification that's available
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:56.046 --> 00:33:00.826 A:middle
-those are in this draft of the
-specification that's available
 
 00:33:00.826 --> 00:33:02.056 A:middle
 through the developer program
@@ -2941,10 +2815,6 @@ format and MPEG-4 file format.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.366 --> 00:34:02.216 A:middle
-now to the QuickTime Movie file
-format and MPEG-4 file format.
 
 00:34:02.736 --> 00:34:04.536 A:middle
 The good news about
@@ -3038,10 +2908,6 @@ associated with that track.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.646 --> 00:35:00.756 A:middle
-of the media that's
-associated with that track.
-
 00:35:01.126 --> 00:35:03.606 A:middle
 That accommodates
 an ISO-639 code.
@@ -3132,10 +2998,6 @@ track group setting.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.816 --> 00:36:01.306 A:middle
-for their alternate
-track group setting.
 
 00:36:01.576 --> 00:36:05.286 A:middle
 So for example I can have
@@ -3308,9 +3170,6 @@ The QuickTime Movie file format
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.926 --> 00:38:01.416 A:middle
-The QuickTime Movie file format
-
 00:38:01.416 --> 00:38:05.056 A:middle
 and the MPEG-4 file format
 accommodate multiple options
@@ -3395,10 +3254,6 @@ in QuickTime Movie files
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:57.736 --> 00:39:03.226 A:middle
-One last note about subtitles
-in QuickTime Movie files
-
 00:39:03.356 --> 00:39:07.486 A:middle
 and in ISO files such as
 MPEG-4 files - we're aware of,
@@ -3472,10 +3327,6 @@ to recommend the media type,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:56.766 --> 00:40:01.016 A:middle
-or M4V files, we continue
-to recommend the media type,
-
 00:40:01.326 --> 00:40:04.556 A:middle
 AVMediaTypeSubtitle, - the
 four character code is 'sbtl' -
@@ -3547,10 +3398,6 @@ known as "in band" text tracks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.056 --> 00:41:02.226 A:middle
-it also supports what are
-known as "in band" text tracks
 
 00:41:02.976 --> 00:41:04.876 A:middle
 for cases in which
@@ -3631,10 +3478,6 @@ points, not all of them
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.666 --> 00:42:02.386 A:middle
-of the highlight decision
-points, not all of them
-
 00:42:02.386 --> 00:42:03.446 A:middle
 that may pertain to you.
 
@@ -3714,10 +3557,6 @@ now, a colleague of mine
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:58.646 --> 00:43:01.466 A:middle
-and here comes Adam Sonnanstine
-now, a colleague of mine
 
 00:43:01.466 --> 00:43:03.186 A:middle
 from the Media Systems Group,
@@ -3801,10 +3640,6 @@ track to an existing Movie file.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:56.356 --> 00:44:00.686 A:middle
-where we add a new subtitle
-track to an existing Movie file.
 
 00:44:00.886 --> 00:44:02.656 A:middle
 So to see that scenario
@@ -3896,10 +3731,6 @@ translation which is "Why"
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.226 --> 00:45:01.896 A:middle
-So Courtney will type in the
-translation which is "Why"
-
 00:45:01.896 --> 00:45:05.686 A:middle
 and then what we're going to
 do is hit this button over here
@@ -3982,10 +3813,6 @@ look at that diagram here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:57.176 --> 00:46:00.556 A:middle
-Alright, so let's take another
-look at that diagram here.
 
 00:46:00.966 --> 00:46:02.426 A:middle
 We're going to zoom
@@ -4078,10 +3905,6 @@ with Media in AV Foundation,"
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.146 --> 00:47:02.466 A:middle
-in the session called "Working
-with Media in AV Foundation,"
-
 00:47:02.796 --> 00:47:05.696 A:middle
 and this one you can
 actually watch directly
@@ -4165,9 +3988,6 @@ that into your Asset Writer.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.986 --> 00:48:01.116 A:middle
-that into your Asset Writer.
-
 00:48:01.116 --> 00:48:04.106 A:middle
 And you see here that we
 nominated the Spanish input
@@ -4247,10 +4067,6 @@ about is tagged characteristics.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:58.066 --> 00:49:00.796 A:middle
-The last one I want to talk
-about is tagged characteristics.
 
 00:49:01.156 --> 00:49:03.576 A:middle
 We've talked in some
@@ -4344,10 +4160,6 @@ our accessibility features
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.156 --> 00:50:01.626 A:middle
-Alright, so that is all of
-our accessibility features
 
 00:50:01.626 --> 00:50:02.706 A:middle
 and how to author them.
@@ -4446,10 +4258,6 @@ subtitles somewhere else.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.906 --> 00:51:00.856 A:middle
-you might want to put the
-subtitles somewhere else.
-
 00:51:01.666 --> 00:51:04.766 A:middle
 So, if you had access
 to the actual text
@@ -4538,10 +4346,6 @@ carried in HLS Streams
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.076 --> 00:52:01.956 A:middle
-and the in-band subtitles
-carried in HLS Streams
 
 00:52:01.956 --> 00:52:04.946 A:middle
 and QuickTime Movie files
@@ -4640,9 +4444,6 @@ to be delivered to the delegate?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:59.276 --> 00:53:00.486 A:middle
-to be delivered to the delegate?
-
 00:53:00.486 --> 00:53:03.276 A:middle
 Well, it's the same story as if
 we were drawing it ourselves.
@@ -4739,10 +4540,6 @@ Native Sample Buffers,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:59.606 --> 00:54:01.486 A:middle
-The third parameter, the
-Native Sample Buffers,
-
 00:54:01.486 --> 00:54:04.536 A:middle
 is a more advanced use; most
 people won't need to use it.
@@ -4834,10 +4631,6 @@ this is a common format.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:58.026 --> 00:55:01.536 A:middle
-The second thing is that
-this is a common format.
 
 00:55:01.536 --> 00:55:03.896 A:middle
 We're going to give you the
@@ -4936,10 +4729,6 @@ current set of user preferences
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:57.826 --> 00:56:02.316 A:middle
-You can both access the
-current set of user preferences
-
 00:56:02.316 --> 00:56:04.596 A:middle
 and it will also give
 you a notification
@@ -5035,10 +4824,6 @@ users don't want you do
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:59.166 --> 00:57:01.666 A:middle
-but more importantly your
-users don't want you do
 
 00:57:01.666 --> 00:57:02.426 A:middle
 to that either.

--- a/2013/609.srt
+++ b/2013/609.srt
@@ -75,10 +75,6 @@ about some features
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.116 --> 00:01:00.376 A:middle
-Then we'll talk specifically
-about some features
-
 00:01:00.376 --> 00:01:02.126 A:middle
 that are just for creating
 iBooks Author Widgets.
@@ -168,10 +164,6 @@ a really great app
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.006 --> 00:02:01.866 A:middle
-iAd Producer is actually
-a really great app
-
 00:02:02.176 --> 00:02:03.646 A:middle
 for producing content
 for WebKit.
@@ -260,9 +252,6 @@ So now, we can use iAd Producer
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.356 --> 00:03:00.806 A:middle
-So now, we can use iAd Producer
 
 00:03:00.806 --> 00:03:03.356 A:middle
 to create these really great
@@ -437,10 +426,6 @@ about this in just a minute.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:55.126 --> 00:05:00.106 A:middle
-and we'll talk a lot more
-about this in just a minute.
-
 00:05:00.196 --> 00:05:01.996 A:middle
 Also, while you're creating your
 project, you're going to bring
@@ -531,10 +516,6 @@ but easy to use animation system
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:53.276 --> 00:06:00.096 A:middle
-And finally, we have a powerful
-but easy to use animation system
 
 00:06:00.536 --> 00:06:02.316 A:middle
 and this Action List sidebar is
@@ -628,10 +609,6 @@ are collections of other views.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.666 --> 00:07:01.666 A:middle
-This category has objects that
-are collections of other views.
-
 00:07:02.026 --> 00:07:05.556 A:middle
 So we've got things like a cover
 flow view, we've got a carousel,
@@ -717,9 +694,6 @@ I've a got a button selected.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.556 --> 00:08:00.646 A:middle
-I've a got a button selected.
 
 00:08:01.796 --> 00:08:04.766 A:middle
 And I've got a zoomed in
@@ -809,10 +783,6 @@ the interesting ones for you.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.346 --> 00:09:00.426 A:middle
-I want to highlight some of
-the interesting ones for you.
-
 00:09:01.116 --> 00:09:03.046 A:middle
 We already talked about
 the action that allows you
@@ -885,9 +855,6 @@ the rotation, and the scale.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.496 --> 00:10:01.136 A:middle
-the rotation, and the scale.
 
 00:10:01.666 --> 00:10:04.786 A:middle
 And those are just a few of
@@ -983,9 +950,6 @@ Chris?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.016 --> 00:11:03.636 A:middle
-[ Applause ]
-
 00:11:04.136 --> 00:11:04.796 A:middle
 &gt;&gt; Thank you, Justin.
 
@@ -1054,10 +1018,6 @@ to let me simply cycle
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.946 --> 00:12:01.006 A:middle
-and right hand corners
-to let me simply cycle
 
 00:12:01.006 --> 00:12:05.036 A:middle
 through which image is
@@ -1131,10 +1091,6 @@ categories up at the top,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:58.796 --> 00:13:01.166 A:middle
-We have those four
-categories up at the top,
 
 00:13:01.786 --> 00:13:03.326 A:middle
 which project type
@@ -1218,9 +1174,6 @@ Here, we see all those objects
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.226 --> 00:14:01.046 A:middle
-Here, we see all those objects
-
 00:14:01.146 --> 00:14:02.816 A:middle
 that Justin was talking
 about earlier.
@@ -1293,10 +1246,6 @@ into this cover flow.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.306 --> 00:15:01.016 A:middle
-It's time to get images
-into this cover flow.
 
 00:15:01.696 --> 00:15:03.046 A:middle
 Before I can do that though,
@@ -1376,10 +1325,6 @@ listing in our Asset Library.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.086 --> 00:16:02.536 A:middle
-of images is now a single
-listing in our Asset Library.
-
 00:16:03.376 --> 00:16:06.056 A:middle
 This is because from here on
 out, iAd Producer is going
@@ -1453,10 +1398,6 @@ built-in Quick Preview
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.066 --> 00:17:00.226 A:middle
-I'm going to use iAd Producer's
-built-in Quick Preview
 
 00:17:00.226 --> 00:17:02.746 A:middle
 functionality to get
@@ -1541,10 +1482,6 @@ open up the Inspector in the--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.156 --> 00:18:03.486 A:middle
-on the background of my page and
-open up the Inspector in the--
-
 00:18:03.706 --> 00:18:05.976 A:middle
 by using the toolbar
 button in the bottom right.
@@ -1615,10 +1552,6 @@ change some of its styles.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:56.776 --> 00:19:00.156 A:middle
-for with this page, so let's
-change some of its styles.
 
 00:19:00.706 --> 00:19:02.556 A:middle
 You notice now that I
@@ -1691,10 +1624,6 @@ often see a visual feedback
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.836 --> 00:20:02.156 A:middle
-and pressing down on it, we
-often see a visual feedback
 
 00:20:03.126 --> 00:20:05.446 A:middle
 for that button so
@@ -1778,10 +1707,6 @@ on the text and now that I'm
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.736 --> 00:21:04.016 A:middle
-I'm just going to double-click
-on the text and now that I'm
-
 00:21:04.016 --> 00:21:05.206 A:middle
 in text editing mode,
 
@@ -1850,10 +1775,6 @@ working the way I want it to.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.276 --> 00:22:02.406 A:middle
-to make sure everything is just
-working the way I want it to.
-
 00:22:02.656 --> 00:22:06.456 A:middle
 You can see my cover flow is
 now in that black background.
@@ -1920,10 +1841,6 @@ is the Focus Cell action
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.136 --> 00:23:00.286 A:middle
-What I'm going to use today
-is the Focus Cell action
 
 00:23:00.426 --> 00:23:02.236 A:middle
 because this is the action
@@ -2005,10 +1922,6 @@ to Events and this time,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:56.286 --> 00:24:00.146 A:middle
-iAd Producer adds that
-to Events and this time,
-
 00:24:01.426 --> 00:24:02.866 A:middle
 I do have my next button here.
 
@@ -2078,10 +1991,6 @@ my Action Lists panel.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:57.396 --> 00:25:00.306 A:middle
-I'm going to open up
-my Action Lists panel.
 
 00:25:00.716 --> 00:25:03.556 A:middle
 It's done by clicking on
@@ -2164,10 +2073,6 @@ from the top instead of the left
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.586 --> 00:26:02.246 A:middle
-I want this to be animating in
-from the top instead of the left
-
 00:26:02.246 --> 00:26:03.616 A:middle
 as we just saw it have.
 
@@ -2237,10 +2142,6 @@ has been applicable
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.716 --> 00:27:01.646 A:middle
-up to this point
-has been applicable
-
 00:27:01.646 --> 00:27:05.916 A:middle
 to all four project types
 we support, iAd projects,
@@ -2309,10 +2210,6 @@ Producer and I'm going to open
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:57.496 --> 00:28:04.076 A:middle
-At this point, I can hide iAd
-Producer and I'm going to open
-
 00:28:04.076 --> 00:28:07.736 A:middle
 up my book in iBooks Author.
 
@@ -2379,10 +2276,6 @@ going to hand it back to Justin.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:59.816 --> 00:29:02.116 A:middle
-Thank you and with that, I'm
-going to hand it back to Justin.
 
 00:29:02.706 --> 00:29:03.836 A:middle
 &gt;&gt; Thanks, Chris, that
@@ -2471,10 +2364,6 @@ Quick Preview that we have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.876 --> 00:30:02.286 A:middle
-to preview it not only in the
-Quick Preview that we have
 
 00:30:02.286 --> 00:30:05.366 A:middle
 in iAd Producer, but you'll want
@@ -2570,10 +2459,6 @@ that at the end too.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.576 --> 00:31:03.256 A:middle
-and we'll mention
-that at the end too.
-
 00:31:03.486 --> 00:31:06.196 A:middle
 So it's a really great new iBook
 specific feature that we've got.
@@ -2659,10 +2544,6 @@ standard Twitter compose view.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.686 --> 00:32:01.646 A:middle
-to compose a tweet using the
-standard Twitter compose view.
 
 00:32:01.966 --> 00:32:04.196 A:middle
 You can change the
@@ -2753,9 +2634,6 @@ because we already know
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.876 --> 00:33:00.706 A:middle
-because we already know
-
 00:33:00.706 --> 00:33:03.486 A:middle
 that these blueprints
 work really great.
@@ -2837,9 +2715,6 @@ an ad more from scratch.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.116 --> 00:34:00.806 A:middle
-an ad more from scratch.
 
 00:34:01.696 --> 00:34:03.856 A:middle
 But if you want to
@@ -2981,10 +2856,6 @@ where we have those spec sheets
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.646 --> 00:36:02.016 A:middle
-Assets Library, and this is
-where we have those spec sheets
-
 00:36:02.016 --> 00:36:03.536 A:middle
 that Justin was talking
 about earlier.
@@ -3055,10 +2926,6 @@ specific settings for my ad,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.576 --> 00:37:01.056 A:middle
-Here, I can put in the
-specific settings for my ad,
 
 00:37:01.386 --> 00:37:04.126 A:middle
 project title, banner
@@ -3436,10 +3303,6 @@ iOS Simulator so that
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.536 --> 00:42:02.126 A:middle
-It also runs in the
-iOS Simulator so that
-
 00:42:02.126 --> 00:42:04.066 A:middle
 if you don't have a
 device handy or if you want
@@ -3516,10 +3379,6 @@ about iAd Producer,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.966 --> 00:43:03.356 A:middle
-So for more information
-about iAd Producer,
 
 00:43:03.766 --> 00:43:04.946 A:middle
 you can email Mark Malone
@@ -3614,10 +3473,6 @@ about iAd Producer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.646 --> 00:44:02.026 A:middle
-to be an advanced session
-about iAd Producer.
 
 00:44:02.026 --> 00:44:03.726 A:middle
 We will show you all of that.

--- a/2013/610.srt
+++ b/2013/610.srt
@@ -67,10 +67,6 @@ have a brief appetizer
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.816 --> 00:01:01.586 A:middle
-Today we're going to
-have a brief appetizer
-
 00:01:01.686 --> 00:01:04.046 A:middle
 of greater transparency
 for users,
@@ -154,10 +150,6 @@ or write to the assets library,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.706 --> 00:02:04.086 A:middle
-that is read to-- read from,
-or write to the assets library,
-
 00:02:04.676 --> 00:02:07.396 A:middle
 so that the user would have an
 opportunity to opt in or out.
@@ -231,10 +223,6 @@ camera to allow users to know
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.866 --> 00:03:02.166 A:middle
-of the microphone or the
-camera to allow users to know
 
 00:03:02.166 --> 00:03:03.746 A:middle
 about it, and to opt in or out.
@@ -311,10 +299,6 @@ already know what the answer is,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.546 --> 00:04:01.626 A:middle
-If on subsequent launches we
-already know what the answer is,
 
 00:04:01.976 --> 00:04:04.346 A:middle
 we can return an
@@ -396,10 +380,6 @@ frame rate movies,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.926 --> 00:05:01.336 A:middle
-So by introducing 60
-frame rate movies,
-
 00:05:01.336 --> 00:05:03.626 A:middle
 we wanted to make sure you
 could also do interesting things
@@ -479,10 +459,6 @@ that the high frame rate areas
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:56.796 --> 00:06:00.436 A:middle
-You can either export such
-that the high frame rate areas
-
 00:06:00.436 --> 00:06:01.746 A:middle
 of the movie are preserved,
 
@@ -553,10 +529,6 @@ the playback and editing.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.376 --> 00:07:00.086 A:middle
-for today's demo, which is
-the playback and editing.
 
 00:07:00.786 --> 00:07:03.306 A:middle
 I recorded several
@@ -637,10 +609,6 @@ that you could even export this
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:53.006 --> 00:08:01.786 A:middle
-We're preserving pitch here, so
-that you could even export this
-
 00:08:01.786 --> 00:08:03.956 A:middle
 and pass it off as him
 doing the real thing.
@@ -719,9 +687,6 @@ And finally, let's go --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.256 --> 00:09:00.266 A:middle
-And finally, let's go --
-
 00:09:00.266 --> 00:09:01.606 A:middle
 [ Applause ]
 
@@ -794,9 +759,6 @@ Now I can go back and play it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:59.246 --> 00:10:02.086 A:middle
-[ Silence ]
 
 00:10:02.586 --> 00:10:09.166 A:middle
 Oh yeah. He's coming for you.
@@ -874,10 +836,6 @@ time pitch algorithm,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.206 --> 00:11:01.426 A:middle
-and set its audio
-time pitch algorithm,
-
 00:11:01.426 --> 00:11:04.426 A:middle
 that's what I was using there to
 either adjust the pitch higher
@@ -951,10 +909,6 @@ tomorrow at 9:00 a.m.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.036 --> 00:12:01.006 A:middle
-I invite you to come back
-tomorrow at 9:00 a.m.
 
 00:12:01.136 --> 00:12:03.456 A:middle
 where we're having an
@@ -1034,10 +988,6 @@ one during playback,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.286 --> 00:13:01.906 A:middle
-or a cheap expensive
-one during playback,
 
 00:13:01.906 --> 00:13:03.646 A:middle
 and then when you export
@@ -1121,10 +1071,6 @@ output settings assistant,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.336 --> 00:14:02.996 A:middle
-So you can instantiate an AV
-output settings assistant,
-
 00:14:03.506 --> 00:14:05.556 A:middle
 tell it what the
 source video format is,
@@ -1201,10 +1147,6 @@ to make new session presets
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.346 --> 00:15:03.486 A:middle
-because we didn't want to try
-to make new session presets
-
 00:15:03.486 --> 00:15:07.476 A:middle
 for every conceivable frame
 rate and resolution combination,
@@ -1271,10 +1213,6 @@ outputs, you have a preview,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.646 --> 00:16:01.806 A:middle
-You have inputs, you have
-outputs, you have a preview,
 
 00:16:02.426 --> 00:16:05.176 A:middle
 and they're connected
@@ -1351,10 +1289,6 @@ large for your processing.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.156 --> 00:17:01.026 A:middle
-that they're not too
-large for your processing.
 
 00:17:01.466 --> 00:17:05.156 A:middle
 So it picks a screen
@@ -1434,9 +1368,6 @@ to find the highest frame rate.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.676 --> 00:18:00.016 A:middle
-to find the highest frame rate.
 
 00:18:00.846 --> 00:18:02.496 A:middle
 In the next little
@@ -1610,10 +1541,6 @@ but I left half of them
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.086 --> 00:20:01.416 A:middle
-There are 20 formats,
-but I left half of them
-
 00:20:01.416 --> 00:20:04.636 A:middle
 out because they're really just
 two flavors of the same format.
@@ -1688,9 +1615,6 @@ of configuring AV capture.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.076 --> 00:21:01.136 A:middle
-of configuring AV capture.
 
 00:21:02.106 --> 00:21:05.236 A:middle
 Instead of talking to the
@@ -1777,9 +1701,6 @@ it has a format description
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.846 --> 00:22:00.156 A:middle
-it has a format description
-
 00:22:00.156 --> 00:22:02.766 A:middle
 from which you can get
 the pixel dimensions,
@@ -1861,9 +1782,6 @@ or may not have heard of.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.896 --> 00:23:00.816 A:middle
-or may not have heard of.
-
 00:23:00.876 --> 00:23:05.326 A:middle
 This is sort of a
 sensor-specific keyword.
@@ -1940,10 +1858,6 @@ mechanism is not deprecated,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.336 --> 00:24:03.486 A:middle
-The session presets setting
-mechanism is not deprecated,
 
 00:24:03.486 --> 00:24:04.586 A:middle
 it's not going away.
@@ -2036,9 +1950,6 @@ of the AV capture connection.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.896 --> 00:25:01.606 A:middle
-of the AV capture connection.
-
 00:25:02.006 --> 00:25:04.386 A:middle
 Apparently this only applies
 to still image outputs,
@@ -2125,10 +2036,6 @@ the capture device is applying
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:56.726 --> 00:26:00.636 A:middle
-However, our new property up on
-the capture device is applying
 
 00:26:00.636 --> 00:26:03.596 A:middle
 to all the image outputs,
@@ -2228,10 +2135,6 @@ device format
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.936 --> 00:27:01.016 A:middle
-of the new AV capture
-device format
-
 00:27:01.016 --> 00:27:02.396 A:middle
 that Brad was just
 talking about.
@@ -2319,10 +2222,6 @@ which is also a method --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.226 --> 00:28:01.916 A:middle
-And it's up to a maximum value,
-which is also a method --
 
 00:28:02.046 --> 00:28:04.816 A:middle
 property of the AV
@@ -2418,10 +2317,6 @@ of the field of view,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.256 --> 00:29:00.176 A:middle
-and as the face goes out
-of the field of view,
-
 00:29:00.626 --> 00:29:01.916 A:middle
 they will stop being detected.
 
@@ -2505,10 +2400,6 @@ being captured in real time.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:57.446 --> 00:30:00.596 A:middle
-factor on each frame as it's
-being captured in real time.
-
 00:30:04.016 --> 00:30:06.396 A:middle
 There's another method,
 cancel video zoom ramp,
@@ -2589,10 +2480,6 @@ And so we go from 1 to 2,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.616 --> 00:31:03.256 A:middle
-And so we go from 1 to 2,
-2 to 4, 4 to 8, and so on.
-
 00:31:03.616 --> 00:31:06.336 A:middle
 In practice you'll probably
 want to stay around 1 to 3
@@ -2672,10 +2559,6 @@ the constant face size.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.356 --> 00:32:01.866 A:middle
-But anyway, so that's
-the constant face size.
 
 00:32:02.216 --> 00:32:04.736 A:middle
 There's another aspect
@@ -2760,10 +2643,6 @@ exponential growth
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.176 --> 00:33:00.176 A:middle
-that'll give you that
-exponential growth
 
 00:33:00.176 --> 00:33:02.426 A:middle
 over the range, and so
@@ -2931,10 +2810,6 @@ there's now a scan code button.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.406 --> 00:35:01.506 A:middle
-In the upper right-hand corner,
-there's now a scan code button.
-
 00:35:01.656 --> 00:35:07.156 A:middle
 So when you press that, you
 get a view to scan in codes.
@@ -3000,10 +2875,6 @@ app we call QRchestra.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:56.306 --> 00:36:00.356 A:middle
-And we have a sample
-app we call QRchestra.
 
 00:36:01.006 --> 00:36:04.206 A:middle
 So Ethan has a version
@@ -3156,10 +3027,6 @@ output, add it to your session,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:56.326 --> 00:38:00.796 A:middle
-First, alloc/init your meta data
-output, add it to your session,
-
 00:38:02.176 --> 00:38:05.096 A:middle
 create your meta data delegate,
 along with its dispatch queue,
@@ -3241,10 +3108,6 @@ between bounds
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.626 --> 00:39:00.966 A:middle
-We'll cover the difference
-between bounds
-
 00:39:00.966 --> 00:39:02.876 A:middle
 and corners here
 in a later slide.
@@ -3318,10 +3181,6 @@ to come back as the corners
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.626 --> 00:40:00.156 A:middle
-But your corners are going
-to come back as the corners
 
 00:40:00.156 --> 00:40:02.836 A:middle
 of where the barcode were
@@ -3411,10 +3270,6 @@ the codes, you might want
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.406 --> 00:41:00.396 A:middle
-Depending on the density of
-the codes, you might want
-
 00:41:00.396 --> 00:41:02.656 A:middle
 to go higher or lower,
 maybe up 720p,
@@ -3489,10 +3344,6 @@ new type for each symbology
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.096 --> 00:42:02.616 A:middle
-but now we're introduced a
-new type for each symbology
 
 00:42:02.616 --> 00:42:04.146 A:middle
 of machine readable
@@ -3572,10 +3423,6 @@ faces within my QR code.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:54.446 --> 00:43:00.336 A:middle
-So here, now I can find
-faces within my QR code.
 
 00:43:00.336 --> 00:43:03.846 A:middle
 Alright, let's talk about
@@ -3668,10 +3515,6 @@ up near the top.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.356 --> 00:44:00.866 A:middle
-of highlighted region
-up near the top.
-
 00:44:01.546 --> 00:44:03.316 A:middle
 That's the rect of
 interest that I would
@@ -3751,10 +3594,6 @@ use the AV capture video preview
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.596 --> 00:45:02.216 A:middle
-to the meta data output, you
-use the AV capture video preview
 
 00:45:02.216 --> 00:45:05.966 A:middle
 layer meta data output rect
@@ -3838,10 +3677,6 @@ it back over to Brad to talk
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.026 --> 00:46:00.196 A:middle
-And with that, I'm going to turn
-it back over to Brad to talk
 
 00:46:00.196 --> 00:46:01.756 A:middle
 about some additional
@@ -3936,10 +3771,6 @@ at a clock that's very close
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:58.056 --> 00:47:01.106 A:middle
-where we have a person looking
-at a clock that's very close
-
 00:47:01.106 --> 00:47:03.036 A:middle
 to him, and a tree that's far.
 
@@ -4013,10 +3844,6 @@ I'll term fast focus --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:56.986 --> 00:48:00.286 A:middle
-The one on the left is what
-I'll term fast focus --
 
 00:48:00.286 --> 00:48:03.206 A:middle
 this is what's shipping
@@ -4093,10 +3920,6 @@ you'll see --
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.246 --> 00:49:00.826 A:middle
-every once in a while
-you'll see --
 
 00:49:00.826 --> 00:49:04.996 A:middle
 you can definitely see that the
@@ -4177,10 +4000,6 @@ it's faster, and no one's going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:57.626 --> 00:50:01.566 A:middle
-for still image taking, because
-it's faster, and no one's going
-
 00:50:01.566 --> 00:50:05.286 A:middle
 to see the pulse in the
 resulting still image
@@ -4254,10 +4073,6 @@ threw in an extra one,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:57.776 --> 00:51:01.116 A:middle
-And then for giggles I
-threw in an extra one,
 
 00:51:01.116 --> 00:51:02.716 A:middle
 which is to set the
@@ -4346,10 +4161,6 @@ you like configure the routing,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:51:59.216 --> 00:52:02.136 A:middle
-And it does important things for
-you like configure the routing,
-
 00:52:02.136 --> 00:52:04.376 A:middle
 for instance, whether
 both the microphones
@@ -4426,9 +4237,6 @@ and with the microphone.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:59.696 --> 00:53:00.806 A:middle
-and with the microphone.
 
 00:53:01.796 --> 00:53:05.066 A:middle
 Well, you're probably going to
@@ -4517,10 +4325,6 @@ not configured automatically
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:53:58.626 --> 00:54:01.986 A:middle
-And your audio session is
-not configured automatically
-
 00:54:01.986 --> 00:54:05.146 A:middle
 by default to record,
 it's just for playback.
@@ -4599,10 +4403,6 @@ your audio session before we
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:57.776 --> 00:55:00.046 A:middle
-of the state that was in
-your audio session before we
 
 00:55:00.046 --> 00:55:01.346 A:middle
 configured it to succeed.
@@ -4686,10 +4486,6 @@ the interruption problem,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:55:59.546 --> 00:56:01.506 A:middle
-so that we don't have
-the interruption problem,
-
 00:56:02.026 --> 00:56:06.916 A:middle
 and we do recommend that you let
 AV capture session modify your
@@ -4771,10 +4567,6 @@ today, but they let you know
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:56:57.706 --> 00:57:00.586 A:middle
-that I have not talked about
-today, but they let you know
 
 00:57:00.586 --> 00:57:02.826 A:middle
 which clock we're
@@ -4866,10 +4658,6 @@ zoom, barcodes, app integration,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:57:59.976 --> 00:58:05.216 A:middle
-60 frames per second, video
-zoom, barcodes, app integration,
 
 00:58:05.216 --> 00:58:07.806 A:middle
 app audio session

--- a/2013/611.srt
+++ b/2013/611.srt
@@ -209,10 +209,6 @@ automatically on export.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:59.566 --> 00:03:02.096 A:middle
-with your content
-automatically on export.
-
 00:03:02.636 --> 00:03:05.286 A:middle
 In this particular example,
 
@@ -278,10 +274,6 @@ custom CSS in iAd Producer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:56.476 --> 00:04:01.276 A:middle
-So that's one way to apply
-custom CSS in iAd Producer.
 
 00:04:02.146 --> 00:04:04.066 A:middle
 Now, we go and look
@@ -480,10 +472,6 @@ we will see the Code Editor.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.266 --> 00:07:03.286 A:middle
-When we choose that option,
-we will see the Code Editor.
-
 00:07:03.646 --> 00:07:07.026 A:middle
 And there we can add the code
 to connect to the NASA server.
@@ -555,10 +543,6 @@ going to assign it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.566 --> 00:08:00.146 A:middle
-In this diagram, I'm
-going to assign it
 
 00:08:00.146 --> 00:08:03.226 A:middle
 to an object represented
@@ -644,10 +628,6 @@ can use the data from the server
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.946 --> 00:09:03.456 A:middle
-I'm going to show you how we
-can use the data from the server
-
 00:09:03.456 --> 00:09:06.056 A:middle
 and populate it in
 a multi-cell object.
@@ -717,10 +697,6 @@ object to supply data
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.476 --> 00:10:01.346 A:middle
-In order for the green
-object to supply data
 
 00:10:01.346 --> 00:10:04.526 A:middle
 to the multi-cell object, you
@@ -809,10 +785,6 @@ got three event associated
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.136 --> 00:11:02.086 A:middle
-to jump in here and maybe I've
-got three event associated
 
 00:11:02.086 --> 00:11:05.086 A:middle
 with Mars curiosity and I want
@@ -906,10 +878,6 @@ one of our multi-cell objects
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:57.166 --> 00:12:00.236 A:middle
-And it's a good example of
-one of our multi-cell objects
-
 00:12:00.236 --> 00:12:02.026 A:middle
 that has some great properties.
 
@@ -1001,10 +969,6 @@ to basically a prototype cell,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:57.606 --> 00:13:00.316 A:middle
-And it's going to bring it down
-to basically a prototype cell,
 
 00:13:00.316 --> 00:13:02.336 A:middle
 one cell that's going
@@ -1101,10 +1065,6 @@ page when press the Code button.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.036 --> 00:14:00.986 A:middle
-I have nothing selected on the
-page when press the Code button.
 
 00:14:00.986 --> 00:14:03.526 A:middle
 And so, what it did was
@@ -1208,10 +1168,6 @@ add or this widget is opened,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.066 --> 00:15:02.586 A:middle
-And whenever this particular
-add or this widget is opened,
-
 00:15:02.586 --> 00:15:04.026 A:middle
 it's going to call
 to this feed and pull
@@ -1311,10 +1267,6 @@ to the path
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.476 --> 00:16:00.516 A:middle
-of web service variable
-to the path
-
 00:16:00.516 --> 00:16:01.856 A:middle
 to that JSON file that you saw.
 
@@ -1406,10 +1358,6 @@ one of these objects.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.356 --> 00:17:02.236 A:middle
-All right, so I'm instantiating
-one of these objects.
 
 00:17:02.986 --> 00:17:05.945 A:middle
 I'm setting its delegate
@@ -1513,10 +1461,6 @@ loaderDidComplete call.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.336 --> 00:18:00.626 A:middle
-And this is the
-loaderDidComplete call.
-
 00:18:00.626 --> 00:18:02.996 A:middle
 And this is, if I successfully
 called back to my server,
@@ -1602,10 +1546,6 @@ those milestones that you saw
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.756 --> 00:19:01.476 A:middle
-And then I'm going to pull out
-those milestones that you saw
 
 00:19:01.476 --> 00:19:02.606 A:middle
 in there which is going to go
@@ -1776,10 +1716,6 @@ from Archive
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:59.776 --> 00:21:01.996 A:middle
-And I just say restore
-from Archive
-
 00:21:01.996 --> 00:21:05.086 A:middle
 and what it does is it
 instantiates one of those views
@@ -1868,10 +1804,6 @@ the call to the local server
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:56.126 --> 00:22:00.546 A:middle
-If I hit Preview here, it made
-the call to the local server
 
 00:22:01.036 --> 00:22:03.356 A:middle
 and there are all the
@@ -1976,10 +1908,6 @@ pass it back to Chi Wai
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.576 --> 00:23:03.286 A:middle
-So that's the demo and I'll
-pass it back to Chi Wai
-
 00:23:03.286 --> 00:23:05.756 A:middle
 to take it to the next step.
 
@@ -2050,10 +1978,6 @@ the HMTL object is MathML.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.386 --> 00:24:03.946 A:middle
-Another great use case of
-the HMTL object is MathML.
 
 00:24:05.176 --> 00:24:06.336 A:middle
 Back to your Code Editor,
@@ -2126,10 +2050,6 @@ embeddable HTML object.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:56.406 --> 00:25:00.466 A:middle
-it does provide an
-embeddable HTML object.
 
 00:25:01.786 --> 00:25:03.916 A:middle
 And we can use it for our--
@@ -2291,10 +2211,6 @@ tool that comes with Safari.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:59.976 --> 00:27:05.446 A:middle
-The Web Inspector is a debugging
-tool that comes with Safari.
-
 00:27:06.786 --> 00:27:09.816 A:middle
 In iAd Producer, you can
 attach a Web Inspector along
@@ -2359,10 +2275,6 @@ will see my content
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.276 --> 00:28:00.896 A:middle
-So I do a preview and
-will see my content
 
 00:28:00.896 --> 00:28:03.356 A:middle
 in the background a Web
@@ -2431,10 +2343,6 @@ latency and duration.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.816 --> 00:29:04.776 A:middle
-we can see the file size,
-latency and duration.
-
 00:29:05.256 --> 00:29:06.826 A:middle
 So it's really easy for us
 
@@ -2494,10 +2402,6 @@ connected to your computer,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:56.636 --> 00:30:00.276 A:middle
-If your iOS device is
-connected to your computer,
 
 00:30:00.486 --> 00:30:01.816 A:middle
 you will see on the side bar.
@@ -2580,9 +2484,6 @@ on the Mac and it looks great.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.096 --> 00:31:00.566 A:middle
-on the Mac and it looks great.
 
 00:31:00.566 --> 00:31:03.416 A:middle
 And that's, as you would
@@ -2671,10 +2572,6 @@ same networking,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:58.996 --> 00:32:00.436 A:middle
-It's not using the
-same networking,
 
 00:32:00.436 --> 00:32:01.126 A:middle
 those types of things.
@@ -2776,10 +2673,6 @@ an iPad or an iPhone,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.646 --> 00:33:00.926 A:middle
-But once you tether with
-an iPad or an iPhone,
 
 00:33:00.926 --> 00:33:01.866 A:middle
 this will become enabled
@@ -2884,10 +2777,6 @@ this particular example.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.286 --> 00:34:03.246 A:middle
-you'll see when I do
-this particular example.
-
 00:34:03.246 --> 00:34:04.386 A:middle
 I just launched it.
 
@@ -2989,10 +2878,6 @@ that I want to look
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.526 --> 00:35:01.316 A:middle
-And the first thing
-that I want to look
-
 00:35:01.316 --> 00:35:03.986 A:middle
 at are the network requests.
 
@@ -3092,10 +2977,6 @@ numbers there.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.406 --> 00:36:01.176 A:middle
-without all of the
-numbers there.
-
 00:36:01.176 --> 00:36:04.606 A:middle
 And it gives you a really good
 feel for the loading aspect
@@ -3187,10 +3068,6 @@ the thing is called lorem.js
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.066 --> 00:37:01.286 A:middle
-If I look at it, I can see that
-the thing is called lorem.js
 
 00:37:02.336 --> 00:37:04.686 A:middle
 which is, you know,
@@ -3286,10 +3163,6 @@ a best practice here,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.576 --> 00:38:00.896 A:middle
-Another good example of
-a best practice here,
-
 00:38:01.196 --> 00:38:03.586 A:middle
 certainly in a cellular
 network and in sort
@@ -3383,9 +3256,6 @@ Here's my particles.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.936 --> 00:39:00.936 A:middle
-Here's my particles.
-
 00:39:01.556 --> 00:39:03.566 A:middle
 All put together
 within one image.
@@ -3477,10 +3347,6 @@ Recording, do a Command-R
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.306 --> 00:40:00.706 A:middle
-I'm going to hit Start
-Recording, do a Command-R
 
 00:40:00.706 --> 00:40:04.706 A:middle
 to relaunch, and Stop Recording
@@ -3581,9 +3447,6 @@ and hit Start Profile.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.596 --> 00:41:01.006 A:middle
-and hit Start Profile.
-
 00:41:01.006 --> 00:41:03.446 A:middle
 And you'll see we have two
 different options for profiling.
@@ -3679,10 +3542,6 @@ simulation move particle that's
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.096 --> 00:42:02.616 A:middle
-that there is this particle
-simulation move particle that's
 
 00:42:02.616 --> 00:42:04.996 A:middle
 got the bulk of the
@@ -3783,10 +3642,6 @@ at network requests.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.076 --> 00:43:02.636 A:middle
-And taking a look
-at network requests.
-
 00:43:03.306 --> 00:43:06.996 A:middle
 The next thing that I'll do
 is I'll show you some items
@@ -3870,10 +3725,6 @@ demonstration.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:58.766 --> 00:44:00.766 A:middle
-with this particular
-demonstration.
 
 00:44:01.216 --> 00:44:04.146 A:middle
 And so, what I'm going to use is
@@ -3972,10 +3823,6 @@ and what I want to do is come
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.166 --> 00:45:02.346 A:middle
-Now I connect to that process
-and what I want to do is come
-
 00:45:02.346 --> 00:45:05.736 A:middle
 into my pad and press Record.
 
@@ -4066,10 +3913,6 @@ freed or you're just building
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.026 --> 00:46:01.406 A:middle
-Maybe things aren't getting
-freed or you're just building
 
 00:46:01.406 --> 00:46:03.236 A:middle
 up arrays until they explode.
@@ -4176,10 +4019,6 @@ and the Web Inspector.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.616 --> 00:47:02.326 A:middle
-So that's it for Instruments
-and the Web Inspector.
-
 00:47:02.326 --> 00:47:04.066 A:middle
 Let me turn it back
 over to Chi Wai.
@@ -4251,10 +4090,6 @@ the memory footprint on device
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:55.026 --> 00:48:01.396 A:middle
-With Instrument, we can memory
-the memory footprint on device
 
 00:48:02.176 --> 00:48:05.786 A:middle
 and we can save some memory
@@ -4328,10 +4163,6 @@ person of the day.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.576 --> 00:49:02.116 A:middle
-also our awesome demo
-person of the day.
 
 00:49:02.116 --> 00:49:07.316 A:middle
 There is documentation

--- a/2013/612.srt
+++ b/2013/612.srt
@@ -59,10 +59,6 @@ of video editing applications
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.886 --> 00:01:00.926 A:middle
-It's used in a wide variety
-of video editing applications
-
 00:01:00.926 --> 00:01:04.366 A:middle
 in the app store
 including those from Apple.
@@ -109,10 +105,6 @@ the video composition
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.276 --> 00:02:00.386 A:middle
-to place your code inside
-the video composition
 
 00:02:00.386 --> 00:02:01.206 A:middle
 render pipeline.
@@ -164,10 +156,6 @@ compositions as a whole,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.316 --> 00:03:01.566 A:middle
-So looking inside
-compositions as a whole,
 
 00:03:01.986 --> 00:03:04.176 A:middle
 we first see the AVComposition,
@@ -287,10 +275,6 @@ which we encode
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.736 --> 00:05:04.326 A:middle
-In this case, a dissolve
-which we encode
-
 00:05:04.326 --> 00:05:05.966 A:middle
 as a property in
 the instruction.
@@ -340,10 +324,6 @@ request.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:56.836 --> 00:06:00.306 A:middle
-AVAsynchronousVideoComposition
-request.
 
 00:06:00.876 --> 00:06:06.846 A:middle
 And, in addition, you'll
@@ -405,10 +385,6 @@ you'll receive YUV 8-bit 420.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.106 --> 00:07:09.876 A:middle
-when we're decoding H.264 video,
-you'll receive YUV 8-bit 420.
-
 00:07:10.026 --> 00:07:13.596 A:middle
 But that could vary and
 your code may not be able
@@ -460,10 +436,6 @@ And we're requiring
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:55.386 --> 00:08:05.276 A:middle
-And we're requiring
-32-bit BGRA here.
 
 00:08:05.356 --> 00:08:08.956 A:middle
 Now in order to get hold of a
@@ -518,10 +490,6 @@ our AVVideoCompositing protocol
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:56.746 --> 00:09:01.176 A:middle
-So, here we're implementing
-our AVVideoCompositing protocol
 
 00:09:02.256 --> 00:09:08.616 A:middle
 and those three methods that
@@ -644,10 +612,6 @@ we'll see what happens.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.946 --> 00:11:00.816 A:middle
-So let's play and
-we'll see what happens.
-
 00:11:01.496 --> 00:11:03.596 A:middle
 Okay so we've got a
 really simple wipe,
@@ -713,10 +677,6 @@ position of the white band.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.606 --> 00:12:02.576 A:middle
-to calculate the vertical
-position of the white band.
 
 00:12:03.496 --> 00:12:08.056 A:middle
 We have to basically interpolate
@@ -790,10 +750,6 @@ there's our otters again.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.666 --> 00:13:01.236 A:middle
-Coming in quite fast, and
-there's our otters again.
-
 00:13:01.816 --> 00:13:03.646 A:middle
 I'll play that again.
 
@@ -858,10 +814,6 @@ it's a strange, hypnotic effect.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:56.856 --> 00:14:02.716 A:middle
-You can see the, as it comes in,
-it's a strange, hypnotic effect.
-
 00:14:02.966 --> 00:14:06.866 A:middle
 But this we can play
 with it even more
@@ -907,10 +859,6 @@ overview of that
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:56.546 --> 00:15:00.246 A:middle
-So let's have a quick
-overview of that
 
 00:15:00.246 --> 00:15:03.316 A:middle
 in case you're not familiar
@@ -966,10 +914,6 @@ time by the duration.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:56.606 --> 00:16:01.586 A:middle
-by dividing the elapsed
-time by the duration.
 
 00:16:01.586 --> 00:16:04.866 A:middle
 In which case we calculate
@@ -1082,10 +1026,6 @@ don't modify the frame at all,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.636 --> 00:18:01.336 A:middle
-Some just take one source and
-don't modify the frame at all,
-
 00:18:01.336 --> 00:18:03.796 A:middle
 they simply pass through
 frames from track A.
@@ -1147,10 +1087,6 @@ to do is just leave it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:54.266 --> 00:19:00.246 A:middle
-Now what we don't want
-to do is just leave it
 
 00:19:00.566 --> 00:19:03.666 A:middle
 to be the default value of
@@ -1220,10 +1156,6 @@ the top right for every frame.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.766 --> 00:20:03.366 A:middle
-The picture-in-picture is at
-the top right for every frame.
-
 00:20:03.886 --> 00:20:05.446 A:middle
 The same source frames
 every time.
@@ -1280,10 +1212,6 @@ since the display, for example,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.906 --> 00:21:05.626 A:middle
-With output it's less critical
-since the display, for example,
-
 00:21:05.626 --> 00:21:08.376 A:middle
 can accept multiple
 formats, like BGRA and YUV.
@@ -1313,10 +1241,6 @@ and complex compositions
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:55.816 --> 00:22:01.696 A:middle
-to construct elaborate
-and complex compositions
 
 00:22:01.826 --> 00:22:09.396 A:middle
 with entirely legal values while
@@ -1433,10 +1357,6 @@ to the demo machine.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:57.386 --> 00:24:00.406 A:middle
-So let's switch back
-to the demo machine.
-
 00:24:01.176 --> 00:24:03.536 A:middle
 I think I see that, yeah, okay.
 
@@ -1487,10 +1407,6 @@ here for video track 2
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:52.396 --> 00:25:00.176 A:middle
-So our source media starts
-here for video track 2
 
 00:25:00.176 --> 00:25:02.396 A:middle
 and there for video track 1.
@@ -1560,10 +1476,6 @@ slowly through.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.886 --> 00:26:02.306 A:middle
-let's just play that
-slowly through.
-
 00:26:03.416 --> 00:26:07.256 A:middle
 If we dissolve away from the
 boat, the deer comes through
@@ -1622,10 +1534,6 @@ where that problem is.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:56.336 --> 00:27:03.376 A:middle
-And I just happen to know
-where that problem is.
 
 00:27:03.376 --> 00:27:08.866 A:middle
 And your bugs won't
@@ -1688,10 +1596,6 @@ the dissolve instructions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.256 --> 00:28:03.666 A:middle
-Down here we have a gap between
-the dissolve instructions
-
 00:28:04.616 --> 00:28:07.726 A:middle
 and the last instruction,
 which isn't good.
@@ -1741,10 +1645,6 @@ own video instructions.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.326 --> 00:29:00.316 A:middle
-Extend it to draw your
-own video instructions.
 
 00:29:01.066 --> 00:29:05.296 A:middle
 Now remember, it's just a
@@ -1807,10 +1707,6 @@ and the request object.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.436 --> 00:30:02.366 A:middle
-with the two new protocols
-and the request object.
-
 00:30:03.076 --> 00:30:07.586 A:middle
 And we've see how
 important it is
@@ -1866,10 +1762,6 @@ I want to see you guys drop
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:56.456 --> 00:31:00.566 A:middle
-So over the next few months,
-I want to see you guys drop
 
 00:31:00.566 --> 00:31:04.236 A:middle
 in some great OpenGL visuals

--- a/2013/613.srt
+++ b/2013/613.srt
@@ -79,10 +79,6 @@ core concepts that are critical
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.116 --> 00:01:01.536 A:middle
-Then we're going to look at some
-core concepts that are critical
-
 00:01:01.536 --> 00:01:05.706 A:middle
 in understanding why your
 application is generating
@@ -167,10 +163,6 @@ want to delight your customers.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.816 --> 00:02:02.196 A:middle
-So first and foremost, we really
-want to delight your customers.
-
 00:02:02.776 --> 00:02:05.776 A:middle
 So that's why the advertisements
 
@@ -244,10 +236,6 @@ experience for them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.016 --> 00:03:01.266 A:middle
-it feels like this amazing
-experience for them.
 
 00:03:01.266 --> 00:03:02.936 A:middle
 And that's what we're
@@ -333,10 +321,6 @@ don't need to worry about it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:57.316 --> 00:04:00.266 A:middle
-So we handle the privacy, so you
-don't need to worry about it.
-
 00:04:00.676 --> 00:04:01.816 A:middle
 Users start using ads
 
@@ -412,9 +396,6 @@ It's a great path to revenue.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.636 --> 00:05:00.076 A:middle
-It's a great path to revenue.
 
 00:05:00.656 --> 00:05:02.836 A:middle
 When your application
@@ -597,10 +578,6 @@ we're talking about today,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:58.766 --> 00:07:00.936 A:middle
-the path to revenue, which
-we're talking about today,
-
 00:07:01.296 --> 00:07:04.276 A:middle
 and also the promotional
 aspect promoting your app.
@@ -678,10 +655,6 @@ that when we're talking
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:59.666 --> 00:08:01.076 A:middle
-And we'll come back to
-that when we're talking
 
 00:08:01.076 --> 00:08:03.346 A:middle
 about improving app performance.
@@ -763,10 +736,6 @@ all starts with a great app.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.046 --> 00:09:03.316 A:middle
-So first and foremost, it
-all starts with a great app.
 
 00:09:03.376 --> 00:09:04.786 A:middle
 You need to focus
@@ -854,10 +823,6 @@ do is to place ads smartly.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.336 --> 00:10:02.076 A:middle
-The next thing that you can
-do is to place ads smartly.
 
 00:10:02.686 --> 00:10:04.666 A:middle
 Key here is not place
@@ -947,9 +912,6 @@ during registration.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.576 --> 00:11:00.616 A:middle
-during registration.
 
 00:11:00.616 --> 00:11:02.246 A:middle
 Maybe you want to
@@ -1046,10 +1008,6 @@ those ad requests,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.776 --> 00:12:01.756 A:middle
-and really drive up
-those ad requests,
-
 00:12:01.966 --> 00:12:04.456 A:middle
 and assist with optimizing
 the ad performance
@@ -1136,10 +1094,6 @@ your marketing budget,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.706 --> 00:13:01.466 A:middle
-Increase a little bit of
-your marketing budget,
-
 00:13:02.086 --> 00:13:05.346 A:middle
 get some more customers into
 your apps at that point in time,
@@ -1212,9 +1166,6 @@ to the iTunes Connect website,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.766 --> 00:14:01.396 A:middle
-to the iTunes Connect website,
 
 00:14:01.396 --> 00:14:05.936 A:middle
 so the iAd preferences
@@ -1369,10 +1320,6 @@ choose the view controllers
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.906 --> 00:16:02.916 A:middle
-And lastly, you need to
-choose the view controllers
-
 00:16:02.956 --> 00:16:07.106 A:middle
 in your application that are
 appropriate for advertising.
@@ -1444,10 +1391,6 @@ canDisplayBannerAds property
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.136 --> 00:17:01.536 A:middle
-So when you sent the
-canDisplayBannerAds property
 
 00:17:01.536 --> 00:17:04.935 A:middle
 to yes, we wrap your
@@ -1530,10 +1473,6 @@ callback is poise
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.546 --> 00:18:01.186 A:middle
-in the viewWillDisappear
-callback is poise
-
 00:18:01.186 --> 00:18:05.016 A:middle
 and intensive media
 activities, sounds, and so on,
@@ -1613,9 +1552,6 @@ There are certain circumstances
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.116 --> 00:19:00.426 A:middle
-There are certain circumstances
-
 00:19:00.426 --> 00:19:03.236 A:middle
 where you want a
 temporarily disable banner ads
@@ -1692,10 +1628,6 @@ in and out of your application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:57.526 --> 00:20:01.136 A:middle
-So this is how quickly ads cycle
-in and out of your application.
 
 00:20:02.266 --> 00:20:03.526 A:middle
 One thing to bear in mind is
@@ -1790,10 +1722,6 @@ bottom of the list of articles.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.176 --> 00:21:02.516 A:middle
-to add a banner view to the
-bottom of the list of articles.
-
 00:21:02.956 --> 00:21:07.396 A:middle
 So I'm going to go ahead and
 pop open the iOS Simulator here,
@@ -1882,10 +1810,6 @@ need to do is set that property
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.056 --> 00:22:02.116 A:middle
-Once we've done that, all we
-need to do is set that property
-
 00:22:02.406 --> 00:22:04.746 A:middle
 on the View Controller
 when it wakes up.
@@ -1968,10 +1892,6 @@ view that you tap on.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.826 --> 00:23:02.326 A:middle
-that intermediary
-view that you tap on.
 
 00:23:02.726 --> 00:23:06.376 A:middle
 It immediately launches into
@@ -2133,10 +2053,6 @@ Controller transitions.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:56.806 --> 00:25:00.006 A:middle
-because there's no View
-Controller transitions.
-
 00:25:00.036 --> 00:25:02.126 A:middle
 So what you need to
 do there is instead
@@ -2229,10 +2145,6 @@ those early impressions.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.786 --> 00:26:02.216 A:middle
-so that you don't miss
-those early impressions.
-
 00:26:02.876 --> 00:26:05.546 A:middle
 And with that, I'm going
 
@@ -2323,10 +2235,6 @@ delegates did finish launching
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:57.536 --> 00:27:00.866 A:middle
-and then inside our app
-delegates did finish launching
-
 00:27:01.036 --> 00:27:02.186 A:middle
 with Options Call.
 
@@ -2415,10 +2323,6 @@ interstitial requests
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.646 --> 00:28:01.176 A:middle
-we're also making
-interstitial requests
-
 00:28:01.176 --> 00:28:04.216 A:middle
 which we'll be loading
 an ad for us.
@@ -2504,9 +2408,6 @@ Pretty easy to get started.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.566 --> 00:29:01.316 A:middle
-Pretty easy to get started.
-
 00:29:01.886 --> 00:29:04.286 A:middle
 So next we're going to look
 
@@ -2577,10 +2478,6 @@ one of these things?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.936 --> 00:30:01.896 A:middle
-So how do we create
-one of these things?
 
 00:30:02.376 --> 00:30:04.496 A:middle
 As you noticed, it
@@ -2660,10 +2557,6 @@ View Delegate protocol.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.816 --> 00:31:00.366 A:middle
-to conform to the 80 Banner
-View Delegate protocol.
 
 00:31:00.696 --> 00:31:01.596 A:middle
 So we do that as well.
@@ -2745,10 +2638,6 @@ being played in the ad.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.326 --> 00:32:01.126 A:middle
-and media that are
-being played in the ad.
 
 00:32:01.396 --> 00:32:04.406 A:middle
 When it comes time to unload
@@ -2835,10 +2724,6 @@ you're positioning them often
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.216 --> 00:33:02.446 A:middle
-for medium rectangles because
-you're positioning them often
-
 00:33:02.446 --> 00:33:04.666 A:middle
 in very specific ways
 in line with content,
@@ -2923,9 +2808,6 @@ There's some text at the bottom
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.736 --> 00:34:00.766 A:middle
-There's some text at the bottom
-
 00:34:00.766 --> 00:34:03.756 A:middle
 that has some wasted white
 space, and we're going to try
@@ -3009,10 +2891,6 @@ is go to our View Controller.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.556 --> 00:35:00.526 A:middle
-the next thing we need to do
-is go to our View Controller.
-
 00:35:01.446 --> 00:35:03.616 A:middle
 We're going to go ahead and
 Import the iAd framework here
@@ -3093,10 +2971,6 @@ do some frame calculations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.316 --> 00:36:01.526 A:middle
-So all we need to do here is
-do some frame calculations
 
 00:36:01.526 --> 00:36:03.136 A:middle
 for the medium rect,
@@ -3187,10 +3061,6 @@ take any action.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.376 --> 00:37:01.226 A:middle
-We don't need to
-take any action.
 
 00:37:01.226 --> 00:37:03.636 A:middle
 If it's not, we're going
@@ -3288,10 +3158,6 @@ user's interacting with the ad.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:57.236 --> 00:38:00.606 A:middle
-on behind the scenes while the
-user's interacting with the ad.
-
 00:38:01.226 --> 00:38:02.636 A:middle
 So to do that, we're
 going to go ahead
@@ -3384,10 +3250,6 @@ ad before that media.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.406 --> 00:39:03.576 A:middle
-to play a pre-roll
-ad before that media.
-
 00:39:03.786 --> 00:39:05.426 A:middle
 When the pre-roll
 starts playing,
@@ -3469,10 +3331,6 @@ controller functionality is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.236 --> 00:40:00.516 A:middle
-the MP movie player
-controller functionality is
 
 00:40:00.516 --> 00:40:03.006 A:middle
 in the media player framework.
@@ -3560,10 +3418,6 @@ video content.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.896 --> 00:41:01.826 A:middle
-and play your original
-video content.
-
 00:41:03.426 --> 00:41:04.936 A:middle
 Once you've called
 this Play Pre-Roll Ad
@@ -3646,10 +3500,6 @@ likely to be available.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:57.416 --> 00:42:00.046 A:middle
-a pre-roll ad is more
-likely to be available.
 
 00:42:00.546 --> 00:42:02.856 A:middle
 It's all about not missing
@@ -3738,10 +3588,6 @@ times that this can happen.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.906 --> 00:43:02.686 A:middle
-There's two slightly indirect
-times that this can happen.
-
 00:43:03.056 --> 00:43:06.756 A:middle
 Many people will observe
 these two notifications
@@ -3822,10 +3668,6 @@ very simple collection view
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:57.686 --> 00:44:01.456 A:middle
-we're going to start with this
-very simple collection view
 
 00:44:01.456 --> 00:44:02.746 A:middle
 application on the phone.
@@ -3916,9 +3758,6 @@ that you want pre-roll ads.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.906 --> 00:45:00.486 A:middle
-that you want pre-roll ads.
-
 00:45:00.546 --> 00:45:03.596 A:middle
 This allows it to go ahead
 and make requests early,
@@ -3999,10 +3838,6 @@ the media player framework
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.216 --> 00:46:00.436 A:middle
-We've already imported
-the media player framework
-
 00:46:00.436 --> 00:46:02.026 A:middle
 since we're playing the videos.
 
@@ -4080,10 +3915,6 @@ pre-roll should play before it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:57.726 --> 00:47:00.706 A:middle
-if an ad is available, a
-pre-roll should play before it.
 
 00:47:01.936 --> 00:47:02.656 A:middle
 And here we go.
@@ -4175,10 +4006,6 @@ support for iPhone,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:58.516 --> 00:48:01.446 A:middle
-We have new interstitial
-support for iPhone,
-
 00:48:01.776 --> 00:48:03.966 A:middle
 which is new in iOS 7.
 
@@ -4254,10 +4081,6 @@ should speak to our director
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:58.006 --> 00:49:02.056 A:middle
-and iAd-related questions, you
-should speak to our director
 
 00:49:02.056 --> 00:49:04.876 A:middle
 of technology evangelism,

--- a/2013/614.srt
+++ b/2013/614.srt
@@ -70,10 +70,6 @@ up the app every time
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.116 --> 00:01:00.816 A:middle
-I don't have to open
-up the app every time
-
 00:01:00.816 --> 00:01:01.836 A:middle
 that I want to see an update.
 
@@ -164,10 +160,6 @@ my notifications,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.666 --> 00:02:01.426 A:middle
-where to go to get
-my notifications,
-
 00:02:01.876 --> 00:02:04.456 A:middle
 but because seeing
 the collection
@@ -246,10 +238,6 @@ notifications off completely.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.066 --> 00:03:00.416 A:middle
-I could turn those
-notifications off completely.
 
 00:03:00.446 --> 00:03:02.056 A:middle
 If it's just that
@@ -330,10 +318,6 @@ session, I like to go
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.346 --> 00:04:02.796 A:middle
-So, in this morning
-session, I like to go
-
 00:04:02.796 --> 00:04:03.466 A:middle
 through the four things.
 
@@ -409,10 +393,6 @@ to send those notifications
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:57.526 --> 00:05:01.036 A:middle
-that actually tell Safari
-to send those notifications
 
 00:05:01.036 --> 00:05:03.266 A:middle
 to the user's Notification
@@ -649,10 +629,6 @@ have to worry
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.236 --> 00:08:00.376 A:middle
-Well, you don't even
-have to worry
-
 00:08:00.376 --> 00:08:01.876 A:middle
 about memorizing this table
 
@@ -731,10 +707,6 @@ for website is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.936 --> 00:09:02.576 A:middle
-to push notifications
-for website is
-
 00:09:02.576 --> 00:09:04.196 A:middle
 to see how it works in apps.
 
@@ -808,10 +780,6 @@ are sent, APNS knows that--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.206 --> 00:10:02.616 A:middle
-And when those notifications
-are sent, APNS knows that--
-
 00:10:03.046 --> 00:10:04.516 A:middle
 from that certificate that you--
 
@@ -879,10 +847,6 @@ signature and this signature
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.436 --> 00:11:01.796 A:middle
-and you create your digital
-signature and this signature
 
 00:11:01.796 --> 00:11:03.616 A:middle
 and the push package
@@ -962,10 +926,6 @@ invitation to subscribe
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:56.766 --> 00:12:02.116 A:middle
-on Mavericks, will see an
-invitation to subscribe
-
 00:12:02.116 --> 00:12:04.856 A:middle
 to your website's
 push notification.
@@ -1034,10 +994,6 @@ your push notifications,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:57.346 --> 00:13:00.106 A:middle
-to unsubscribe from
-your push notifications,
 
 00:13:00.106 --> 00:13:01.496 A:middle
 they can go Safari preferences
@@ -1127,10 +1083,6 @@ user's default web browser.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:57.386 --> 00:14:05.356 A:middle
-to a web page in Safari or the
-user's default web browser.
-
 00:14:05.526 --> 00:14:07.566 A:middle
 OK. So we talked about
 these two things,
@@ -1204,10 +1156,6 @@ with the websites icon
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:57.506 --> 00:15:00.876 A:middle
-And it is branded
-with the websites icon
 
 00:15:01.146 --> 00:15:02.326 A:middle
 and the website's name.
@@ -1287,10 +1235,6 @@ great about push notifications
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.146 --> 00:16:01.406 A:middle
-And some other things that are
-great about push notifications
-
 00:16:01.406 --> 00:16:04.346 A:middle
 for websites is that they
 are first class citizens
@@ -1369,10 +1313,6 @@ learn a little bit more
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.156 --> 00:17:00.326 A:middle
-And now we're going to
-learn a little bit more
 
 00:17:00.326 --> 00:17:01.446 A:middle
 about how to implement it.
@@ -1472,10 +1412,6 @@ third is how your web server
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.816 --> 00:18:02.986 A:middle
-with your web server, and the
-third is how your web server
-
 00:18:02.986 --> 00:18:05.846 A:middle
 communicates with APNS to
 deliver those notifications.
@@ -1563,10 +1499,6 @@ how the code actually knows
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:56.676 --> 00:19:00.866 A:middle
-The second is how your--
-how the code actually knows
-
 00:19:00.866 --> 00:19:03.466 A:middle
 about your website or can
 identify your website.
@@ -1649,9 +1581,6 @@ to a P12 file, and that--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.446 --> 00:20:02.906 A:middle
-to a P12 file, and that--
-
 00:20:02.906 --> 00:20:06.286 A:middle
 it's that representation of your
 certificate that you will use
@@ -1731,9 +1660,6 @@ The first is default which means
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.586 --> 00:21:00.606 A:middle
-The first is default which means
 
 00:21:00.606 --> 00:21:03.076 A:middle
 that the user has never
@@ -1827,9 +1753,6 @@ and you're going to call--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.356 --> 00:22:01.236 A:middle
-and you're going to call--
-
 00:22:01.406 --> 00:22:03.226 A:middle
 you're going to pass
 in four parameters.
@@ -1912,10 +1835,6 @@ receive those notifications.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.496 --> 00:23:00.416 A:middle
-in which they want to
-receive those notifications.
-
 00:23:00.856 --> 00:23:04.156 A:middle
 Finally, you're going to
 pass a callback function
@@ -1995,10 +1914,6 @@ implement in your web service.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.166 --> 00:24:01.746 A:middle
-that you're going to have to
-implement in your web service.
 
 00:24:02.426 --> 00:24:07.396 A:middle
 So the first is when Safari
@@ -2083,10 +1998,6 @@ two different parameters.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:58.726 --> 00:25:01.016 A:middle
-And this function contains
-two different parameters.
 
 00:25:01.016 --> 00:25:04.966 A:middle
 The first is the websitePushID
@@ -2176,10 +2087,6 @@ of files formatted
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.246 --> 00:26:00.376 A:middle
-of a whole bunch
-of files formatted
-
 00:26:00.376 --> 00:26:01.846 A:middle
 and structured in
 a specific way.
@@ -2254,10 +2161,6 @@ domains that are allowed
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:57.956 --> 00:27:01.126 A:middle
-and it's just a list of
-domains that are allowed
 
 00:27:01.566 --> 00:27:06.006 A:middle
 to request permission from
@@ -2344,10 +2247,6 @@ purpose to userInfo.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.136 --> 00:28:02.286 A:middle
-and it's similar in its
-purpose to userInfo.
-
 00:28:02.846 --> 00:28:06.046 A:middle
 Remember that with userInfo,
 we were saying it's just a way
@@ -2424,10 +2323,6 @@ space that your URL needs
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:57.246 --> 00:29:00.716 A:middle
-to reduce the amount of
-space that your URL needs
 
 00:29:00.716 --> 00:29:02.296 A:middle
 in the notification
@@ -2510,10 +2405,6 @@ reason why we have this file.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.136 --> 00:30:01.646 A:middle
-So that's how we-- that's the
-reason why we have this file.
-
 00:30:02.166 --> 00:30:04.976 A:middle
 And then finally,
 you're going to sign
@@ -2585,10 +2476,6 @@ the body is just formatted
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.606 --> 00:31:02.946 A:middle
-and you'll notice that
-the body is just formatted
 
 00:31:02.996 --> 00:31:04.976 A:middle
 like a JSON object
@@ -2662,10 +2549,6 @@ deviceToken itself
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.776 --> 00:32:01.956 A:middle
-The first is the
-deviceToken itself
 
 00:32:01.956 --> 00:32:04.276 A:middle
 and that's what you're going to
@@ -2742,10 +2625,6 @@ Apps, we'll be happy to learn
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.436 --> 00:33:02.416 A:middle
-notifications for Native
-Apps, we'll be happy to learn
-
 00:33:02.416 --> 00:33:04.626 A:middle
 that it works exactly the
 same way for websites.
@@ -2820,10 +2699,6 @@ entire URL 'cause it might be
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.516 --> 00:34:00.596 A:middle
-to necessarily include the
-entire URL 'cause it might be
 
 00:34:00.596 --> 00:34:03.836 A:middle
 too long and you
@@ -2903,10 +2778,6 @@ icon and website name
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.526 --> 00:35:01.306 A:middle
-The header gets its
-icon and website name
-
 00:35:01.306 --> 00:35:05.306 A:middle
 from your push package and the
 actual notification itself comes
@@ -2982,10 +2853,6 @@ for push notifications,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.436 --> 00:36:02.646 A:middle
-So when I want to sign up
-for push notifications,
-
 00:36:03.006 --> 00:36:08.476 A:middle
 I will click the
 Subscribe button and some--
@@ -3045,10 +2912,6 @@ allowed domains it's just listed
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:57.876 --> 00:37:02.486 A:middle
-And as you can see, we have
-allowed domains it's just listed
 
 00:37:02.486 --> 00:37:04.146 A:middle
 as bayairline.com.
@@ -3114,10 +2977,6 @@ the Bay Airlines web server
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:57.176 --> 00:38:02.506 A:middle
-we sent the device token to
-the Bay Airlines web server
-
 00:38:03.096 --> 00:38:09.256 A:middle
 and in the HTTP Authorize Header
 we have the userInfo specified
@@ -3175,10 +3034,6 @@ we can either just close the
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:57.406 --> 00:39:00.916 A:middle
-over here with-- and then
-we can either just close the
 
 00:39:00.916 --> 00:39:02.436 A:middle
 notification or see more.
@@ -3244,10 +3099,6 @@ server will see when users sign
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.706 --> 00:40:03.026 A:middle
-So that is what your web
-server will see when users sign
 
 00:40:03.026 --> 00:40:06.246 A:middle
 up for Push Notifications
@@ -3335,10 +3186,6 @@ something very generic
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:58.686 --> 00:41:01.496 A:middle
-in the push package was
-something very generic
-
 00:41:01.496 --> 00:41:04.826 A:middle
 and we put the entire URL
 inside the notification payload.
@@ -3418,10 +3265,6 @@ that will never get displayed.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.396 --> 00:42:00.966 A:middle
-delivering push notifications
-that will never get displayed.
-
 00:42:01.376 --> 00:42:07.576 A:middle
 Remember to take advantage of
 the userInfo in the JavaScript
@@ -3494,10 +3337,6 @@ API ability as an example
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.726 --> 00:43:02.246 A:middle
-so you want to check for
-API ability as an example
 
 00:43:02.246 --> 00:43:03.036 A:middle
 of what that looks like.
@@ -3573,10 +3412,6 @@ contains links to lot
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.836 --> 00:44:03.316 A:middle
-for Developers page which
-contains links to lot
 
 00:44:03.316 --> 00:44:05.876 A:middle
 of different references
@@ -3665,10 +3500,6 @@ please to announce that Safari 7
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:56.096 --> 00:45:00.516 A:middle
-So just in summary, I'm really
-please to announce that Safari 7
-
 00:45:00.516 --> 00:45:02.716 A:middle
 on Mavericks now
 allows your website
@@ -3755,7 +3586,4 @@ and I'll see you at the lab.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.716 --> 00:46:03.560 A:middle
-[ Applause ]
 

--- a/2013/615.srt
+++ b/2013/615.srt
@@ -72,10 +72,6 @@ there are certain things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.956 --> 00:01:02.836 A:middle
-And what this means is that
-there are certain things
-
 00:01:02.836 --> 00:01:08.096 A:middle
 that you want to do with a
 framework like JavaScriptCore
@@ -144,10 +140,6 @@ and we want you to feel
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.166 --> 00:02:01.806 A:middle
-when you're writing Objective-C,
-and we want you to feel
 
 00:02:01.806 --> 00:02:04.366 A:middle
 like you're writing JavaScript
@@ -229,9 +221,6 @@ that interacts with the API.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.526 --> 00:03:00.836 A:middle
-that interacts with the API.
 
 00:03:01.296 --> 00:03:05.236 A:middle
 And then we'll speak to-- a
@@ -317,10 +306,6 @@ a little crazy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.896 --> 00:04:03.226 A:middle
-to drive yourself
-a little crazy.
-
 00:04:03.376 --> 00:04:06.276 A:middle
 And if I don't want to wait
 around for the random shuffle
@@ -388,10 +373,6 @@ corresponding red, green,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.066 --> 00:05:00.286 A:middle
-that maps color names to their
-corresponding red, green,
-
 00:05:00.286 --> 00:05:02.676 A:middle
 and blue value stored inside
 the JavaScript objects.
@@ -457,10 +438,6 @@ about how to get Objective-C
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.836 --> 00:06:02.756 A:middle
-So, first we're going to talk
-about how to get Objective-C
-
 00:06:02.756 --> 00:06:04.036 A:middle
 to talk to JavaScript.
 
@@ -524,10 +501,6 @@ a window object.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.496 --> 00:07:02.516 A:middle
-it corresponds to
-a window object.
 
 00:07:02.756 --> 00:07:04.736 A:middle
 There is no thing
@@ -612,10 +585,6 @@ all of those things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.626 --> 00:08:03.126 A:middle
-so JSValue keeps alive
-all of those things
-
 00:08:03.126 --> 00:08:04.436 A:middle
 that it needs to do its job.
 
@@ -682,10 +651,6 @@ you get it back from a call
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.346 --> 00:09:01.766 A:middle
-Once you have a JSValue, if
-you get it back from a call
 
 00:09:01.766 --> 00:09:03.246 A:middle
 or something, you
@@ -763,10 +728,6 @@ the context like we saw earlier.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.936 --> 00:10:03.356 A:middle
-We evaluate the script using
-the context like we saw earlier.
-
 00:10:04.776 --> 00:10:07.406 A:middle
 And since the script defines
 a single global function,
@@ -831,10 +792,6 @@ result back and we print it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:56.466 --> 00:11:01.266 A:middle
-And finally, we get the
-result back and we print it.
 
 00:11:01.706 --> 00:11:03.396 A:middle
 It should be 120, right?
@@ -985,9 +942,6 @@ The other way is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.706 --> 00:13:00.266 A:middle
-The other way is
-
 00:13:00.266 --> 00:13:03.026 A:middle
 to use something called
 the JSExport protocol
@@ -1060,10 +1014,6 @@ block takes an NSDictionary
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.116 --> 00:14:02.536 A:middle
-And you'll notice that the
-block takes an NSDictionary
-
 00:14:02.536 --> 00:14:05.526 A:middle
 of RGB values as its argument.
 
@@ -1132,10 +1082,6 @@ and it forwards that call
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.916 --> 00:15:02.486 A:middle
-Colorforword calls a function
-and it forwards that call
 
 00:15:02.486 --> 00:15:03.666 A:middle
 to the Objective-C block.
@@ -1209,9 +1155,6 @@ And it's for the same reason,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:57.496 --> 00:16:00.426 A:middle
-And it's for the same reason,
-
 00:16:00.426 --> 00:16:04.736 A:middle
 the JSContext maintains a strong
 reference to the global object
@@ -1281,10 +1224,6 @@ what it would look like.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:58.006 --> 00:17:00.126 A:middle
-So, let's take a look at
-what it would look like.
 
 00:17:00.446 --> 00:17:03.016 A:middle
 So imagine that I have a
@@ -1415,10 +1354,6 @@ MyPoint will look just exactly
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:59.536 --> 00:19:03.456 A:middle
-And then your implementation of
-MyPoint will look just exactly
-
 00:19:03.456 --> 00:19:04.606 A:middle
 like Objective-C code.
 
@@ -1501,10 +1436,6 @@ context like before.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.976 --> 00:20:00.966 A:middle
-So we allocate our
-context like before.
-
 00:20:01.576 --> 00:20:07.136 A:middle
 We evaluate some geometry script
 which I'll show you in a second.
@@ -1567,10 +1498,6 @@ the form of a JSValue
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:57.226 --> 00:21:00.206 A:middle
-We get a result back in
-the form of a JSValue
 
 00:21:00.846 --> 00:21:04.446 A:middle
 and we used two object to
@@ -1641,10 +1568,6 @@ probably aware,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:57.996 --> 00:22:00.506 A:middle
-So as you all are
-probably aware,
 
 00:22:01.096 --> 00:22:03.216 A:middle
 Objective-C uses ARC, yes.
@@ -1728,10 +1651,6 @@ you have an Objective-C object
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.476 --> 00:23:02.736 A:middle
-and what I mean by that is if
-you have an Objective-C object
-
 00:23:03.396 --> 00:23:07.866 A:middle
 that you bridge to JavaScript,
 if you add a field to it,
@@ -1804,10 +1723,6 @@ onClickHandler to itself
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:56.796 --> 00:24:00.036 A:middle
-and it also sets the buttons
-onClickHandler to itself
 
 00:24:00.036 --> 00:24:03.636 A:middle
 and then it stores the
@@ -1888,10 +1803,6 @@ set onClickHandler.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.476 --> 00:25:03.506 A:middle
-So, this is the correct
-set onClickHandler.
-
 00:25:04.616 --> 00:25:09.226 A:middle
 We take the JSValue
 that's passed to us
@@ -1965,10 +1876,6 @@ know that this edge exist
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:59.876 --> 00:26:02.916 A:middle
-about this edge, it lets it
-know that this edge exist
 
 00:26:03.366 --> 00:26:06.116 A:middle
 and that it may need to
@@ -2046,10 +1953,6 @@ about memory management,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:57.666 --> 00:27:02.406 A:middle
-So now that we talked
-about memory management,
-
 00:27:02.986 --> 00:27:05.396 A:middle
 let's talk a little
 bit about threading.
@@ -2119,10 +2022,6 @@ has its own heap
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.286 --> 00:28:00.416 A:middle
-each JSVirtualMachine
-has its own heap
 
 00:28:00.416 --> 00:28:01.806 A:middle
 and its own garbage collector.
@@ -2194,10 +2093,6 @@ executing JavaScript
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.486 --> 00:29:00.626 A:middle
-no other thread can be
-executing JavaScript
 
 00:29:00.686 --> 00:29:01.996 A:middle
 in that virtual machine.
@@ -2274,10 +2169,6 @@ the appropriate--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.966 --> 00:30:00.506 A:middle
-and we'll give you
-the appropriate--
-
 00:30:00.506 --> 00:30:01.976 A:middle
 the corresponding JSContext.
 
@@ -2345,10 +2236,6 @@ something like that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.266 --> 00:31:01.546 A:middle
-of you probably use
-something like that.
-
 00:31:03.046 --> 00:31:06.486 A:middle
 And it uses JavaScript
 to implement sort
@@ -2402,10 +2289,6 @@ extension, the editor detects
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:53.076 --> 00:32:01.766 A:middle
-And now that we have a file
-extension, the editor detects
 
 00:32:01.816 --> 00:32:05.776 A:middle
 that this is JavaScript so
@@ -2467,9 +2350,6 @@ It does strings, so string.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:57.726 --> 00:33:01.376 A:middle
-It does strings, so string.
 
 00:33:01.896 --> 00:33:05.096 A:middle
 Sure, strong, why not.
@@ -2533,9 +2413,6 @@ So that's just a brief example
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.576 --> 00:34:00.306 A:middle
-So that's just a brief example
 
 00:34:00.846 --> 00:34:04.446 A:middle
 of what's possible using
@@ -2614,10 +2491,6 @@ them inside of your web content.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.136 --> 00:35:02.476 A:middle
-your own native objects and use
-them inside of your web content.
-
 00:35:02.976 --> 00:35:08.476 A:middle
 So, the way to do this is to
 use the WebFrameLoadDelegate,
@@ -2682,9 +2555,6 @@ in the WebFrameLoadDelegate,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.506 --> 00:36:01.416 A:middle
-in the WebFrameLoadDelegate,
 
 00:36:01.416 --> 00:36:03.456 A:middle
 it replaces those old
@@ -2763,10 +2633,6 @@ MyFrameLoadDelegete
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.956 --> 00:37:03.416 A:middle
-So I defined my
-MyFrameLoadDelegete
-
 00:37:03.576 --> 00:37:05.306 A:middle
 and I override the callback.
 
@@ -2835,10 +2701,6 @@ with the JavaScriptCore C API.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:55.516 --> 00:38:00.126 A:middle
-We talked about interfacing
-with the JavaScriptCore C API.
 
 00:38:00.226 --> 00:38:02.606 A:middle
 We talked about how to
@@ -2910,10 +2772,6 @@ using the old JavaScriptCore
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:57.816 --> 00:39:01.056 A:middle
-that you might have experienced
-using the old JavaScriptCore
 
 00:39:01.056 --> 00:39:02.496 A:middle
 C API.
@@ -2991,10 +2849,6 @@ the Apple Developer Forums.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:56.226 --> 00:40:00.876 A:middle
-And of course you can go
-the Apple Developer Forums.
 
 00:40:01.146 --> 00:40:03.696 A:middle
 So related sessions, this

--- a/2013/700.srt
+++ b/2013/700.srt
@@ -80,10 +80,6 @@ thank you giving me a nice crowd
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.666 --> 00:01:00.806 A:middle
-thank you for coming today,
-thank you giving me a nice crowd
-
 00:01:00.806 --> 00:01:02.296 A:middle
 to get nervous in front of.
 
@@ -175,10 +171,6 @@ become better individuals
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:57.206 --> 00:02:00.766 A:middle
-of their everyday lives to
-become better individuals
-
 00:02:00.766 --> 00:02:04.466 A:middle
 and to really make the
 merging of the applications,
@@ -267,10 +259,6 @@ enabled by accessories.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:57.646 --> 00:03:00.476 A:middle
-And all of that is
-enabled by accessories.
-
 00:03:00.666 --> 00:03:02.016 A:middle
 All of that is enabled
 by you guys.
@@ -356,10 +344,6 @@ the 3.5-millimeter jack,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:57.946 --> 00:04:00.776 A:middle
-But also things such as
-the 3.5-millimeter jack,
-
 00:04:00.776 --> 00:04:03.706 A:middle
 the headphone jack are
 also opportunities for you
@@ -444,10 +428,6 @@ accessory manufacturing side.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.816 --> 00:05:02.906 A:middle
-as a standard and that's on the
-accessory manufacturing side.
-
 00:05:03.286 --> 00:05:06.266 A:middle
 And that's for both
 input and output devices.
@@ -528,10 +508,6 @@ to you as well.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.586 --> 00:06:00.046 A:middle
-and that's all available
-to you as well.
 
 00:06:00.536 --> 00:06:02.376 A:middle
 So next up, something new.
@@ -628,10 +604,6 @@ a great, a better experience
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.196 --> 00:07:02.946 A:middle
-really to make the game space
-a great, a better experience
-
 00:07:02.946 --> 00:07:06.376 A:middle
 than it even is today,
 and that's hard to create.
@@ -714,10 +686,6 @@ EA as we like to call it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.736 --> 00:08:02.426 A:middle
-external accessory protocol,
-EA as we like to call it.
 
 00:08:02.426 --> 00:08:04.726 A:middle
 It's the best way to have
@@ -817,10 +785,6 @@ and help everyone enjoy
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.486 --> 00:09:00.306 A:middle
-that help them use that
-and help everyone enjoy
-
 00:09:00.306 --> 00:09:03.626 A:middle
 and utilize their iOS
 device to its fullest.
@@ -892,10 +856,6 @@ quality for the consumer
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.856 --> 00:10:01.366 A:middle
-that there's a sense of
-quality for the consumer
 
 00:10:01.366 --> 00:10:01.976 A:middle
 when they go into a store.
@@ -1070,10 +1030,6 @@ highlight wireless.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:56.996 --> 00:12:00.876 A:middle
-First up, I'd like to
-highlight wireless.
-
 00:12:01.356 --> 00:12:03.146 A:middle
 We at Apple think wireless
 is a great solution,
@@ -1167,10 +1123,6 @@ details of them.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.106 --> 00:13:00.516 A:middle
-to know the technical
-details of them.
-
 00:13:01.086 --> 00:13:03.376 A:middle
 On the hardware front, a couple
 of things I want to stress,
@@ -1261,10 +1213,6 @@ avoid audio dropouts
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:57.016 --> 00:14:00.196 A:middle
-experience, so, to
-avoid audio dropouts
-
 00:14:00.436 --> 00:14:04.416 A:middle
 and communication breakdowns
 and the fact that if you walk
@@ -1354,9 +1302,6 @@ to start running out addresses.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:59.986 --> 00:15:01.426 A:middle
-to start running out addresses.
-
 00:15:01.816 --> 00:15:05.376 A:middle
 And so we at Apple, believe
 strongly we should all be making
@@ -1438,10 +1383,6 @@ them to bring something home,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:58.826 --> 00:16:00.966 A:middle
-It should just be easy for
-them to bring something home,
 
 00:16:00.966 --> 00:16:03.046 A:middle
 put it on their network
@@ -1540,10 +1481,6 @@ obviously you can talk to us
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.276 --> 00:17:02.476 A:middle
-about general functionality,
-obviously you can talk to us
-
 00:17:02.476 --> 00:17:04.685 A:middle
 in the accessory labs or I'm
 sure you can find someone
@@ -1635,9 +1572,6 @@ Well, we agreed and now you can.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.756 --> 00:18:01.656 A:middle
-Well, we agreed and now you can.
 
 00:18:02.636 --> 00:18:05.746 A:middle
 So, what I'm showing you
@@ -1817,10 +1751,6 @@ Program and we're super excited
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.896 --> 00:20:02.596 A:middle
-It's going to be part of the MFi
-Program and we're super excited
-
 00:20:02.596 --> 00:20:05.656 A:middle
 to have people come and talk to
 us about how you implement this.
@@ -1910,10 +1840,6 @@ of compliance, same everything.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:59.336 --> 00:21:03.486 A:middle
-same feature set, same terms
-of compliance, same everything.
 
 00:21:03.656 --> 00:21:04.596 A:middle
 It's just that now you get
@@ -2005,10 +1931,6 @@ session to this
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:57.986 --> 00:22:00.356 A:middle
-We do have a followup
-session to this
-
 00:22:00.356 --> 00:22:04.076 A:middle
 that specifically covers Core
 Bluetooth in a lot more detail.
@@ -2088,9 +2010,6 @@ And this year is no different.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.756 --> 00:23:01.406 A:middle
-And this year is no different.
 
 00:23:01.406 --> 00:23:04.046 A:middle
 We're seeing more and
@@ -2177,10 +2096,6 @@ to the Bluetooth SIG,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.536 --> 00:24:01.636 A:middle
-and have been provided
-to the Bluetooth SIG,
 
 00:24:02.196 --> 00:24:05.806 A:middle
 we're going to surpass a billion
@@ -2373,10 +2288,6 @@ and your phone will tell you,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.396 --> 00:27:01.626 A:middle
-So, like you can go eat a bagel
-and your phone will tell you,
-
 00:27:01.906 --> 00:27:04.356 A:middle
 "Dude, your blood sugar level
 is spiking, you may not want
@@ -2453,10 +2364,6 @@ in California, it's just peace
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.776 --> 00:28:01.846 A:middle
-They live in Arizona, I live
-in California, it's just peace
 
 00:28:01.846 --> 00:28:04.036 A:middle
 of mind, but they
@@ -2549,10 +2456,6 @@ conversations
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.126 --> 00:29:00.206 A:middle
-and I remember having
-conversations
-
 00:29:00.206 --> 00:29:03.066 A:middle
 with some chip guys and they
 literally laughed at us,
@@ -2638,10 +2541,6 @@ I'm giving you based
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.116 --> 00:30:01.396 A:middle
-of those sneak peeks
-I'm giving you based
-
 00:30:01.396 --> 00:30:05.056 A:middle
 on our Core Bluetooth session,
 but this idea of improved--
@@ -2724,10 +2623,6 @@ butt and go exercise."
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.436 --> 00:31:02.816 A:middle
-But it says, "Get off your
-butt and go exercise."
 
 00:31:02.816 --> 00:31:03.676 A:middle
 It's a great product.
@@ -2814,10 +2709,6 @@ basketball, there is a product
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.966 --> 00:32:03.166 A:middle
-In addition to that in
-basketball, there is a product
-
 00:32:03.166 --> 00:32:06.976 A:middle
 by 94Fifty, a smart ball that
 does very similar things,
@@ -2901,9 +2792,6 @@ So the third thing is security
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.376 --> 00:33:00.896 A:middle
-So the third thing is security
-
 00:33:01.386 --> 00:33:05.326 A:middle
 and security is kind
 of snuck up on us.
@@ -2977,10 +2865,6 @@ my plumber, for example,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:58.946 --> 00:34:01.136 A:middle
-So if I want to allow
-my plumber, for example,
 
 00:34:01.136 --> 00:34:04.056 A:middle
 to get in my home,
@@ -3066,10 +2950,6 @@ obviously an area
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.746 --> 00:35:01.166 A:middle
-Game controller is
-obviously an area
-
 00:35:01.166 --> 00:35:04.746 A:middle
 where Bluetooth low energy
 is perfect for this space.
@@ -3144,10 +3024,6 @@ this is the first time
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.816 --> 00:36:03.156 A:middle
-in both platforms is
-this is the first time
 
 00:36:03.426 --> 00:36:07.276 A:middle
 that we have supported
@@ -3227,10 +3103,6 @@ about security,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.796 --> 00:37:00.786 A:middle
-we already talked
-about security,
-
 00:37:01.206 --> 00:37:05.796 A:middle
 advertising the ability
 to go into a retail space,
@@ -3306,10 +3178,6 @@ App Preservation Restoration.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.766 --> 00:38:01.746 A:middle
-about here, Core Bluetooth
-App Preservation Restoration.
 
 00:38:02.056 --> 00:38:04.766 A:middle
 I know it's an interesting
@@ -3392,10 +3260,6 @@ about it to add it twice.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.676 --> 00:39:01.516 A:middle
-Apparently, we thought enough
-about it to add it twice.
-
 00:39:01.976 --> 00:39:05.676 A:middle
 And-- but anyway, we did
 give you the ability now
@@ -3476,10 +3340,6 @@ current time service is also
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.416 --> 00:40:02.016 A:middle
-And then finally, the
-current time service is also
 
 00:40:02.016 --> 00:40:02.906 A:middle
 always available.
@@ -3564,10 +3424,6 @@ of transferring both data and
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.836 --> 00:41:01.156 A:middle
-of transferring both data and
-[inaudible] digital video,
-
 00:41:01.156 --> 00:41:06.136 A:middle
 namely DisplayPort, at really
 high speeds and it can handle--
@@ -3642,9 +3498,6 @@ And the reason
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.916 --> 00:42:01.056 A:middle
-And the reason
 
 00:42:01.056 --> 00:42:02.826 A:middle
 that certification
@@ -3730,10 +3583,6 @@ still quite fast,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.516 --> 00:43:02.756 A:middle
-USB throughput is
-still quite fast,
-
 00:43:03.666 --> 00:43:05.326 A:middle
 although not quite
 as fast Thunderbolt.
@@ -3811,10 +3660,6 @@ Lightning last fall, of course.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:57.036 --> 00:44:02.656 A:middle
-because we did talk a lot about
-Lightning last fall, of course.
 
 00:44:02.896 --> 00:44:05.076 A:middle
 But to briefly summarize,
@@ -3900,10 +3745,6 @@ with Lightning.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.986 --> 00:45:00.066 A:middle
-You won't have that
-with Lightning.
 
 00:45:01.226 --> 00:45:02.866 A:middle
 Lightning connectors
@@ -3991,10 +3832,6 @@ of its data transmission.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.716 --> 00:46:01.876 A:middle
-is multifaceted in terms
-of its data transmission.
-
 00:46:02.326 --> 00:46:03.916 A:middle
 That supports multiple types
 
@@ -4073,10 +3910,6 @@ of going back to why--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.296 --> 00:47:01.566 A:middle
-very low power, kind
-of going back to why--
 
 00:47:01.566 --> 00:47:03.566 A:middle
 the question about drawing
@@ -4160,10 +3993,6 @@ feature one more time
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.676 --> 00:48:02.086 A:middle
-up the game controller
-feature one more time
 
 00:48:02.706 --> 00:48:05.466 A:middle
 and I'm mentioning

--- a/2013/701.srt
+++ b/2013/701.srt
@@ -55,10 +55,6 @@ life is key for mobility.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.546 --> 00:01:02.156 A:middle
-for our customers and battery
-life is key for mobility.
-
 00:01:02.816 --> 00:01:08.686 A:middle
 Now, mobility has always
 been an important feature.
@@ -138,10 +134,6 @@ last all day, they would plug it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.506 --> 00:02:03.396 A:middle
-of the time their battery would
-last all day, they would plug it
-
 00:02:03.396 --> 00:02:04.856 A:middle
 in at night and that was it.
 
@@ -210,10 +202,6 @@ know if this is Mavericks,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.246 --> 00:03:03.986 A:middle
-they've got the-- I don't
-know if this is Mavericks,
 
 00:03:04.056 --> 00:03:07.236 A:middle
 probably isn't Mavericks
@@ -287,10 +275,6 @@ detail on how we get there,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.386 --> 00:04:02.246 A:middle
-Now, I'll go into some
-detail on how we get there,
-
 00:04:02.656 --> 00:04:06.496 A:middle
 it's actually there's a
 lot of ingredients that go
@@ -360,10 +344,6 @@ nanoscale and the architecture
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:56.416 --> 00:05:01.336 A:middle
-both at the atomic scale, the
-nanoscale and the architecture
 
 00:05:01.336 --> 00:05:05.506 A:middle
 of the chip itself, that's
@@ -445,10 +425,6 @@ application is using energy
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:57.116 --> 00:06:00.346 A:middle
-take a closer look at how your
-application is using energy
-
 00:06:00.796 --> 00:06:06.196 A:middle
 and try and maximize the
 efficiency to give that customer
@@ -517,10 +493,6 @@ Mac 512 back in 1984.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.076 --> 00:07:01.396 A:middle
-into the Mac 128K and
-Mac 512 back in 1984.
-
 00:07:01.896 --> 00:07:08.506 A:middle
 Now, that chip had oddly enough,
 around 68,000 transistors on it.
@@ -581,10 +553,6 @@ just got smaller but again,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.426 --> 00:08:02.426 A:middle
-of course the transistors
-just got smaller but again,
 
 00:08:02.426 --> 00:08:04.526 A:middle
 this chip is running
@@ -748,10 +716,6 @@ thickness of the gate.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.386 --> 00:10:00.226 A:middle
-so you can increase the
-thickness of the gate.
-
 00:10:00.876 --> 00:10:03.806 A:middle
 And then finally,
 most recently in 2011,
@@ -831,10 +795,6 @@ brain its taking on the order
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:57.046 --> 00:11:00.806 A:middle
-when a neuron fires in your
-brain its taking on the order
-
 00:11:00.806 --> 00:11:03.516 A:middle
 of picojoules, about a
 thousand times as much.
@@ -900,10 +860,6 @@ the memory manager and some
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:56.456 --> 00:12:00.576 A:middle
-There's the shared L2 cache,
-the memory manager and some
 
 00:12:00.576 --> 00:12:02.556 A:middle
 of the things for managing DMA.
@@ -991,10 +947,6 @@ the chip as its executing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.336 --> 00:13:02.886 A:middle
-at the heat waves coming off
-the chip as its executing.
-
 00:13:03.466 --> 00:13:06.696 A:middle
 So, the blue spots
 are cooler, the orange
@@ -1066,10 +1018,6 @@ the GPU to be done.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.816 --> 00:14:00.526 A:middle
-It's waiting for
-the GPU to be done.
 
 00:14:00.766 --> 00:14:04.616 A:middle
 A lot of the time in modern chip
@@ -1149,10 +1097,6 @@ to the backlight.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.486 --> 00:15:00.016 A:middle
-of power is going
-to the backlight.
 
 00:15:00.016 --> 00:15:01.586 A:middle
 It maybe go into Wi-Fi,
@@ -1372,10 +1316,6 @@ are pretty huge gaps
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.796 --> 00:18:02.036 A:middle
-We see that there
-are pretty huge gaps
-
 00:18:02.036 --> 00:18:04.996 A:middle
 where you could literally
 execute tens of thousands
@@ -1447,10 +1387,6 @@ up with the rest of the chip
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.976 --> 00:19:02.136 A:middle
-You have to get it to sync
-up with the rest of the chip
 
 00:19:02.136 --> 00:19:04.746 A:middle
 and then finally,
@@ -1531,9 +1467,6 @@ you're powering the chip,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.746 --> 00:20:00.736 A:middle
-you're powering the chip,
-
 00:20:00.786 --> 00:20:03.466 A:middle
 you're not doing any useful
 work, that's wasted power.
@@ -1609,10 +1542,6 @@ how perhaps that interacts
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.096 --> 00:21:01.666 A:middle
-that interacts with App Nap,
-how perhaps that interacts
-
 00:21:01.666 --> 00:21:04.066 A:middle
 with the application you're
 writing, how you can do
@@ -1682,10 +1611,6 @@ aspect of the system making it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:57.236 --> 00:22:00.616 A:middle
-And if you want to improve any
-aspect of the system making it
 
 00:22:00.616 --> 00:22:02.436 A:middle
 so you can measure that is key
@@ -1765,10 +1690,6 @@ energy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.476 --> 00:23:01.656 A:middle
-which are using significant
-energy.
-
 00:23:02.466 --> 00:23:08.776 A:middle
 Now, in many cases, that will
 be entirely expected and desired
@@ -1830,10 +1751,6 @@ surrogate for trying to look
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.206 --> 00:24:02.966 A:middle
-So, energy impact is a
-surrogate for trying to look
 
 00:24:02.966 --> 00:24:05.536 A:middle
 at the energy impact
@@ -1979,10 +1896,6 @@ app might be using energy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:57.546 --> 00:26:00.956 A:middle
-to investigate why this
-app might be using energy.
-
 00:26:01.356 --> 00:26:07.226 A:middle
 So, in the latest Xcode, we have
 what's called the Energy Gauge,
@@ -2059,10 +1972,6 @@ bit more detail
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.056 --> 00:27:00.616 A:middle
-I'll go into little
-bit more detail
 
 00:27:00.616 --> 00:27:03.396 A:middle
 into what App Nap is actually
@@ -2142,10 +2051,6 @@ interested in results.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.786 --> 00:28:00.116 A:middle
-where they're really
-interested in results.
 
 00:28:00.516 --> 00:28:03.176 A:middle
 But the apps that
@@ -2231,9 +2136,6 @@ So, what do we do?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.356 --> 00:29:00.196 A:middle
-So, what do we do?
-
 00:29:00.256 --> 00:29:04.636 A:middle
 Well, we will adjust CPU
 and I/O prioritization.
@@ -2312,10 +2214,6 @@ thing in App Nap.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.476 --> 00:30:01.346 A:middle
-so we can do the right
-thing in App Nap.
-
 00:30:03.036 --> 00:30:05.206 A:middle
 So, Timer Coalescing.
 
@@ -2384,10 +2282,6 @@ system how much leeway
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:56.526 --> 00:31:00.516 A:middle
-that lets you tell the
-system how much leeway
 
 00:31:00.516 --> 00:31:05.586 A:middle
 or how much tolerance you can
@@ -2462,9 +2356,6 @@ So, here we have an example
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.376 --> 00:32:02.186 A:middle
-So, here we have an example
-
 00:32:02.506 --> 00:32:08.016 A:middle
 and what you've done is really
 reclaim that wasted energy due
@@ -2537,10 +2428,6 @@ them out.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.846 --> 00:33:01.266 A:middle
-and essentially stretch
-them out.
-
 00:33:01.986 --> 00:33:07.216 A:middle
 So, we will let those timers
 execute but let them execute
@@ -2612,10 +2499,6 @@ is-- comes up in preview mode,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:57.956 --> 00:34:03.806 A:middle
-This is Photo Booth, Photo Booth
-is-- comes up in preview mode,
-
 00:34:03.806 --> 00:34:05.206 A:middle
 it turns on the camera,
 
@@ -2680,10 +2563,6 @@ helps the system as a whole,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:55.406 --> 00:35:01.066 A:middle
-that you can use really
-helps the system as a whole,
 
 00:35:01.456 --> 00:35:03.126 A:middle
 give the user the
@@ -2758,10 +2637,6 @@ battery, but it's a task
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:59.086 --> 00:36:01.206 A:middle
-use up some of your
-battery, but it's a task
 
 00:36:01.206 --> 00:36:04.016 A:middle
 that can wait hours
@@ -2851,9 +2726,6 @@ to go more than a few hours.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.196 --> 00:37:00.486 A:middle
-to go more than a few hours.
-
 00:37:00.696 --> 00:37:03.286 A:middle
 Whatever that is, you tell
 the system through this API.
@@ -2927,10 +2799,6 @@ you have a block of code.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.966 --> 00:38:02.306 A:middle
-So, XPC is one example where
-you have a block of code.
 
 00:38:02.306 --> 00:38:05.276 A:middle
 It's going to execute
@@ -3008,10 +2876,6 @@ have a separate process per tab.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:55.276 --> 00:39:01.026 A:middle
-Well, since in Safari, we now
-have a separate process per tab.
-
 00:39:01.436 --> 00:39:04.696 A:middle
 We can use those same techniques
 we talked about in App Nap
@@ -3071,10 +2935,6 @@ plug-ins that are not the center
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:55.266 --> 00:40:00.276 A:middle
-And what it does is for
-plug-ins that are not the center
 
 00:40:00.276 --> 00:40:04.926 A:middle
 of your browsing
@@ -3158,10 +3018,6 @@ to talk about not just this
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.266 --> 00:41:00.876 A:middle
-because the Safari team is going
-to talk about not just this
-
 00:41:00.876 --> 00:41:04.226 A:middle
 but also what you should do as
 a web developer to make sure
@@ -3243,9 +3099,6 @@ That's going to help everything.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.706 --> 00:42:00.856 A:middle
-That's going to help everything.
-
 00:42:00.856 --> 00:42:02.426 A:middle
 That's going to help
 responsiveness.
@@ -3322,9 +3175,6 @@ do I have high-frequency timers
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:58.646 --> 00:43:00.246 A:middle
-do I have high-frequency timers
-
 00:43:00.816 --> 00:43:03.426 A:middle
 that could have some
 tolerance introduce
@@ -3397,10 +3247,6 @@ XPC, I mentioned before
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.086 --> 00:44:02.416 A:middle
-Efficient Design with
-XPC, I mentioned before
-
 00:44:03.356 --> 00:44:06.726 A:middle
 and that's an area where
 you again can take advantage
@@ -3470,10 +3316,6 @@ most important feature to them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.566 --> 00:45:03.556 A:middle
-for users becomes almost the
-most important feature to them.
 
 00:45:03.906 --> 00:45:06.246 A:middle
 More and more you see

--- a/2013/702.srt
+++ b/2013/702.srt
@@ -69,10 +69,6 @@ getting a service up and running
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.136 --> 00:01:02.416 A:middle
-So, everything relating to
-getting a service up and running
-
 00:01:02.416 --> 00:01:05.596 A:middle
 and talking to it,
 exchanging messages,
@@ -161,10 +157,6 @@ side of this coin,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.996 --> 00:02:01.236 A:middle
-And also, on the other
-side of this coin,
-
 00:02:01.446 --> 00:02:03.726 A:middle
 you'll have a different
 set of privilege levels
@@ -252,10 +244,6 @@ Services.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.956 --> 00:03:01.476 A:middle
-The main one is Bundled
-Services.
 
 00:03:01.476 --> 00:03:03.676 A:middle
 These are the things that
@@ -348,10 +336,6 @@ additional capabilities.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:57.856 --> 00:04:00.336 A:middle
-to write, but you do get
-additional capabilities.
-
 00:04:00.376 --> 00:04:02.256 A:middle
 You can run as root for one,
 
@@ -431,10 +415,6 @@ down at the libSystem Layer
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:59.426 --> 00:05:02.366 A:middle
-that we just really can't do
-down at the libSystem Layer
 
 00:05:02.366 --> 00:05:04.086 A:middle
 where the C Library exits.
@@ -523,10 +503,6 @@ things to initialize lazily.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.076 --> 00:06:02.246 A:middle
-And finally, we want
-things to initialize lazily.
-
 00:06:02.246 --> 00:06:04.526 A:middle
 So this goes with
 the on-demand theme.
@@ -600,10 +576,6 @@ Distributed Notifications.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:58.396 --> 00:07:01.206 A:middle
-we also introduced CF
-Distributed Notifications.
 
 00:07:01.356 --> 00:07:04.096 A:middle
 So if that's your preferred
@@ -693,10 +665,6 @@ key and set it to true,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:57.576 --> 00:08:01.216 A:middle
-to add this IOMatchLaunchStream
-key and set it to true,
-
 00:08:01.606 --> 00:08:04.486 A:middle
 just do that, I won't
 explain why.
@@ -776,9 +744,6 @@ and then you can reconstruct it
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.526 --> 00:09:00.916 A:middle
-and then you can reconstruct it
 
 00:09:00.916 --> 00:09:04.966 A:middle
 and turn it into
@@ -867,10 +832,6 @@ certain tasks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.776 --> 00:10:00.786 A:middle
-because we can take
-certain tasks
 
 00:10:00.786 --> 00:10:02.766 A:middle
 that have similar
@@ -963,10 +924,6 @@ is asleep.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.886 --> 00:11:00.116 A:middle
-and whether the screen
-is asleep.
-
 00:11:00.116 --> 00:11:03.086 A:middle
 So we can actually do your
 work while the user is, say,
@@ -1051,10 +1008,6 @@ we have a 10-minute slack time.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.566 --> 00:12:02.656 A:middle
-And the grace periods, you know,
-we have a 10-minute slack time.
-
 00:12:02.656 --> 00:12:04.956 A:middle
 So it's like we'd like every
 five minutes but it's okay
@@ -1135,10 +1088,6 @@ app is killed before it can be
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:59.456 --> 00:13:03.346 A:middle
-let's-- and then let's say the
-app is killed before it can be
 
 00:13:03.346 --> 00:13:06.526 A:middle
 invoked, we'll bring you back
@@ -1225,10 +1174,6 @@ as the last one goes away
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.126 --> 00:14:01.006 A:middle
-and that means that as soon
-as the last one goes away
 
 00:14:01.136 --> 00:14:03.436 A:middle
 or as soon as the last reply is
@@ -1319,10 +1264,6 @@ now for bundled services.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.686 --> 00:15:01.086 A:middle
-And this is the default behavior
-now for bundled services.
-
 00:15:01.276 --> 00:15:03.646 A:middle
 And what happens is that they
 are background by default.
@@ -1410,10 +1351,6 @@ services by default.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.996 --> 00:16:03.366 A:middle
-So that's bundled XPC
-services by default.
-
 00:16:03.366 --> 00:16:06.436 A:middle
 But if you have a launchd job,
 you can also opt into this.
@@ -1489,10 +1426,6 @@ its UI in response to something
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.356 --> 00:17:01.226 A:middle
-So it's not supposed to update
-its UI in response to something
 
 00:17:01.226 --> 00:17:02.566 A:middle
 that that launchd job is doing.
@@ -1584,10 +1517,6 @@ some work asynchronously.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:58.646 --> 00:18:01.206 A:middle
-And then we're going to do
-some work asynchronously.
-
 00:18:01.466 --> 00:18:03.296 A:middle
 Since we're using
 ARC in this example,
@@ -1672,10 +1601,6 @@ connection, you just give Null
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:56.786 --> 00:19:00.346 A:middle
-And to create that
-connection, you just give Null
 
 00:19:00.346 --> 00:19:02.556 A:middle
 as the first parameter
@@ -1920,10 +1845,6 @@ very large data objects.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:58.486 --> 00:22:02.596 A:middle
-The runtime recognizes
-very large data objects.
-
 00:22:02.686 --> 00:22:06.516 A:middle
 And when it sees one of these,
 it goes down a fast path
@@ -1998,10 +1919,6 @@ the characteristics of.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.006 --> 00:23:01.596 A:middle
-and created and know
-the characteristics of.
-
 00:23:01.676 --> 00:23:03.946 A:middle
 And here's why that
 part is important.
@@ -2075,10 +1992,6 @@ a password in there.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.696 --> 00:24:01.076 A:middle
-And there might be
-a password in there.
 
 00:24:01.076 --> 00:24:03.346 A:middle
 There could be any
@@ -2157,9 +2070,6 @@ So here's how you do it in code.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.456 --> 00:25:00.856 A:middle
-So here's how you do it in code.
-
 00:25:00.856 --> 00:25:02.816 A:middle
 So we create that
 dispatch data object
@@ -2234,10 +2144,6 @@ free bridge with NSData.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.986 --> 00:26:01.916 A:middle
-dispatch data is toll
-free bridge with NSData.
 
 00:26:02.206 --> 00:26:05.776 A:middle
 So you can create a dispatch
@@ -2323,10 +2229,6 @@ a message
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.276 --> 00:27:00.196 A:middle
-So the act of receiving
-a message
 
 00:27:00.246 --> 00:27:03.376 A:middle
 in prior releases would end
@@ -2417,10 +2319,6 @@ get one of these messages
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:57.636 --> 00:28:00.136 A:middle
-So, for example, if you
-get one of these messages
 
 00:28:00.246 --> 00:28:03.476 A:middle
 and then you start-- and then
@@ -2574,10 +2472,6 @@ guarantee for message delivery.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.056 --> 00:30:01.396 A:middle
-and it can actually make a
-guarantee for message delivery.
-
 00:30:02.046 --> 00:30:05.276 A:middle
 So once you have this guarantee,
 there's really no reason
@@ -2646,10 +2540,6 @@ mismanagement of resources
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:57.566 --> 00:31:00.016 A:middle
-or there's kind of
-mismanagement of resources
 
 00:31:00.016 --> 00:31:02.606 A:middle
 that prevented the server from
@@ -2741,9 +2631,6 @@ and I should investigate.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.446 --> 00:32:00.436 A:middle
-and I should investigate.
-
 00:32:00.896 --> 00:32:06.046 A:middle
 That being said, there
 are cases where IPC--
@@ -2825,10 +2712,6 @@ there's really no need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.746 --> 00:33:02.406 A:middle
-that you've given it,
-there's really no need
-
 00:33:02.566 --> 00:33:04.696 A:middle
 to keep waiting for it.
 
@@ -2902,10 +2785,6 @@ to do any other work.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.956 --> 00:34:03.056 A:middle
-You don't actually have
-to do any other work.
-
 00:34:04.606 --> 00:34:04.976 A:middle
 [applause] Yeah.
 
@@ -2973,10 +2852,6 @@ try and talk to their service,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:58.686 --> 00:35:01.776 A:middle
-And then, immediately, when they
-try and talk to their service,
 
 00:35:01.776 --> 00:35:03.736 A:middle
 they get a connection
@@ -3059,10 +2934,6 @@ will have dollar, you know,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:57.036 --> 00:36:00.136 A:middle
-it will actually be-- it
-will have dollar, you know,
-
 00:36:00.176 --> 00:36:03.246 A:middle
 product identifier that gets
 filled in at build time.
@@ -3136,10 +3007,6 @@ tell-tale sign for this is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.846 --> 00:37:01.036 A:middle
-And you'll-- the
-tell-tale sign for this is
 
 00:37:01.036 --> 00:37:04.356 A:middle
 that you'll see an illegal
@@ -3215,10 +3082,6 @@ Over-release of an object.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:57.436 --> 00:38:00.396 A:middle
-and it says API MISUSE:
-Over-release of an object.
-
 00:38:00.466 --> 00:38:04.086 A:middle
 So in this case, we called
 XPC release more times
@@ -3287,10 +3150,6 @@ to make sense of it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.636 --> 00:39:01.806 A:middle
-because we now how
-to make sense of it.
 
 00:39:02.136 --> 00:39:05.196 A:middle
 If you're curious, it's just
@@ -3371,10 +3230,6 @@ Include XPC and then all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.436 --> 00:40:01.936 A:middle
-So, look in User
-Include XPC and then all
 
 00:40:01.936 --> 00:40:05.186 A:middle
 of those public interfaces

--- a/2013/703.srt
+++ b/2013/703.srt
@@ -70,10 +70,6 @@ show booths walls.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.866 --> 00:01:02.506 A:middle
-I saw it in trade
-show booths walls.
-
 00:01:02.506 --> 00:01:04.465 A:middle
 I saw it in people's shirts.
 
@@ -153,10 +149,6 @@ and visits and conversations
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:57.396 --> 00:02:00.556 A:middle
-as well as all the phone calls
-and visits and conversations
 
 00:02:00.556 --> 00:02:04.616 A:middle
 that we've had over the
@@ -238,10 +230,6 @@ around all the areas,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.496 --> 00:03:01.086 A:middle
-to you guys about,
-around all the areas,
 
 00:03:01.446 --> 00:03:03.316 A:middle
 healthcare for example.
@@ -331,9 +319,6 @@ So, Renaud?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:59.626 --> 00:04:01.056 A:middle
-[Applause]
 
 00:04:01.056 --> 00:04:02.856 A:middle
 &gt;&gt; Thank you, Brian.
@@ -485,10 +470,6 @@ report for all coverage of APIs
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.316 --> 00:06:05.306 A:middle
-In 2011, we had a simulator's
-report for all coverage of APIs
-
 00:06:05.306 --> 00:06:07.606 A:middle
 because low energy was
 an emerging market.
@@ -568,10 +549,6 @@ able to buy from third parties
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.936 --> 00:07:03.116 A:middle
-goals that you guys may be
-able to buy from third parties
 
 00:07:03.276 --> 00:07:04.486 A:middle
 that you can plug on your Mac.
@@ -660,10 +637,6 @@ didn't have UUID class
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:56.526 --> 00:08:00.956 A:middle
-Another time in 2011, we
-didn't have UUID class
-
 00:08:00.956 --> 00:08:02.066 A:middle
 in the foundation framework.
 
@@ -747,9 +720,6 @@ We didn't like it.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.396 --> 00:09:00.196 A:middle
-We didn't like it.
 
 00:09:00.196 --> 00:09:00.946 A:middle
 You didn't like it.
@@ -849,10 +819,6 @@ be simple Boolean
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.496 --> 00:10:00.616 A:middle
-And we have the folders
-be simple Boolean
-
 00:10:00.616 --> 00:10:02.666 A:middle
 that told you whether a
 peripheral was connected or not.
@@ -933,10 +899,6 @@ that are not proper--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:57.596 --> 00:11:00.076 A:middle
-and fixing of things we--
-that are not proper--
 
 00:11:00.076 --> 00:11:02.756 A:middle
 that were not proper previously.
@@ -1038,9 +1000,6 @@ on the unnecessary conversation.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.946 --> 00:12:01.636 A:middle
-on the unnecessary conversation.
 
 00:12:02.526 --> 00:12:05.986 A:middle
 So in iOS 6, we are currently
@@ -1231,10 +1190,6 @@ about this.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:58.836 --> 00:14:00.366 A:middle
-So we're really excited
-about this.
-
 00:14:00.366 --> 00:14:01.846 A:middle
 We think this is--
 this can be great
@@ -1410,10 +1365,6 @@ do is take a page from Wi-Fi
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.556 --> 00:16:03.426 A:middle
-we figure that the least we can
-do is take a page from Wi-Fi
-
 00:16:03.426 --> 00:16:05.126 A:middle
 and try to make things
 go a little faster.
@@ -1507,10 +1458,6 @@ put a very small amount
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:57.426 --> 00:17:00.496 A:middle
-for the default you can
-put a very small amount
-
 00:17:00.496 --> 00:17:01.756 A:middle
 of data on each train.
 
@@ -1596,10 +1543,6 @@ that streamed large amounts
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.776 --> 00:18:02.256 A:middle
-So we wrote a test app
-that streamed large amounts
 
 00:18:02.256 --> 00:18:05.316 A:middle
 of data via notifications,
@@ -1692,10 +1635,6 @@ faster, faster, faster.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.316 --> 00:19:00.336 A:middle
-to make things faster,
-faster, faster, faster.
 
 00:19:00.336 --> 00:19:03.006 A:middle
 But for all of you who are
@@ -1794,10 +1733,6 @@ aware, there's a problem.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.136 --> 00:20:00.806 A:middle
-But as many of you may be
-aware, there's a problem.
-
 00:20:01.656 --> 00:20:04.066 A:middle
 Because while your application
 is running in the background,
@@ -1891,10 +1826,6 @@ yes, but we've come
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:58.966 --> 00:21:01.196 A:middle
-And not only is it
-yes, but we've come
 
 00:21:01.196 --> 00:21:02.346 A:middle
 up with a really simple way
@@ -1993,10 +1924,6 @@ for those of you who don't run
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.776 --> 00:22:03.616 A:middle
-So this is an optional feature,
-for those of you who don't run
-
 00:22:03.616 --> 00:22:05.786 A:middle
 into the background or
 who aren't interested
@@ -2086,10 +2013,6 @@ may keep track of everything
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:59.686 --> 00:23:02.316 A:middle
-And the peripheral manager side
-may keep track of everything
 
 00:23:02.316 --> 00:23:04.966 A:middle
 as well, what you're
@@ -2182,10 +2105,6 @@ one delegate callback
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.936 --> 00:24:00.636 A:middle
-It's going to get that
-one delegate callback
-
 00:24:00.636 --> 00:24:02.056 A:middle
 where we give you
 back all the state
@@ -2275,10 +2194,6 @@ familiar for any of you
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.746 --> 00:25:02.586 A:middle
-But it should look pretty
-familiar for any of you
 
 00:25:02.586 --> 00:25:04.446 A:middle
 who have worked with
@@ -2565,10 +2480,6 @@ central manger object.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:59.906 --> 00:28:02.516 A:middle
-where we instantiate our
-central manger object.
-
 00:28:02.826 --> 00:28:06.526 A:middle
 And we're going to move
 it to a new init method.
@@ -2663,9 +2574,6 @@ OK, so now, we've opted-in.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:59.986 --> 00:29:02.416 A:middle
-OK, so now, we've opted-in.
 
 00:29:02.416 --> 00:29:04.956 A:middle
 And I said, the second thing
@@ -2847,10 +2755,6 @@ applications this might be
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:59.546 --> 00:31:01.756 A:middle
-Now, for some of your
-applications this might be
 
 00:31:01.756 --> 00:31:04.166 A:middle
 enough, really simple we
@@ -3049,9 +2953,6 @@ to discover that characteristic.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.646 --> 00:33:00.756 A:middle
-to discover that characteristic.
-
 00:33:01.406 --> 00:33:05.026 A:middle
 And finally, we're going to
 look and see, are we subscribed
@@ -3134,10 +3035,6 @@ the restored managers
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.236 --> 00:34:00.306 A:middle
-of the identifiers representing
-the restored managers
 
 00:34:00.306 --> 00:34:03.296 A:middle
 that we've been keeping track
@@ -3232,10 +3129,6 @@ call
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.986 --> 00:35:00.906 A:middle
-we changed the initialization
-call
-
 00:35:00.906 --> 00:35:03.096 A:middle
 to provide a restore
 identifier for it.
@@ -3325,9 +3218,6 @@ Four years if I count correctly.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.836 --> 00:36:00.466 A:middle
-Four years if I count correctly.
 
 00:36:01.026 --> 00:36:02.466 A:middle
 And as you see you guys come up,
@@ -3419,10 +3309,6 @@ away therefore giving this
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.276 --> 00:37:02.826 A:middle
-to it if the connection goes
-away therefore giving this
-
 00:37:02.826 --> 00:37:05.276 A:middle
 illusion that it works just
 like a normal Bluetooth device
@@ -3502,10 +3388,6 @@ on the markets,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.116 --> 00:38:02.036 A:middle
-of accessories going
-on the markets,
 
 00:38:02.586 --> 00:38:05.076 A:middle
 the so called "Companion
@@ -3591,10 +3473,6 @@ Notification Service.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.906 --> 00:39:01.936 A:middle
-for example is the Alert
-Notification Service.
 
 00:39:02.286 --> 00:39:06.436 A:middle
 The problem with it is that
@@ -3761,10 +3639,6 @@ I just talked to you about,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.986 --> 00:41:03.506 A:middle
-And again, like the HID service
-I just talked to you about,
-
 00:41:03.506 --> 00:41:07.336 A:middle
 once an accessory has been
 recognized as using ANCS,
@@ -3849,10 +3723,6 @@ a UUID for this notification
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:58.296 --> 00:42:02.236 A:middle
-notification and we will create
-a UUID for this notification
 
 00:42:02.236 --> 00:42:03.656 A:middle
 which is going to
@@ -3944,10 +3814,6 @@ the accessory
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.106 --> 00:43:00.766 A:middle
-we will also notify
-the accessory
-
 00:43:00.766 --> 00:43:04.206 A:middle
 that this notification is
 now invalid and you're free
@@ -4036,9 +3902,6 @@ Please keep a reference to them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.436 --> 00:44:00.936 A:middle
-Please keep a reference to them.
 
 00:44:01.706 --> 00:44:03.756 A:middle
 If a CBPeripheral gets locked,
@@ -4131,10 +3994,6 @@ objects and all of that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:58.156 --> 00:45:00.276 A:middle
-between UUIDs and CB
-objects and all of that.
-
 00:45:00.886 --> 00:45:02.936 A:middle
 Just use the CB objects
 as dictionary keys.
@@ -4225,10 +4084,6 @@ have told about.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:59.776 --> 00:46:02.136 A:middle
-things that Jason
-have told about.
-
 00:46:02.136 --> 00:46:05.896 A:middle
 You have all to the
 tools for you to not have
@@ -4302,10 +4157,6 @@ percent up all the time.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.486 --> 00:47:00.996 A:middle
-It should be 100
-percent up all the time.
 
 00:47:01.246 --> 00:47:05.266 A:middle
 Every time I walk in front of
@@ -4384,9 +4235,6 @@ in part CoreBluetooth.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.876 --> 00:48:02.276 A:middle
-in part CoreBluetooth.
 
 00:48:02.276 --> 00:48:06.316 A:middle
 So, these, you cannot hear
@@ -4561,10 +4409,6 @@ updated as we speak.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.146 --> 00:50:01.706 A:middle
-and this is being
-updated as we speak.
-
 00:50:02.136 --> 00:50:04.416 A:middle
 I don't know if an
 update is online yet.
@@ -4660,10 +4504,6 @@ developer program, DTS.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.976 --> 00:51:02.966 A:middle
-We also have the
-developer program, DTS.
-
 00:51:02.966 --> 00:51:05.466 A:middle
 It's a little bit more formal.
 
@@ -4751,10 +4591,6 @@ get those bugs to as
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.546 --> 00:52:01.446 A:middle
-This is the time to
-get those bugs to as
 
 00:52:01.446 --> 00:52:04.706 A:middle
 so that we can investigate these
@@ -4847,10 +4683,6 @@ whole lot about proximity.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.876 --> 00:53:01.276 A:middle
-And then we didn't talk a
-whole lot about proximity.
 
 00:53:01.486 --> 00:53:03.826 A:middle
 Well, because they're talking

--- a/2013/704.srt
+++ b/2013/704.srt
@@ -82,10 +82,6 @@ using at a time.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.456 --> 00:01:01.486 A:middle
-that a user is actively
-using at a time.
-
 00:01:01.486 --> 00:01:05.486 A:middle
 And so, that application
 can be provided the full use
@@ -165,10 +161,6 @@ any value to the system,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.926 --> 00:02:02.116 A:middle
-And this isn't really providing
-any value to the system,
-
 00:02:02.116 --> 00:02:02.866 A:middle
 it's just sitting there.
 
@@ -247,9 +239,6 @@ to the system may take longer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.136 --> 00:03:01.096 A:middle
-to the system may take longer.
 
 00:03:01.096 --> 00:03:03.646 A:middle
 This is where we'll begin
@@ -337,10 +326,6 @@ us to establish a mapping
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.936 --> 00:04:01.416 A:middle
-And virtual memory allows
-us to establish a mapping
 
 00:04:01.416 --> 00:04:04.536 A:middle
 from that address space
@@ -430,10 +415,6 @@ low memory situations.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.516 --> 00:05:00.716 A:middle
-when the system is under
-low memory situations.
 
 00:05:01.246 --> 00:05:03.866 A:middle
 It means that more memory will
@@ -529,10 +510,6 @@ cause and fix them.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.076 --> 00:06:00.916 A:middle
-to understand their
-cause and fix them.
-
 00:06:01.566 --> 00:06:04.046 A:middle
 Now, both these tools will
 be covered in much more depth
@@ -623,10 +600,6 @@ any leaks that you find
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:57.786 --> 00:07:00.206 A:middle
-And you want to consider
-any leaks that you find
-
 00:07:00.606 --> 00:07:02.816 A:middle
 to be a bug you should
 immediately fix
@@ -716,10 +689,6 @@ whether you've caused memory
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.656 --> 00:08:01.496 A:middle
-of your app to understand
-whether you've caused memory
 
 00:08:01.496 --> 00:08:03.816 A:middle
 regressions and look for changes
@@ -819,10 +788,6 @@ stack that allocated the object
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:57.546 --> 00:09:00.776 A:middle
-we'll also get the full call
-stack that allocated the object
-
 00:09:01.256 --> 00:09:03.656 A:middle
 which can help you narrow down
 where the object came from
@@ -908,10 +873,6 @@ deciding what things you want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.886 --> 00:10:01.606 A:middle
-This is really helpful for
-deciding what things you want
 
 00:10:01.606 --> 00:10:02.976 A:middle
 to target to as far
@@ -1008,10 +969,6 @@ an approximation
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.936 --> 00:11:01.366 A:middle
-This is roughly,
-an approximation
-
 00:11:01.366 --> 00:11:04.996 A:middle
 of how difficult it is for the
 system to create new free memory
@@ -1093,10 +1050,6 @@ its contents can be discarded
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.736 --> 00:12:01.296 A:middle
-but it has the property that
-its contents can be discarded
 
 00:12:01.296 --> 00:12:03.826 A:middle
 automatically when the system
@@ -1180,10 +1133,6 @@ call endContentAccess again
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.576 --> 00:13:01.376 A:middle
-And eventually we'll want to
-call endContentAccess again
-
 00:13:01.686 --> 00:13:03.816 A:middle
 to indicate to the system
 that we're no longer using it.
@@ -1263,10 +1212,6 @@ least recently used eviction.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:57.236 --> 00:14:00.986 A:middle
-And it uses a version of
-least recently used eviction.
 
 00:14:00.986 --> 00:14:02.666 A:middle
 Should expect the contents
@@ -1356,10 +1301,6 @@ are then subdivided
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.606 --> 00:15:00.736 A:middle
-These regions, each
-are then subdivided
-
 00:15:00.736 --> 00:15:04.846 A:middle
 into 4 kilobyte pages, and
 those pages inherit a variety
@@ -1447,10 +1388,6 @@ have less than 10 percent
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.506 --> 00:16:01.716 A:middle
-And so, a simple game might
-have less than 10 percent
-
 00:16:01.716 --> 00:16:04.876 A:middle
 of its memory actually
 allocated in its heap.
@@ -1534,9 +1471,6 @@ in practice.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.596 --> 00:17:00.326 A:middle
-in practice.
 
 00:17:01.016 --> 00:17:04.066 A:middle
 There's also CA layers,
@@ -1633,9 +1567,6 @@ that code in from disk.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.086 --> 00:18:00.086 A:middle
-that code in from disk.
-
 00:18:00.476 --> 00:18:02.706 A:middle
 And then, as it accesses
 a data file,
@@ -1721,10 +1652,6 @@ memory interesting is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.266 --> 00:19:00.556 A:middle
-Now, what makes a dirty
-memory interesting is
 
 00:19:00.556 --> 00:19:03.186 A:middle
 that it's much more expensive
@@ -1815,10 +1742,6 @@ when it's known.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:59.666 --> 00:20:02.406 A:middle
-of that allocation,
-when it's known.
 
 00:20:03.056 --> 00:20:04.686 A:middle
 And you can then drill
@@ -1999,10 +1922,6 @@ this for graphics memory
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.416 --> 00:22:01.426 A:middle
-You'll most commonly see
-this for graphics memory
-
 00:22:01.826 --> 00:22:03.766 A:middle
 or in multi-process
 applications.
@@ -2083,10 +2002,6 @@ system will do to satisfy demand
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:55.886 --> 00:23:00.636 A:middle
-So I want to walk through what a
-system will do to satisfy demand
 
 00:23:00.636 --> 00:23:03.626 A:middle
 for new memory given these
@@ -2178,10 +2093,6 @@ begin to decline.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.716 --> 00:24:00.896 A:middle
-performance really
-begin to decline.
-
 00:24:03.976 --> 00:24:06.616 A:middle
 Now, in Mavericks, there's
 one more part of this.
@@ -2265,10 +2176,6 @@ used in your system.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.236 --> 00:25:01.186 A:middle
-of where memory is being
-used in your system.
-
 00:25:01.796 --> 00:25:05.266 A:middle
 App memory refers to anonymous
 memory regions like heap
@@ -2348,10 +2255,6 @@ a couple statistics that cover
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:57.186 --> 00:26:00.856 A:middle
-And so, we can see here, we have
-a couple statistics that cover
 
 00:26:00.896 --> 00:26:02.786 A:middle
 where a memory is
@@ -2438,10 +2341,6 @@ the kernel is doing
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.786 --> 00:27:00.476 A:middle
-So you can see what
-the kernel is doing
 
 00:27:00.476 --> 00:27:01.776 A:middle
 in response to a page fault.
@@ -2621,9 +2520,6 @@ about what your app was doing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.176 --> 00:29:00.646 A:middle
-about what your app was doing.
-
 00:29:00.646 --> 00:29:01.186 A:middle
 All right.
 
@@ -2706,10 +2602,6 @@ about in your app.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:59.566 --> 00:30:01.556 A:middle
-that you probably care
-about in your app.
 
 00:30:01.876 --> 00:30:04.076 A:middle
 And what that app launch
@@ -2798,10 +2690,6 @@ but ultimately,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.796 --> 00:31:01.426 A:middle
-to help it do IO,
-but ultimately,
-
 00:31:01.806 --> 00:31:04.216 A:middle
 all access to the disk are
 going to fall through one
@@ -2888,10 +2776,6 @@ because it uses rotating media
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.456 --> 00:32:02.856 A:middle
-On the other hand, a hard drive,
-because it uses rotating media
-
 00:32:02.856 --> 00:32:05.316 A:middle
 and must first seek to
 the correct location
@@ -2977,10 +2861,6 @@ might mostly have focused
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.666 --> 00:33:01.606 A:middle
-This meant in the past you
-might mostly have focused
 
 00:33:01.606 --> 00:33:03.296 A:middle
 on what reads your
@@ -3074,10 +2954,6 @@ part of Grand Central Dispatch.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.646 --> 00:34:02.646 A:middle
-Dispatch IO is an API that's
-part of Grand Central Dispatch.
-
 00:34:03.236 --> 00:34:04.906 A:middle
 It's been available since 10.7.
 
@@ -3156,10 +3032,6 @@ we want to read this data.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.156 --> 00:35:04.636 A:middle
-and informing dispatch IO that
-we want to read this data.
 
 00:35:04.636 --> 00:35:06.326 A:middle
 We can then set a
@@ -3255,10 +3127,6 @@ want to read in a couple
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.756 --> 00:36:00.576 A:middle
-Let's say for example you
-want to read in a couple
-
 00:36:00.576 --> 00:36:02.096 A:middle
 of hundred thumbnails
 from a disk?
@@ -3349,10 +3217,6 @@ operations should I have
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:59.006 --> 00:37:00.986 A:middle
-how many of these
-operations should I have
 
 00:37:00.986 --> 00:37:01.846 A:middle
 running concurrently?
@@ -3450,10 +3314,6 @@ provides other benefits
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.016 --> 00:38:01.746 A:middle
-Of course, using a database
-provides other benefits
-
 00:38:02.026 --> 00:38:05.896 A:middle
 like control over atomicity so
 you can put multiple operations
@@ -3548,10 +3408,6 @@ writes into a single flushing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.166 --> 00:39:03.306 A:middle
-If you can combine multiple
-writes into a single flushing
-
 00:39:03.306 --> 00:39:05.776 A:middle
 of data, that can help
 improve the IO performance
@@ -3632,10 +3488,6 @@ data into the file cache,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:57.456 --> 00:40:00.416 A:middle
-And any time you pull new
-data into the file cache,
 
 00:40:00.756 --> 00:40:02.936 A:middle
 other data is going
@@ -3729,10 +3581,6 @@ in the memory section,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:57.206 --> 00:41:00.436 A:middle
-Now I also mentioned
-in the memory section,
-
 00:41:00.436 --> 00:41:02.536 A:middle
 file-backed memory regions.
 
@@ -3820,10 +3668,6 @@ call to map a file into memory.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:56.816 --> 00:42:00.936 A:middle
-or you can use the mmap system
-call to map a file into memory.
-
 00:42:01.946 --> 00:42:05.366 A:middle
 Now, regardless of how you do
 IO and what data you're writing
@@ -3903,10 +3747,6 @@ of these things are important
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:55.526 --> 00:43:01.136 A:middle
-Now, of course, it's-- none
-of these things are important
 
 00:43:01.136 --> 00:43:03.806 A:middle
 until you understand what IO
@@ -3999,10 +3839,6 @@ duration the event lasted for,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.716 --> 00:44:02.376 A:middle
-about the event, the
-duration the event lasted for,
-
 00:44:03.156 --> 00:44:05.296 A:middle
 and finally, the
 process and thread ID
@@ -4080,10 +3916,6 @@ things like whether it's a write
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:57.406 --> 00:45:00.216 A:middle
-So the command name will include
-things like whether it's a write
 
 00:45:00.216 --> 00:45:02.766 A:middle
 or a read, whether
@@ -4166,10 +3998,6 @@ critical time especially
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.496 --> 00:46:02.426 A:middle
-Try to defer those to a less
-critical time especially
 
 00:46:02.426 --> 00:46:03.796 A:middle
 if it's the time
@@ -4258,9 +4086,6 @@ through it for you.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:56.516 --> 00:47:01.536 A:middle
-[ Pause ]
-
 00:47:02.036 --> 00:47:05.026 A:middle
 Now this is potentially a little
 bit of an extreme example.
@@ -4345,10 +4170,6 @@ dispatch IO APIs.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:57.806 --> 00:48:01.156 A:middle
-of files is to usually
-dispatch IO APIs.
-
 00:48:01.236 --> 00:48:03.936 A:middle
 When profiling your disk
 accesses, make sure to do it
@@ -4425,10 +4246,6 @@ use of your app
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.136 --> 00:49:01.056 A:middle
-to limit the resource
-use of your app
 
 00:49:01.376 --> 00:49:02.736 A:middle
 when performing these
@@ -4610,9 +4427,6 @@ Things that you run
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:58.836 --> 00:51:00.116 A:middle
-Things that you run
-
 00:51:00.116 --> 00:51:03.716 A:middle
 in the background may take
 an unbounded amount of time
@@ -4694,10 +4508,6 @@ mechanism to unbackground tasks
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:57.116 --> 00:52:00.456 A:middle
-you can use this boosting
-mechanism to unbackground tasks
 
 00:52:00.716 --> 00:52:03.536 A:middle
 so that they complete quickly
@@ -4786,10 +4596,6 @@ time profiler sample.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:52:59.586 --> 00:53:02.606 A:middle
-This is similar to
-time profiler sample.
-
 00:53:03.426 --> 00:53:07.436 A:middle
 But it has the advantage that it
 will also show you the priority
@@ -4871,10 +4677,6 @@ different performance based
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:59.716 --> 00:54:02.936 A:middle
-that your users will experience
-different performance based
 
 00:54:02.936 --> 00:54:04.696 A:middle
 on what type of system
@@ -4964,10 +4766,6 @@ and then you can boot off
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:54:59.346 --> 00:55:01.576 A:middle
-to your external hard drive
-and then you can boot off
 
 00:55:01.576 --> 00:55:03.886 A:middle
 that by holding option at

--- a/2013/705.srt
+++ b/2013/705.srt
@@ -68,10 +68,6 @@ technologies, NSNetServices,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.746 --> 00:01:01.146 A:middle
-around some specific
-technologies, NSNetServices,
-
 00:01:01.146 --> 00:01:04.086 A:middle
 single sign-on an iCloud
 credential syncing.
@@ -148,10 +144,6 @@ at these different layers,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.396 --> 00:02:01.116 A:middle
-In these different frameworks
-at these different layers,
-
 00:02:01.116 --> 00:02:03.816 A:middle
 there are different
 APIs you can use.
@@ -219,10 +211,6 @@ Objective-C ARC compatible way.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.716 --> 00:03:02.276 A:middle
-so in a delegate-based
-Objective-C ARC compatible way.
 
 00:03:03.586 --> 00:03:06.906 A:middle
 But NSURLConnection is more
@@ -295,10 +283,6 @@ introduced the Power Mac G5 back
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.946 --> 00:04:02.276 A:middle
-which I think the same year we
-introduced the Power Mac G5 back
 
 00:04:02.316 --> 00:04:05.336 A:middle
 when the bits all
@@ -378,10 +362,6 @@ NSURLConnection works by looking
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.176 --> 00:05:01.146 A:middle
-But by and large,
-NSURLConnection works by looking
 
 00:05:01.146 --> 00:05:02.866 A:middle
 at the global state
@@ -629,10 +609,6 @@ model which is kind of--
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:57.916 --> 00:08:02.546 A:middle
-And I have this rich delegate
-model which is kind of--
-
 00:08:03.306 --> 00:08:04.586 A:middle
 weird way of saying this,
 
@@ -713,10 +689,6 @@ API consistent between request,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:59.326 --> 00:09:02.696 A:middle
-So just trying to make this
-API consistent between request,
-
 00:09:02.696 --> 00:09:04.046 A:middle
 response, payload, payload.
 
@@ -795,10 +767,6 @@ called NSURLSession.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.516 --> 00:10:01.436 A:middle
-a big square object
-called NSURLSession.
-
 00:10:02.026 --> 00:10:04.176 A:middle
 And you create a session
 with a configuration object.
@@ -867,9 +835,6 @@ on a per request basis.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.166 --> 00:11:00.326 A:middle
-on a per request basis.
 
 00:11:01.746 --> 00:11:03.886 A:middle
 There is a delegate
@@ -955,9 +920,6 @@ You create a delegate conforming
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.346 --> 00:12:00.356 A:middle
-You create a delegate conforming
 
 00:12:00.576 --> 00:12:02.086 A:middle
 to the session delegate
@@ -1050,10 +1012,6 @@ then you can use a
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.556 --> 00:13:01.536 A:middle
-you create a URL, and
-then you can use a
-
 00:13:01.536 --> 00:13:03.616 A:middle
 dataTaskWithHTTPGetRequest
 which returns
@@ -1127,10 +1085,6 @@ we want to open to a host.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:58.466 --> 00:14:00.546 A:middle
-for how many connections
-we want to open to a host.
 
 00:14:00.546 --> 00:14:02.286 A:middle
 But what we've heard is that
@@ -1217,9 +1171,6 @@ in three days, forget about it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.686 --> 00:15:00.026 A:middle
-in three days, forget about it.
-
 00:15:00.026 --> 00:15:02.506 A:middle
 I'd rather hear that it failed.
 
@@ -1305,10 +1256,6 @@ kept on a per session basis.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:56.586 --> 00:16:00.256 A:middle
-Lastly, protocol handlers are
-kept on a per session basis.
 
 00:16:00.416 --> 00:16:02.586 A:middle
 There is still the
@@ -1399,10 +1346,6 @@ can't modify it.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.636 --> 00:17:01.626 A:middle
-of a session, you
-can't modify it.
-
 00:17:02.936 --> 00:17:06.056 A:middle
 So the task object,
 this is the thing
@@ -1475,10 +1418,6 @@ upload or download tasks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:58.506 --> 00:18:02.846 A:middle
-You can schedule background
-upload or download tasks.
 
 00:18:03.536 --> 00:18:05.686 A:middle
 Download tasks don't
@@ -1561,10 +1500,6 @@ subclass of DataTask.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:59.536 --> 00:19:03.216 A:middle
-and UploadTask is a
-subclass of DataTask.
 
 00:19:04.286 --> 00:19:06.616 A:middle
 Any task can have
@@ -1726,10 +1661,6 @@ session didReceiveAuthentication
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.576 --> 00:21:00.366 A:middle
-Those come in through the URL
-session didReceiveAuthentication
-
 00:21:00.366 --> 00:21:03.566 A:middle
 Challenge:completionHandler
 delegate method.
@@ -1814,10 +1745,6 @@ to do something different
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.556 --> 00:22:02.726 A:middle
-If you care whether you want
-to do something different
-
 00:22:02.726 --> 00:22:05.816 A:middle
 for redirection, then
 you implement this
@@ -1898,10 +1825,6 @@ didSendBodyData delegate method
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.966 --> 00:23:00.986 A:middle
-we periodically call this
-didSendBodyData delegate method
 
 00:23:01.066 --> 00:23:01.856 A:middle
 if you implement it.
@@ -1987,10 +1910,6 @@ in-house, this never gets called
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.696 --> 00:24:02.606 A:middle
-when you're doing your testing
-in-house, this never gets called
 
 00:24:02.606 --> 00:24:03.896 A:middle
 because everything
@@ -2079,10 +1998,6 @@ we did our job,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.306 --> 00:25:01.706 A:middle
-as far as we're concerned
-we did our job,
-
 00:25:01.706 --> 00:25:04.086 A:middle
 we sent you request
 and got a response.
@@ -2166,10 +2081,6 @@ from the network, if you kept it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:59.106 --> 00:26:02.886 A:middle
-As your resource is being loaded
-from the network, if you kept it
-
 00:26:02.886 --> 00:26:05.456 A:middle
 as a data task, you'll
 receive zero
@@ -2249,10 +2160,6 @@ necessarily get called
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.766 --> 00:27:01.986 A:middle
-Note that this won't
-necessarily get called
 
 00:27:01.986 --> 00:27:04.086 A:middle
 because there could
@@ -2339,10 +2246,6 @@ offset you're given here is the
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:59.156 --> 00:28:02.966 A:middle
-One thing to note is that the
-offset you're given here is the
 
 00:28:02.966 --> 00:28:07.196 A:middle
 real offset at which we
@@ -2435,10 +2338,6 @@ provides these asynchronous
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:58.466 --> 00:29:02.836 A:middle
-and download tasks, but it also
-provides these asynchronous
-
 00:29:02.836 --> 00:29:05.146 A:middle
 convenience APIs with
 a various type of task.
@@ -2521,10 +2420,6 @@ the data is resolved.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:59.596 --> 00:30:01.536 A:middle
-with the data once
-the data is resolved.
-
 00:30:03.076 --> 00:30:04.676 A:middle
 If I wanted to further
 customize this,
@@ -2605,10 +2500,6 @@ uploadTaskWithStreamedRequest,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.956 --> 00:31:01.586 A:middle
-through
-uploadTaskWithStreamedRequest,
-
 00:31:01.996 --> 00:31:02.786 A:middle
 we ignore the body.
 
@@ -2683,10 +2574,6 @@ walked out of Wi-Fi range
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:57.406 --> 00:32:00.216 A:middle
-so let's say your user
-walked out of Wi-Fi range
 
 00:32:00.216 --> 00:32:02.506 A:middle
 and we lost the connection,
@@ -2773,10 +2660,6 @@ when we're doing a background
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:57.296 --> 00:33:00.266 A:middle
-What this tells us is that
-when we're doing a background
 
 00:33:00.266 --> 00:33:04.546 A:middle
 transfer for a session
@@ -2871,10 +2754,6 @@ and we're going to do our best
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.476 --> 00:34:01.936 A:middle
-You set discretionary to be true
-and we're going to do our best
-
 00:34:02.206 --> 00:34:05.406 A:middle
 to prioritize it given the
 constraints of the network
@@ -2949,10 +2828,6 @@ you create a background pass,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:56.306 --> 00:35:00.396 A:middle
-" So, while your app is running,
-you create a background pass,
 
 00:35:00.536 --> 00:35:02.366 A:middle
 you're going to receive
@@ -3033,10 +2908,6 @@ delegate messages for a task.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.906 --> 00:36:02.586 A:middle
-But you will receive
-delegate messages for a task.
-
 00:36:02.586 --> 00:36:04.526 A:middle
 You don't have to call the
 taskWithCompletionHandler.
@@ -3113,9 +2984,6 @@ and an image will appear.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:56.876 --> 00:37:01.536 A:middle
-[ Applause ]
-
 00:37:02.036 --> 00:37:05.726 A:middle
 So, now just to show you
 again, we can start a download
@@ -3191,10 +3059,6 @@ of a dispatch once here
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:58.196 --> 00:38:01.206 A:middle
-So, I do this inside
-of a dispatch once here
 
 00:38:01.206 --> 00:38:04.386 A:middle
 to emphasize the fact that
@@ -3282,10 +3146,6 @@ to update that progress wheel.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:58.476 --> 00:39:01.276 A:middle
-So the fraction, we use that
-to update that progress wheel.
-
 00:39:01.766 --> 00:39:04.746 A:middle
 This is the--
 
@@ -3366,9 +3226,6 @@ So this leads us though to our--
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:58.516 --> 00:40:00.216 A:middle
-So this leads us though to our--
 
 00:40:00.216 --> 00:40:02.186 A:middle
 to one more additional
@@ -3466,9 +3323,6 @@ So we only want to call this
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.816 --> 00:41:01.446 A:middle
-So we only want to call this
 
 00:41:01.446 --> 00:41:03.076 A:middle
 when we're done handling
@@ -3568,10 +3422,6 @@ are empty,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.536 --> 00:42:00.026 A:middle
-So if all these arrays
-are empty,
-
 00:42:00.306 --> 00:42:03.556 A:middle
 that means you know you're
 done handling all the events
@@ -3667,10 +3517,6 @@ NSURL cache subclass
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:59.166 --> 00:43:02.136 A:middle
-You could create an
-NSURL cache subclass
-
 00:43:02.536 --> 00:43:04.796 A:middle
 but then you would set it to
 be the default for the system
@@ -3753,10 +3599,6 @@ publish Bonjour Services.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.356 --> 00:44:02.646 A:middle
-It also allows you to
-publish Bonjour Services.
-
 00:44:02.646 --> 00:44:06.146 A:middle
 You do this by creating an
 NSNetServices describing the
@@ -3822,10 +3664,6 @@ new option NSNetService
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:58.946 --> 00:45:01.106 A:middle
-you need to specify this
-new option NSNetService
 
 00:45:01.316 --> 00:45:02.426 A:middle
 ListenForConnections.
@@ -3901,10 +3739,6 @@ I think it was yesterday
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.716 --> 00:46:02.676 A:middle
-There is an-- a session,
-I think it was yesterday
 
 00:46:02.676 --> 00:46:04.786 A:middle
 "Extending your Apps for
@@ -3987,10 +3821,6 @@ on NSURLCredentialStorage.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:56.666 --> 00:47:00.036 A:middle
-for protection space API
-on NSURLCredentialStorage.
-
 00:47:00.766 --> 00:47:03.866 A:middle
 You invoke this using a
 dictionary of properties
@@ -4070,10 +3900,6 @@ services and publish it
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.096 --> 00:48:01.126 A:middle
-so that you can create
-services and publish it
-
 00:48:01.126 --> 00:48:05.266 A:middle
 on your local network and
 NSURLAuthentication is enhanced
@@ -4149,10 +3975,6 @@ in order to get work done
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:56.516 --> 00:49:00.156 A:middle
-to background notifications
-in order to get work done
 
 00:49:01.156 --> 00:49:05.016 A:middle
 in response to, you know,

--- a/2013/707.srt
+++ b/2013/707.srt
@@ -70,10 +70,6 @@ it then here's a couple things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.656 --> 00:01:02.046 A:middle
-So if you're thinking about
-it then here's a couple things
-
 00:01:02.046 --> 00:01:02.836 A:middle
 that you need to think
 
@@ -157,10 +153,6 @@ writing your first line of code.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:59.756 --> 00:02:04.666 A:middle
-to read before you even start
-writing your first line of code.
 
 00:02:05.226 --> 00:02:07.496 A:middle
 The Kernel Extension
@@ -292,10 +284,6 @@ kernel and part of that means
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:59.766 --> 00:04:03.756 A:middle
-Okay, so you're part of the
-kernel and part of that means
-
 00:04:03.756 --> 00:04:06.766 A:middle
 that you have to buy
 into extra protection.
@@ -352,10 +340,6 @@ signatures are verified.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.276 --> 00:05:04.096 A:middle
-In OS 10.9 all kext
-signatures are verified.
 
 00:05:06.486 --> 00:05:09.806 A:middle
 Unsigned or invalid
@@ -421,10 +405,6 @@ to getting that working,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.666 --> 00:06:02.436 A:middle
-I didn't quite get around
-to getting that working,
 
 00:06:02.436 --> 00:06:06.146 A:middle
 so it's fixed in the next
@@ -493,10 +473,6 @@ if you supply nothing else
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:57.126 --> 00:07:01.246 A:middle
-for our sample kext, and again,
-if you supply nothing else
 
 00:07:01.246 --> 00:07:04.336 A:middle
 to kextload, we'll go
@@ -567,10 +543,6 @@ we will automatically rebuild
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:57.616 --> 00:08:00.996 A:middle
-the /System/Library/Extensions
-we will automatically rebuild
 
 00:08:00.996 --> 00:08:01.456 A:middle
 the kernel cache.
@@ -648,10 +620,6 @@ the application folder,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:54.886 --> 00:09:00.596 A:middle
-Library startup items, in
-the application folder,
-
 00:09:00.636 --> 00:09:04.406 A:middle
 inside your app bundles,
 that's a perfectly good place
@@ -721,10 +689,6 @@ move them to
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:58.846 --> 00:10:00.576 A:middle
-move them to
-/Library/Extensions,
 
 00:10:01.146 --> 00:10:05.866 A:middle
 and anything on 10.8 and
@@ -796,10 +760,6 @@ bundle, all those are fine.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:56.986 --> 00:11:01.506 A:middle
-applications in your application
-bundle, all those are fine.
 
 00:11:01.706 --> 00:11:07.446 A:middle
 So, you may need to have
@@ -878,10 +838,6 @@ this Developer ID Certificate?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:58.616 --> 00:12:04.176 A:middle
-So how do you go about getting
-this Developer ID Certificate?
-
 00:12:05.406 --> 00:12:06.106 A:middle
 Very simple.
 
@@ -956,9 +912,6 @@ in context for applications.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.926 --> 00:13:01.676 A:middle
-in context for applications.
-
 00:13:02.376 --> 00:13:06.106 A:middle
 All that stuff he talked about
 in that session, he gives a lot
@@ -1026,10 +979,6 @@ that will come out.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.296 --> 00:14:02.616 A:middle
-There's a second alert
-that will come out.
-
 00:14:03.166 --> 00:14:07.666 A:middle
 Anything that is a kext outside
 of /Library/Extensions will load
@@ -1091,10 +1040,6 @@ signature error codes
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:56.096 --> 00:15:00.146 A:middle
-So the most common code
-signature error codes
 
 00:15:00.146 --> 00:15:04.086 A:middle
 that you're going to
@@ -1161,10 +1106,6 @@ a modified Info.plist,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.516 --> 00:16:03.106 A:middle
-So this is an example of
-a modified Info.plist,
 
 00:16:03.396 --> 00:16:04.776 A:middle
 invalidates the signature,
@@ -1235,10 +1176,6 @@ just going to run
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.146 --> 00:17:01.486 A:middle
-in Core OS, and I'm
-just going to run
 
 00:17:01.486 --> 00:17:04.366 A:middle
 through a couple examples
@@ -1317,10 +1254,6 @@ of kernel extensions: The
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:59.266 --> 00:18:02.766 A:middle
-of kernel extensions: The
-"Generic Kernel Extension",
-
 00:18:02.766 --> 00:18:05.366 A:middle
 which is typically used for File
 Systems and network plug-ins.
@@ -1396,10 +1329,6 @@ any Developer ID.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.456 --> 00:19:00.196 A:middle
-which would match
-any Developer ID.
 
 00:19:00.196 --> 00:19:03.056 A:middle
 If you have multiple
@@ -1482,10 +1411,6 @@ happen to subclass OSObject
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:56.996 --> 00:20:00.406 A:middle
-or IOKit kext and you
-happen to subclass OSObject
-
 00:20:00.406 --> 00:20:02.336 A:middle
 or any class that's
 derived from it,
@@ -1561,10 +1486,6 @@ just described builds one kext.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:57.696 --> 00:21:05.176 A:middle
-that we need.The project we
-just described builds one kext.
-
 00:21:05.906 --> 00:21:10.086 A:middle
 It will load on OS X 10.9
 with no errors or warnings
@@ -1631,10 +1552,6 @@ important; this calls back
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.796 --> 00:22:01.826 A:middle
-Now, this is very
-important; this calls back
 
 00:22:01.826 --> 00:22:03.186 A:middle
 to what Jerry told you earlier.
@@ -1713,10 +1630,6 @@ target is going
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.056 --> 00:23:01.136 A:middle
-Your new OS X 10.8
-target is going
 
 00:23:01.136 --> 00:23:04.126 A:middle
 to have the same
@@ -1804,10 +1717,6 @@ to
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.306 --> 00:24:05.026 A:middle
-to
-/System/Library/Extensions.Since
-
 00:24:05.026 --> 00:24:06.986 A:middle
 you'll be installing
 two kernel extensions,
@@ -1884,10 +1793,6 @@ going to use Xcode 4.6.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:56.656 --> 00:25:01.306 A:middle
-but one difference is we're
-going to use Xcode 4.6.
-
 00:25:01.586 --> 00:25:03.956 A:middle
 You can't use Xcode 5 for this
 
@@ -1958,10 +1863,6 @@ in the old path,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.686 --> 00:26:01.946 A:middle
-the one that's installing
-in the old path,
-
 00:26:01.946 --> 00:26:09.436 A:middle
 /System/Library/Extensions,
 
@@ -2028,10 +1929,6 @@ flavors of 10.8, and you will,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:57.316 --> 00:27:01.416 A:middle
-all flavors of 10.7 and all
-flavors of 10.8, and you will,
 
 00:27:01.416 --> 00:27:05.326 A:middle
 again, use gdb to debug that.
@@ -2113,10 +2010,6 @@ effectively you're kind
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.256 --> 00:28:01.086 A:middle
-in /Library/Extensions.So
-effectively you're kind
-
 00:28:01.086 --> 00:28:04.766 A:middle
 of building a line in the
 sand between Mavericks
@@ -2190,10 +2083,6 @@ robust against write failures
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.286 --> 00:29:01.836 A:middle
-and also make sure that you're
-robust against write failures
 
 00:29:01.836 --> 00:29:02.686 A:middle
 to the /System folder
@@ -2272,10 +2161,6 @@ that after about 10,000 panics,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.006 --> 00:30:02.686 A:middle
-[Laughter] And it really is true
-that after about 10,000 panics,
-
 00:30:02.686 --> 00:30:06.196 A:middle
 there pretty straightforward.
 
@@ -2344,10 +2229,6 @@ map up on the llvm.org website,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:56.706 --> 00:31:01.916 A:middle
-There is a gdb to lldb command
-map up on the llvm.org website,
-
 00:31:01.996 --> 00:31:04.536 A:middle
 which helps you make
 this transition,
@@ -2410,10 +2291,6 @@ via gdb to a 10.8 system
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:54.196 --> 00:32:00.206 A:middle
-in the debugger while connected
-via gdb to a 10.8 system
 
 00:32:00.596 --> 00:32:03.216 A:middle
 and lldb to a 10.9 system.
@@ -2488,10 +2365,6 @@ the generic information we need
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:58.356 --> 00:33:02.156 A:middle
-when we're debugging to just get
-the generic information we need
-
 00:33:02.156 --> 00:33:04.346 A:middle
 for a panic.
 
@@ -2563,10 +2436,6 @@ would like to know.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:58.246 --> 00:34:01.046 A:middle
-that I thought you guys
-would like to know.
-
 00:34:01.416 --> 00:34:06.416 A:middle
 lldb likes to pretend it
 doesn't know how to do addition.
@@ -2634,10 +2503,6 @@ MyClass," and instead it says,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:55.656 --> 00:35:00.436 A:middle
-"MyClass," and you say, "Print
-MyClass," and instead it says,
 
 00:35:00.436 --> 00:35:03.456 A:middle
 "I don't know what MyClass is,"
@@ -2718,10 +2583,6 @@ current line that you're stopped
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:59.306 --> 00:36:01.246 A:middle
-If you just want to see the
-current line that you're stopped
-
 00:36:01.246 --> 00:36:03.796 A:middle
 on you can say, "disassemble
 -l -m
@@ -2791,10 +2652,6 @@ that out in a day or two.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:57.596 --> 00:37:07.036 A:middle
-Here, you could probably figure
-that out in a day or two.
-
 00:37:07.036 --> 00:37:07.103 A:middle
 [Laughter]
 
@@ -2863,10 +2720,6 @@ to just get the information
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:56.056 --> 00:38:01.036 A:middle
-and then say -s AppleSamplePCI
-to just get the information
 
 00:38:01.036 --> 00:38:03.966 A:middle
 on one line rather than have to
@@ -2944,10 +2797,6 @@ of times you only want
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:59.316 --> 00:39:01.876 A:middle
-For faster loading, a lot
-of times you only want
 
 00:39:01.876 --> 00:39:03.946 A:middle
 to see your particular
@@ -3029,10 +2878,6 @@ debugging at all.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:56.746 --> 00:40:00.546 A:middle
-We use nvram to enable
-debugging at all.
-
 00:40:01.056 --> 00:40:03.376 A:middle
 If you have no debug
 boot argument set,
@@ -3104,10 +2949,6 @@ we do not support USB Ethernet,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:59.806 --> 00:41:03.616 A:middle
-We do not support wireless and
-we do not support USB Ethernet,
-
 00:41:04.016 --> 00:41:06.336 A:middle
 so you're going to have to get
 one of those other connections.
@@ -3176,10 +3017,6 @@ inet value that makes sense.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.996 --> 00:42:02.576 A:middle
-I'm looking for a port with an
-inet value that makes sense.
-
 00:42:02.896 --> 00:42:07.136 A:middle
 So, for instance, here
 at the conference,
@@ -3237,10 +3074,6 @@ So you can simplify this to
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.286 --> 00:43:00.716 A:middle
-So you can simplify this to
-104 instead if you wanted.
 
 00:43:02.216 --> 00:43:05.086 A:middle
 For Thunderbolt to
@@ -3307,10 +3140,6 @@ System not to turn off power
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:57.976 --> 00:44:02.156 A:middle
-That tells the Thunderbolt
-System not to turn off power
 
 00:44:02.156 --> 00:44:05.376 A:middle
 to the FireWire chip, which
@@ -3388,10 +3217,6 @@ be grabbed.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.606 --> 00:45:01.376 A:middle
-that might accidentally
-be grabbed.
-
 00:45:01.716 --> 00:45:06.626 A:middle
 If you use xcrun lldb it will
 always find the proper lldb
@@ -3456,9 +3281,6 @@ do a NMI in Mac OS X 10.9.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:57.756 --> 00:46:00.366 A:middle
-do a NMI in Mac OS X 10.9.
 
 00:46:01.056 --> 00:46:04.756 A:middle
 With boot-args set
@@ -3532,10 +3354,6 @@ easy process.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:46:59.666 --> 00:47:01.936 A:middle
-because it's a pretty
-easy process.
-
 00:47:02.746 --> 00:47:05.636 A:middle
 As root on a host machine,
 the machine where you're going
@@ -3596,10 +3414,6 @@ mismatched frees, you know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:58.676 --> 00:48:02.336 A:middle
-use after free errors,
-mismatched frees, you know,
 
 00:48:02.536 --> 00:48:05.056 A:middle
 freeing from a zone that you
@@ -3663,10 +3477,6 @@ gzalloc-size, gzalloc-min,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.926 --> 00:49:02.436 A:middle
-You set, specify one of
-gzalloc-size, gzalloc-min,
 
 00:49:02.776 --> 00:49:07.556 A:middle
 gzalloc-max, or min and
@@ -3735,10 +3545,6 @@ we changed graphics
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:49:59.236 --> 00:50:03.746 A:middle
-in Mac OS X 10.8,
-we changed graphics
 
 00:50:03.746 --> 00:50:05.356 A:middle
 to support multiple buffers.
@@ -3823,9 +3629,6 @@ So, it's not very difficult.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:59.576 --> 00:51:00.866 A:middle
-So, it's not very difficult.
-
 00:51:01.236 --> 00:51:03.666 A:middle
 And there's a new revision
 
@@ -3902,9 +3705,6 @@ There you go.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:58.896 --> 00:52:00.766 A:middle
-There you go.
 
 00:52:01.266 --> 00:52:22.480 A:middle
 [ Applause ]

--- a/2013/708.srt
+++ b/2013/708.srt
@@ -77,10 +77,6 @@ a collection of functions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.576 --> 00:01:01.186 A:middle
-The Accelerate Framework is
-a collection of functions
-
 00:01:01.186 --> 00:01:04.346 A:middle
 of commonly used computationally
 intensive operations.
@@ -167,10 +163,6 @@ so that you don't have to.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.976 --> 00:02:03.336 A:middle
-We spent a lot of time testing
-so that you don't have to.
-
 00:02:04.256 --> 00:02:06.956 A:middle
 The big one is fast
 with low energy usage.
@@ -242,10 +234,6 @@ with vForce and vMathLib,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.046 --> 00:03:01.626 A:middle
-transcendental math functions
-with vForce and vMathLib,
 
 00:03:03.176 --> 00:03:06.946 A:middle
 and finally, linear
@@ -328,10 +316,6 @@ Accelerate Framework is fast is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.366 --> 00:04:03.446 A:middle
-One of the big reasons the
-Accelerate Framework is fast is
-
 00:04:03.446 --> 00:04:05.246 A:middle
 we utilize SIMD instructions.
 
@@ -405,10 +389,6 @@ it requires a certain amount
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:57.586 --> 00:05:00.326 A:middle
-So I bring these up because
-it requires a certain amount
 
 00:05:00.326 --> 00:05:01.736 A:middle
 of data before optimizations
@@ -505,10 +485,6 @@ Framework we always strive
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.866 --> 00:06:01.986 A:middle
-With the Accelerate
-Framework we always strive
-
 00:06:01.986 --> 00:06:03.466 A:middle
 to deliver the greatest
 performance,
@@ -599,10 +575,6 @@ be as small as 8 elements.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.356 --> 00:07:02.896 A:middle
-Matrix Multiply, it could
-be as small as 8 elements.
-
 00:07:04.156 --> 00:07:06.266 A:middle
 The best thing you can
 do here is to experiment.
@@ -681,10 +653,6 @@ to the Accelerate Framework,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.446 --> 00:08:00.856 A:middle
-For those of you brand new
-to the Accelerate Framework,
-
 00:08:01.116 --> 00:08:03.946 A:middle
 including it is just like
 including any other framework.
@@ -759,10 +727,6 @@ details of what's available
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:57.416 --> 00:09:03.326 A:middle
-So now I want to dive into the
-details of what's available
 
 00:09:03.326 --> 00:09:04.376 A:middle
 in the Accelerate Framework.
@@ -897,10 +861,6 @@ performance.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.706 --> 00:11:00.616 A:middle
-to deliver the maximum
-performance.
-
 00:11:03.756 --> 00:11:07.116 A:middle
 We also introduced
 resampling of 16-bit images,
@@ -972,10 +932,6 @@ to look at how to go
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.816 --> 00:12:03.726 A:middle
-So here we're going
-to look at how to go
-
 00:12:03.726 --> 00:12:06.716 A:middle
 from a CGImageRef
 to a vImage-Buffer.
@@ -1039,10 +995,6 @@ describing an ARGB 8-bit image.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.866 --> 00:13:00.646 A:middle
-This descriptor is
-describing an ARGB 8-bit image.
 
 00:13:01.986 --> 00:13:03.886 A:middle
 We see that the first entry
@@ -1124,10 +1076,6 @@ about background color.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.696 --> 00:14:01.776 A:middle
-This is information
-about background color.
-
 00:14:02.776 --> 00:14:05.986 A:middle
 In certain conversions when
 alpha channels are involved,
@@ -1201,10 +1149,6 @@ that we created before.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:58.576 --> 00:15:01.746 A:middle
-to use our same format specifier
-that we created before.
-
 00:15:01.826 --> 00:15:05.566 A:middle
 To create the CGImageRef
 we're going
@@ -1274,10 +1218,6 @@ allocated CGImageRef containing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.606 --> 00:16:03.406 A:middle
-This is going to be a freshly
-allocated CGImageRef containing
-
 00:16:03.556 --> 00:16:07.326 A:middle
 the image information,
 and we are free
@@ -1341,10 +1281,6 @@ you an example of this
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.406 --> 00:17:01.286 A:middle
-and I want to show
-you an example of this
 
 00:17:01.286 --> 00:17:02.656 A:middle
 with a real world application.
@@ -1421,9 +1357,6 @@ We see a few things here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.596 --> 00:18:01.856 A:middle
-We see a few things here.
-
 00:18:02.316 --> 00:18:04.056 A:middle
 First we see a lot
 of variability.
@@ -1489,10 +1422,6 @@ format to the other format,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.496 --> 00:19:01.186 A:middle
-converting from the input image
-format to the other format,
 
 00:19:01.776 --> 00:19:04.336 A:middle
 to a very small percent
@@ -1565,10 +1494,6 @@ to perform the scale,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.626 --> 00:20:02.726 A:middle
-In step two, we're going
-to perform the scale,
-
 00:20:03.996 --> 00:20:05.776 A:middle
 and then in step
 three we're going
@@ -1635,10 +1560,6 @@ some performance of vImage
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:54.066 --> 00:21:01.066 A:middle
-Now I want to talk about
-some performance of vImage
 
 00:21:01.066 --> 00:21:04.806 A:middle
 as compared to some of the
@@ -1712,10 +1633,6 @@ below 1 it means OpenCV is going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:56.406 --> 00:22:00.326 A:middle
-than OpenCV, and for numbers
-below 1 it means OpenCV is going
-
 00:22:00.326 --> 00:22:00.916 A:middle
 to be faster.
 
@@ -1783,10 +1700,6 @@ I've got our instantaneous
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.686 --> 00:23:01.246 A:middle
-In the beginning, on the y-axis
-I've got our instantaneous
 
 00:23:01.246 --> 00:23:01.966 A:middle
 power measurement.
@@ -1866,9 +1779,6 @@ for the energy numbers.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.976 --> 00:24:00.486 A:middle
-for the energy numbers.
-
 00:24:01.926 --> 00:24:05.286 A:middle
 So I've got the vImage energy
 savings over OpenCV here.
@@ -1934,10 +1844,6 @@ signal processing.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:24:59.676 --> 00:25:02.416 A:middle
-and that is digital
-signal processing.
 
 00:25:02.966 --> 00:25:06.676 A:middle
 You'll find digital
@@ -2069,10 +1975,6 @@ that you use the DFT.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:56.076 --> 00:27:00.736 A:middle
-to compute, we recommend
-that you use the DFT.
-
 00:27:00.946 --> 00:27:03.366 A:middle
 So this brings up another
 question: How can I be sure
@@ -2150,10 +2052,6 @@ vDSP-DFT-zop-CreateSetup.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.596 --> 00:28:00.726 A:middle
-that with
-vDSP-DFT-zop-CreateSetup.
-
 00:28:01.966 --> 00:28:03.146 A:middle
 It takes a few arguments.
 
@@ -2223,10 +2121,6 @@ comparison now,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:56.146 --> 00:29:00.416 A:middle
-So I want to do another
-comparison now,
-
 00:29:00.616 --> 00:29:02.666 A:middle
 vDSP versus FFTW.
 
@@ -2295,10 +2189,6 @@ We see that vDSP is between
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.606 --> 00:30:06.906 A:middle
-We see that vDSP is between
-1.8 and about 2.5 times faster
-
 00:30:06.936 --> 00:30:09.676 A:middle
 than FFTW for all of these
 number of points that we looked
@@ -2361,10 +2251,6 @@ linking against FFTW.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.266 --> 00:31:02.876 A:middle
-This is when we're
-linking against FFTW.
-
 00:31:02.876 --> 00:31:07.216 A:middle
 The only thing we change
 is we link against vDSP
@@ -2425,9 +2311,6 @@ Highly recommended."
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.296 --> 00:32:00.366 A:middle
-Highly recommended."
 
 00:32:01.586 --> 00:32:02.076 A:middle
 Thank you.
@@ -2494,10 +2377,6 @@ library, it has a collection
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:54.996 --> 00:33:00.206 A:middle
-It's a standard C math
-library, it has a collection
-
 00:33:00.206 --> 00:33:05.496 A:middle
 of transcendental functions
 like exponential, logarithm,
@@ -2554,10 +2433,6 @@ constant 10 as base.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.096 --> 00:34:03.246 A:middle
-one, to use Pow and use
-constant 10 as base.
 
 00:34:04.116 --> 00:34:08.366 A:middle
 However, this is inefficient,
@@ -2616,10 +2491,6 @@ function in terms of pi.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:57.336 --> 00:35:00.546 A:middle
-Next is trigonometry
-function in terms of pi.
 
 00:35:01.906 --> 00:35:04.996 A:middle
 Basically it's the same
@@ -2745,9 +2616,6 @@ Without this, you're more likely
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.986 --> 00:37:01.246 A:middle
-Without this, you're more likely
-
 00:37:01.246 --> 00:37:05.786 A:middle
 to do the real part
 + imaginary part x I.
@@ -2809,10 +2677,6 @@ a single V, so we have vexp,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:59.536 --> 00:38:03.956 A:middle
-We prefix the function then with
-a single V, so we have vexp,
-
 00:38:04.376 --> 00:38:07.056 A:middle
 vlog, vsin, et cetera.
 
@@ -2871,10 +2735,6 @@ function call to vsinf.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.616 --> 00:39:01.406 A:middle
-for loop you make one
-function call to vsinf.
 
 00:39:01.556 --> 00:39:04.216 A:middle
 It will take a SIMD vector
@@ -2942,9 +2802,6 @@ Here's how.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.606 --> 00:40:00.116 A:middle
-Here's how.
 
 00:40:02.376 --> 00:40:04.116 A:middle
 Instead of using a for loop,
@@ -3085,10 +2942,6 @@ number that's 4 bytes aligned,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.296 --> 00:42:01.726 A:middle
-for a single precision floating
-number that's 4 bytes aligned,
-
 00:42:02.176 --> 00:42:04.726 A:middle
 double precision floating point
 number is 8 bytes aligned.
@@ -3163,9 +3016,6 @@ of the presentation.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:56.486 --> 00:43:01.886 A:middle
-&gt;&gt; Geoff: Thanks, Luke.
-
 00:43:03.276 --> 00:43:06.626 A:middle
 So for linear algebra we've got
 the industry standard LAPACK
@@ -3239,10 +3089,6 @@ look at here is using a matrix
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.806 --> 00:44:01.506 A:middle
-The one that we're going to
-look at here is using a matrix
-
 00:44:01.506 --> 00:44:03.546 A:middle
 of 1,000 x 1,000 elements.
 
@@ -3311,10 +3157,6 @@ running on the iPhone 4S.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.756 --> 00:45:04.446 A:middle
-This is the performance
-running on the iPhone 4S.
-
 00:45:04.446 --> 00:45:07.286 A:middle
 Let's look at the performance
 
@@ -3378,10 +3220,6 @@ bake-offs with the Power Mac G5,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:58.926 --> 00:46:02.396 A:middle
-you might remember some of the
-bake-offs with the Power Mac G5,
 
 00:46:02.396 --> 00:46:04.986 A:middle
 so we're having a
@@ -3449,10 +3287,6 @@ Accelerate Framework header,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.306 --> 00:47:00.526 A:middle
-by including the
-Accelerate Framework header,
 
 00:47:00.526 --> 00:47:03.956 A:middle
 and then we're going to
@@ -3609,10 +3443,6 @@ and prepare our data,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:48:59.946 --> 00:49:02.356 A:middle
-As always we'll create
-and prepare our data,
-
 00:49:02.406 --> 00:49:04.816 A:middle
 so we'll align these
 buffers if we can.
@@ -3750,10 +3580,6 @@ in vDSP,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:57.866 --> 00:51:01.596 A:middle
-digital signal processing
-in vDSP,
-
 00:51:01.596 --> 00:51:04.946 A:middle
 transcendental math functions
 in vForce and vMathLib
@@ -3835,9 +3661,6 @@ Understand the problem size.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.786 --> 00:52:01.316 A:middle
-Understand the problem size.
 
 00:52:01.916 --> 00:52:04.506 A:middle
 For small problem sets,
@@ -3921,10 +3744,6 @@ with us, contact Paul or George.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:57.306 --> 00:53:00.356 A:middle
-if you guys need to get in touch
-with us, contact Paul or George.
 
 00:53:00.356 --> 00:53:04.536 A:middle
 There's some documentation

--- a/2013/709.srt
+++ b/2013/709.srt
@@ -60,10 +60,6 @@ There's a lot of small secrets
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.046 --> 00:01:02.736 A:middle
-in Mac OS 9; so long time
-There's a lot of small secrets
-
 00:01:03.006 --> 00:01:04.866 A:middle
 that your programs
 need to handle --
@@ -196,10 +192,6 @@ We call those "metadata."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:02:57.346 --> 00:03:04.256 A:middle
-or that you stick on the side
-We call those "metadata."
-
 00:03:04.256 --> 00:03:09.426 A:middle
 And keychains are optimized
 for storing small secrets
@@ -267,10 +259,6 @@ Thousands of secrets is fine
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:57.236 --> 00:04:01.586 A:middle
-kilobytes probably fine
-Thousands of secrets is fine
 
 00:04:01.586 --> 00:04:04.696 A:middle
 as long as you're not trying
@@ -410,10 +398,6 @@ what you want to spend your time
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.386 --> 00:06:03.486 A:middle
-hard And it's not typically
-what you want to spend your time
 
 00:06:03.486 --> 00:06:05.606 A:middle
 on So that's why you want
@@ -557,10 +541,6 @@ you back the matching value
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.986 --> 00:08:03.416 A:middle
-in the keychain and I'll give
-you back the matching value
-
 00:08:04.426 --> 00:08:08.756 A:middle
 So this is the same
 dictionary that you passed in,
@@ -628,10 +608,6 @@ combination of a lookup
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:59.236 --> 00:09:02.226 A:middle
-because it's sort of a
-combination of a lookup
 
 00:09:02.226 --> 00:09:06.076 A:middle
 and a creation; so it takes
@@ -710,10 +686,6 @@ it away You forget about it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:59.826 --> 00:10:04.066 A:middle
-you're throwing everything about
-it away You forget about it,
-
 00:10:04.066 --> 00:10:06.616 A:middle
 and then you make a new one
 and it gets default values
@@ -786,10 +758,6 @@ user about the password,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:59.446 --> 00:11:01.326 A:middle
-so let's go ask the
-user about the password,
 
 00:11:01.726 --> 00:11:05.016 A:middle
 pop up a dialog or, you
@@ -870,10 +838,6 @@ time or, you know,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.956 --> 00:12:01.896 A:middle
-this may be the first
-time or, you know,
-
 00:12:02.076 --> 00:12:04.246 A:middle
 something may have
 happened to the keychain --
@@ -951,10 +915,6 @@ the user three times,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.576 --> 00:13:01.386 A:middle
-If you want to keep asking
-the user three times,
-
 00:13:01.386 --> 00:13:04.476 A:middle
 as many of you want, you
 know, just add the code,
@@ -1026,10 +986,6 @@ a environmental problems,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.026 --> 00:14:03.716 A:middle
-No Try to distinguish between
-a environmental problems,
-
 00:14:03.966 --> 00:14:07.016 A:middle
 which basically means you don't
 know if the password worked
@@ -1096,10 +1052,6 @@ how hard it is for the user
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:54.656 --> 00:15:00.806 A:middle
-And ask yourself a little bit
-how hard it is for the user
 
 00:15:00.806 --> 00:15:05.096 A:middle
 to get the stuff back We
@@ -1174,10 +1126,6 @@ ask the user for the secret
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:57.806 --> 00:16:01.106 A:middle
-when everything else fails on
-ask the user for the secret
 
 00:16:01.106 --> 00:16:04.546 A:middle
 and then feed it out to the
@@ -1314,10 +1262,6 @@ lot of banks seem to think
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:56.466 --> 00:18:00.246 A:middle
-but strangely enough, a
-lot of banks seem to think
-
 00:18:00.246 --> 00:18:04.406 A:middle
 that they should be
 So think a little bit
@@ -1392,10 +1336,6 @@ in a key value attribute
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:57.476 --> 00:19:00.486 A:middle
-you can just store that
-in a key value attribute
-
 00:19:00.716 --> 00:19:03.396 A:middle
 in your cloud storage, or in
 your file if you're so inclined
@@ -1466,10 +1406,6 @@ you need to know in order
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.716 --> 00:20:04.036 A:middle
-And that's basically all
-you need to know in order
-
 00:20:04.036 --> 00:20:07.946 A:middle
 to use keychains as
 a high-level service
@@ -1516,10 +1452,6 @@ secured, by the user And by
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:54.336 --> 00:21:03.106 A:middle
-it is secured, cryptographically
-secured, by the user And by
 
 00:21:03.106 --> 00:21:06.906 A:middle
 that we mean, by the PIN or
@@ -1579,10 +1511,6 @@ non other, and the user On iOS,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:59.166 --> 00:22:07.366 A:middle
-to this particular phone and
-non other, and the user On iOS,
-
 00:22:07.966 --> 00:22:11.296 A:middle
 by default, if you just use
 the calls that I showed you,
@@ -1639,10 +1567,6 @@ an entitlement It's called the
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:56.646 --> 00:23:01.376 A:middle
-And the way you do it is you add
-an entitlement It's called the
 
 00:23:01.376 --> 00:23:03.666 A:middle
 Keychain-Access-Groups
@@ -1712,10 +1636,6 @@ these names are teamID, dot,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.596 --> 00:24:02.806 A:middle
-with your team ID So all of
-these names are teamID, dot,
 
 00:24:02.806 --> 00:24:05.516 A:middle
 and then make up something
@@ -1790,10 +1710,6 @@ keychain access group;
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.656 --> 00:25:00.746 A:middle
-as essentially a
-keychain access group;
-
 00:25:01.086 --> 00:25:04.176 A:middle
 so by default you're only
 sharing yourself What you do is
@@ -1862,10 +1778,6 @@ but you can What that means is
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:58.316 --> 00:26:01.876 A:middle
-so you don't have to specify
-but you can What that means is
 
 00:26:01.876 --> 00:26:04.216 A:middle
 that keychain items
@@ -1940,10 +1852,6 @@ the user is not using the phone,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:58.256 --> 00:27:02.296 A:middle
-from a background activity while
-the user is not using the phone,
 
 00:27:02.706 --> 00:27:04.866 A:middle
 this is what you need to
@@ -2076,10 +1984,6 @@ as your backups are encrypted --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:59.156 --> 00:29:02.956 A:middle
-up along with the phone as long
-as your backups are encrypted --
-
 00:29:02.956 --> 00:29:05.326 A:middle
 and all of your backups
 are encrypted, right?
@@ -2145,10 +2049,6 @@ looks perfectly,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:56.816 --> 00:30:01.646 A:middle
-All right This all
-looks perfectly,
-
 00:30:01.646 --> 00:30:02.996 A:middle
 so there will be no need
 
@@ -2206,10 +2106,6 @@ code that's running inside
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.616 --> 00:31:01.526 A:middle
-of your app because only
-code that's running inside
 
 00:31:01.526 --> 00:31:03.476 A:middle
 of your app actually can
@@ -2284,10 +2180,6 @@ values that become attributes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:56.376 --> 00:32:01.026 A:middle
-into two classes There are the
-values that become attributes
-
 00:32:01.186 --> 00:32:04.996 A:middle
 and item values They're data
 They are stuff that goes
@@ -2354,10 +2246,6 @@ so And that's it for iOS Hey,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:57.736 --> 00:33:05.566 A:middle
-in doesn't make a sense here
-so And that's it for iOS Hey,
-
 00:33:06.186 --> 00:33:10.226 A:middle
 that's great Welcome back
 OS X crowd The keychain
@@ -2422,10 +2310,6 @@ call SecKeychain APIs
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:56.946 --> 00:34:00.416 A:middle
-on the older APIs we
-call SecKeychain APIs
-
 00:34:00.416 --> 00:34:05.636 A:middle
 because they are all folded
 around the SecKeychain calls
@@ -2483,10 +2367,6 @@ password Just like on iOS,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:34:59.996 --> 00:35:04.006 A:middle
-by the user's login
-password Just like on iOS,
 
 00:35:04.006 --> 00:35:07.026 A:middle
 they are protected by the
@@ -2565,10 +2445,6 @@ The way this is done is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.176 --> 00:36:00.946 A:middle
-to retrieve the item
-The way this is done is
-
 00:36:00.946 --> 00:36:05.126 A:middle
 with access control lists Every
 Keychain item on OS X has an ACL
@@ -2642,10 +2518,6 @@ An access control list
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:59.206 --> 00:37:03.466 A:middle
-So what is in these ACLs
-An access control list
-
 00:37:03.466 --> 00:37:05.746 A:middle
 on a keychain item
 is essentially a list
@@ -2715,10 +2587,6 @@ discussion On OS X if you're
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:56.766 --> 00:38:00.446 A:middle
-end of story There's just no
-discussion On OS X if you're
 
 00:38:00.446 --> 00:38:02.936 A:middle
 in an application that
@@ -2864,10 +2732,6 @@ There's a particular error code,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.356 --> 00:40:03.476 A:middle
-bit more about these prompts
-There's a particular error code,
-
 00:40:03.536 --> 00:40:08.336 A:middle
 one of the OSStatus values that
 can come out of a keychain call,
@@ -2933,10 +2797,6 @@ standard OS X login screen,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.506 --> 00:41:01.466 A:middle
-When you log in through the
-standard OS X login screen,
 
 00:41:01.796 --> 00:41:04.376 A:middle
 the password you type in
@@ -3084,10 +2944,6 @@ So what do you do if you're
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:42:56.666 --> 00:43:00.726 A:middle
-of the problems people have
-So what do you do if you're
-
 00:43:00.726 --> 00:43:02.006 A:middle
 in a nongraphical context?
 
@@ -3160,10 +3016,6 @@ on the access control list
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:59.526 --> 00:44:02.176 A:middle
-that your application isn't
-on the access control list
 
 00:44:02.176 --> 00:44:05.686 A:middle
 of the item, well, that's your
@@ -3239,10 +3091,6 @@ are in a system daemon,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.866 --> 00:45:02.226 A:middle
-default keychain If you
-are in a system daemon,
-
 00:45:02.226 --> 00:45:05.726 A:middle
 you can store secrets in
 the keychain, but it will go
@@ -3311,9 +3159,6 @@ files It's called the
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:45:59.286 --> 00:46:00.186 A:middle
-"security command."
 
 00:46:00.916 --> 00:46:06.996 A:middle
 It's in usr/bin, and because the
@@ -3445,10 +3290,6 @@ that it is for something,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:56.686 --> 00:48:01.016 A:middle
-as the text or data value
-that it is for something,
-
 00:48:01.776 --> 00:48:04.056 A:middle
 authenticating, passing
 it off to a service,
@@ -3506,9 +3347,6 @@ out of there and use them Keys
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:57.806 --> 00:49:00.926 A:middle
-out of there and use them Keys
 
 00:49:00.926 --> 00:49:03.226 A:middle
 and keychains are actually
@@ -3583,10 +3421,6 @@ authentication What --
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:49:59.666 --> 00:50:02.666 A:middle
-for cryptographic
-authentication What --
-
 00:50:05.256 --> 00:50:13.516 A:middle
 yeah Okay All right
 Well, one last thing:
@@ -3632,10 +3466,6 @@ That's all you have to do.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:50:55.546 --> 00:51:05.296 A:middle
-and iOS devices for that user
-That's all you have to do.
 
 00:51:05.296 --> 00:51:05.646 A:middle
 [ Pause ]
@@ -3690,10 +3520,6 @@ feature So to sum it all up:
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:55.886 --> 00:52:03.186 A:middle
-with the application sharing
-feature So to sum it all up:
 
 00:52:04.196 --> 00:52:07.546 A:middle
 Use the keychain APIs to
@@ -3757,10 +3583,6 @@ doing Try not
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.816 --> 00:53:01.456 A:middle
-if that's what you're
-doing Try not
 
 00:53:01.456 --> 00:53:04.286 A:middle
 to manipulate ACLs unless
@@ -3827,10 +3649,6 @@ you're just wondering how all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:53:59.146 --> 00:54:05.006 A:middle
-with how to set this all up If
-you're just wondering how all
 
 00:54:05.006 --> 00:54:07.046 A:middle
 of that cryptographic

--- a/2013/710.srt
+++ b/2013/710.srt
@@ -74,10 +74,6 @@ industry has been investing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:59.276 --> 00:01:01.456 A:middle
-it's because the car
-industry has been investing
-
 00:01:01.456 --> 00:01:04.866 A:middle
 into safety mechanisms
 for a long time.
@@ -170,10 +166,6 @@ make it so that if you wind
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.906 --> 00:02:02.706 A:middle
-of mechanisms that try to
-make it so that if you wind
-
 00:02:02.706 --> 00:02:05.536 A:middle
 up in an accident,
 harm is minimized.
@@ -251,9 +243,6 @@ for a desktop computer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:58.936 --> 00:03:00.116 A:middle
-for a desktop computer.
 
 00:03:00.706 --> 00:03:03.406 A:middle
 In other words, it was
@@ -341,10 +330,6 @@ of look back and think
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:58.986 --> 00:04:02.836 A:middle
-And, again, if you sort
-of look back and think
 
 00:04:02.836 --> 00:04:05.106 A:middle
 about why 40 years ago
@@ -436,10 +421,6 @@ real time and, you know,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:56.056 --> 00:05:00.276 A:middle
-It shows grass growing in
-real time and, you know,
 
 00:05:00.626 --> 00:05:02.436 A:middle
 it connects to the network
@@ -619,10 +600,6 @@ didn't use to be the case.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.706 --> 00:07:03.026 A:middle
-than they do disconnected which
-didn't use to be the case.
-
 00:07:03.346 --> 00:07:05.976 A:middle
 Finding new software, super
 easy; it's never been this easy.
@@ -692,10 +669,6 @@ incredibly complex things behind
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:56.876 --> 00:08:01.536 A:middle
-and frameworks which are doing
-incredibly complex things behind
 
 00:08:01.536 --> 00:08:03.626 A:middle
 the scenes where you might
@@ -771,10 +744,6 @@ to drive security policy
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.666 --> 00:09:01.596 A:middle
-which is, instead of trying
-to drive security policy
 
 00:09:01.596 --> 00:09:04.746 A:middle
 by explicit user
@@ -852,10 +821,6 @@ what your app is meant
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:57.476 --> 00:10:00.856 A:middle
-I mentioned that you specify
-what your app is meant
 
 00:10:00.856 --> 00:10:01.596 A:middle
 to be able to do.
@@ -957,10 +922,6 @@ user's Home Directory.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.286 --> 00:11:00.456 A:middle
-that that location is the
-user's Home Directory.
-
 00:11:01.466 --> 00:11:03.456 A:middle
 So, here's what that looks
 like where we have an app,
@@ -1040,10 +1001,6 @@ actually drawn out of process
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.496 --> 00:12:02.216 A:middle
-and NSSave panels are
-actually drawn out of process
 
 00:12:02.216 --> 00:12:03.546 A:middle
 by a trusted system service.
@@ -1137,10 +1094,6 @@ the App Sandbox world,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:58.266 --> 00:13:00.126 A:middle
-But what happens in
-the App Sandbox world,
-
 00:13:00.816 --> 00:13:03.496 A:middle
 because of the Powerbox, is that
 AppKit realizes it's running
@@ -1218,10 +1171,6 @@ more and more complex,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.806 --> 00:14:02.396 A:middle
-Well because, as apps get
-more and more complex,
 
 00:14:02.396 --> 00:14:03.796 A:middle
 they do more and more things.
@@ -1311,10 +1260,6 @@ when you want them.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:14:57.786 --> 00:15:00.176 A:middle
-whether they're running
-when you want them.
-
 00:15:00.176 --> 00:15:01.736 A:middle
 It's just done for
 you by the OS.
@@ -1400,10 +1345,6 @@ instant messaging client.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.466 --> 00:16:02.706 A:middle
-which is a really popular
-instant messaging client.
-
 00:16:03.306 --> 00:16:05.746 A:middle
 And I'm thrilled to be
 switching to TextEdit this year
@@ -1478,10 +1419,6 @@ Sandbox is just one set of them.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:57.176 --> 00:17:00.226 A:middle
-of various capabilities, App
-Sandbox is just one set of them.
 
 00:17:00.966 --> 00:17:03.606 A:middle
 So, we'll flip on the
@@ -1562,10 +1499,6 @@ some system socket access
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:57.826 --> 00:18:02.276 A:middle
-on SCNetworkReachability and
-some system socket access
 
 00:18:02.276 --> 00:18:04.966 A:middle
 and then some more mach
@@ -1734,10 +1667,6 @@ some boxes, try it,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:57.916 --> 00:20:00.756 A:middle
-in Xcode 5, tick
-some boxes, try it,
-
 00:20:00.916 --> 00:20:04.126 A:middle
 check for violations,
 and you'll be done.
@@ -1817,10 +1746,6 @@ as the apps are used.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:57.856 --> 00:21:00.236 A:middle
-without bound, over time,
-as the apps are used.
 
 00:21:00.596 --> 00:21:03.346 A:middle
 So defaulting to losing the
@@ -1991,10 +1916,6 @@ such as in its container
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:58.686 --> 00:23:05.506 A:middle
-to store anywhere it pleases
-such as in its container
-
 00:23:05.506 --> 00:23:09.596 A:middle
 as a file or in user
 defaults or even in Core Data.
@@ -2073,9 +1994,6 @@ and app-scoped bookmarks.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:59.216 --> 00:24:00.016 A:middle
-and app-scoped bookmarks.
 
 00:24:00.016 --> 00:24:03.946 A:middle
 For document-scope, they
@@ -2239,10 +2157,6 @@ the file system or get renamed.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.636 --> 00:26:01.406 A:middle
-and folders as they move around
-the file system or get renamed.
-
 00:26:02.466 --> 00:26:04.266 A:middle
 But there's one critical
 difference
@@ -2330,10 +2244,6 @@ many, many Sandbox extensions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:26:58.776 --> 00:27:01.806 A:middle
-and you start accumulating many,
-many, many Sandbox extensions
-
 00:27:01.806 --> 00:27:04.756 A:middle
 that were done in this way,
 eventually your app will,
@@ -2413,10 +2323,6 @@ disk that they all share
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.336 --> 00:28:00.736 A:middle
-to have a scratch base on
-disk that they all share
 
 00:28:00.736 --> 00:28:04.716 A:middle
 or that they want to be
@@ -2501,10 +2407,6 @@ the helper's container directly.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:57.396 --> 00:29:00.736 A:middle
-Well, our main app can't access
-the helper's container directly.
-
 00:29:00.736 --> 00:29:02.316 A:middle
 The Sandbox prohibits this.
 
@@ -2586,9 +2488,6 @@ that sort of makes sense.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.806 --> 00:30:00.226 A:middle
-that sort of makes sense.
-
 00:30:01.066 --> 00:30:02.566 A:middle
 But there are some cases
 
@@ -2667,10 +2566,6 @@ specify that RTF is related
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.096 --> 00:31:03.226 A:middle
-And in this case, you can
-specify that RTF is related
 
 00:31:03.226 --> 00:31:07.176 A:middle
 to RTFD so that if the user
@@ -2752,10 +2647,6 @@ allows a Sandboxed app to go
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.836 --> 00:32:03.566 A:middle
-restrictions, but the Sandbox
-allows a Sandboxed app to go
-
 00:32:03.566 --> 00:32:05.156 A:middle
 and script Finder or Terminal,
 
@@ -2836,10 +2727,6 @@ user to send E-mail.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:58.956 --> 00:33:00.666 A:middle
-and get ready for the
-user to send E-mail.
 
 00:33:00.956 --> 00:33:02.976 A:middle
 iTunes, similarly, has a
@@ -2923,10 +2810,6 @@ triggered, a script should run.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:56.486 --> 00:34:01.176 A:middle
-that when a certain mail rule is
-triggered, a script should run.
 
 00:34:01.176 --> 00:34:03.396 A:middle
 Aperture allows you to set that
@@ -3018,10 +2901,6 @@ scripts can run uninhibited
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.926 --> 00:35:00.376 A:middle
-Once that happens, those
-scripts can run uninhibited
-
 00:35:00.376 --> 00:35:01.196 A:middle
 by the Sandbox.
 
@@ -3099,10 +2978,6 @@ forth, then Sandbox apps,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.036 --> 00:36:01.026 A:middle
-or different disks and so
-forth, then Sandbox apps,
 
 00:36:01.026 --> 00:36:03.206 A:middle
 even though they could
@@ -3193,10 +3068,6 @@ Sandbox launched.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.766 --> 00:37:00.366 A:middle
-around since App
-Sandbox launched.
-
 00:37:00.806 --> 00:37:01.986 A:middle
 As I'm sure most of you know,
 
@@ -3272,10 +3143,6 @@ common kinds of things
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:57.926 --> 00:38:00.596 A:middle
-that I think are the most
-common kinds of things
 
 00:38:00.596 --> 00:38:01.506 A:middle
 that you might run in to.
@@ -3365,10 +3232,6 @@ really only enable the ones
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.396 --> 00:39:00.616 A:middle
-that you don't need,
-really only enable the ones
 
 00:39:00.616 --> 00:39:03.026 A:middle
 that your app clearly
@@ -3465,10 +3328,6 @@ of figure out why,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.376 --> 00:40:01.936 A:middle
-that we can kind
-of figure out why,
-
 00:40:02.336 --> 00:40:05.656 A:middle
 but it doesn't fully match the
 model so here's an example.
@@ -3555,9 +3414,6 @@ That's not what most apps do so,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:57.766 --> 00:41:00.316 A:middle
-That's not what most apps do so,
 
 00:41:00.736 --> 00:41:03.506 A:middle
 if you're selecting the
@@ -3650,10 +3506,6 @@ some point in the future,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:41:59.486 --> 00:42:01.356 A:middle
-and it's simply that, at
-some point in the future,
 
 00:42:01.356 --> 00:42:04.926 A:middle
 as a better mechanism becomes
@@ -3826,10 +3678,6 @@ vocabulary of our iOS users
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:57.526 --> 00:44:00.566 A:middle
-Those are simply not in the
-vocabulary of our iOS users
 
 00:44:00.566 --> 00:44:02.096 A:middle
 because the Sandbox,

--- a/2013/711.srt
+++ b/2013/711.srt
@@ -81,10 +81,6 @@ printing architecture.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.386 --> 00:01:01.056 A:middle
-So let's start with the
-printing architecture.
-
 00:01:01.286 --> 00:01:02.796 A:middle
 Apple has a long tradition.
 
@@ -167,9 +163,6 @@ for application developers.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:59.336 --> 00:02:00.946 A:middle
-for application developers.
-
 00:02:01.506 --> 00:02:07.856 A:middle
 So what we have done is for
 iOS we've brought over the best
@@ -238,10 +231,6 @@ carving them on stone tablets
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.586 --> 00:03:02.116 A:middle
-of time when they were
-carving them on stone tablets
 
 00:03:02.116 --> 00:03:03.316 A:middle
 and putting them in pyramids.
@@ -318,10 +307,6 @@ in iOS 4.2 so iOS 4.2
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:03:56.326 --> 00:04:00.466 A:middle
-AirPrint was released
-in iOS 4.2 so iOS 4.2
 
 00:04:00.466 --> 00:04:01.646 A:middle
 and later will support that.
@@ -403,10 +388,6 @@ I show you have printers
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:58.786 --> 00:05:01.806 A:middle
-This list of licensees that
-I show you have printers
 
 00:05:01.806 --> 00:05:03.816 A:middle
 that have AirPrint
@@ -493,10 +474,6 @@ update for an existing printer.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:57.656 --> 00:06:00.266 A:middle
-Actually it's a firmware
-update for an existing printer.
 
 00:06:00.786 --> 00:06:02.086 A:middle
 Awesome printer and we're going
@@ -643,9 +620,6 @@ for the Enterprise class.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:59.916 --> 00:08:01.646 A:middle
-for the Enterprise class.
-
 00:08:01.646 --> 00:08:03.866 A:middle
 Label printers, I
 mentioned Brother already,
@@ -727,10 +701,6 @@ to print to all
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:58.656 --> 00:09:00.536 A:middle
-and you'll be able
-to print to all
 
 00:09:00.536 --> 00:09:02.976 A:middle
 of their printers plus
@@ -816,10 +786,6 @@ IPPS which secure IPP with TLS
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:09:58.706 --> 00:10:04.086 A:middle
-AirPrint natively supports
-IPPS which secure IPP with TLS
-
 00:10:04.536 --> 00:10:06.976 A:middle
 and we support users in groups.
 
@@ -893,10 +859,6 @@ need to know anything.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:10:58.016 --> 00:11:00.046 A:middle
-well really you don't
-need to know anything.
 
 00:11:00.176 --> 00:11:02.156 A:middle
 All of these changes are
@@ -978,10 +940,6 @@ everything at print time
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:58.406 --> 00:12:01.966 A:middle
-You should be able to draw
-everything at print time
 
 00:12:02.366 --> 00:12:05.566 A:middle
 in high quality and you should
@@ -1072,10 +1030,6 @@ return procedures printed
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.846 --> 00:13:02.286 A:middle
-with the address of the
-return procedures printed
-
 00:13:02.286 --> 00:13:02.876 A:middle
 on the bottom.
 
@@ -1151,10 +1105,6 @@ different classes that are set
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:13:59.816 --> 00:14:02.516 A:middle
-And we have a couple of
-different classes that are set
 
 00:14:02.516 --> 00:14:06.286 A:middle
 up that will make this
@@ -1328,10 +1278,6 @@ not going to look right.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:59.406 --> 00:16:00.846 A:middle
-that their output is
-not going to look right.
-
 00:16:01.546 --> 00:16:03.686 A:middle
 Printers also have
 paper size sensors.
@@ -1429,10 +1375,6 @@ has a caption, we have footers
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.206 --> 00:17:02.696 A:middle
-There's you know the picture
-has a caption, we have footers
 
 00:17:02.696 --> 00:17:04.675 A:middle
 at the bottom that tell
@@ -1611,10 +1553,6 @@ print and release situations
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:58.876 --> 00:19:02.126 A:middle
-Howard mentioned servers, for
-print and release situations
-
 00:19:02.126 --> 00:19:04.856 A:middle
 and stuff, users will
 be identifying their job
@@ -1703,10 +1641,6 @@ the network is lower.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:19:58.996 --> 00:20:01.096 A:middle
-so that the data over
-the network is lower.
 
 00:20:01.396 --> 00:20:04.036 A:middle
 We'll tell the printer to print
@@ -1798,10 +1732,6 @@ of the page at the printer
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.546 --> 00:21:03.506 A:middle
-It's basically just the size
-of the page at the printer
-
 00:21:04.106 --> 00:21:06.796 A:middle
 and then inside of that we
 have the printable area.
@@ -1883,10 +1813,6 @@ memory in the form of NSData
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.746 --> 00:22:03.646 A:middle
-or elsewhere, it could be in
-memory in the form of NSData
 
 00:22:04.146 --> 00:22:08.166 A:middle
 or a UIImage or CI image
@@ -1974,10 +1900,6 @@ to be output general.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.176 --> 00:23:02.386 A:middle
-We'll set the output type
-to be output general.
-
 00:23:02.526 --> 00:23:05.566 A:middle
 This makes sense for PDF because
 PDF typically have, you know,
@@ -2060,10 +1982,6 @@ thing to get to know.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.426 --> 00:24:00.116 A:middle
-formatters are the first
-thing to get to know.
-
 00:24:01.356 --> 00:24:02.706 A:middle
 Now what exactly is a formatter?
 
@@ -2145,10 +2063,6 @@ as a helper in a full renderer
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.356 --> 00:25:02.586 A:middle
-You can also use formatters
-as a helper in a full renderer
-
 00:25:02.656 --> 00:25:03.676 A:middle
 and we'll go over that later.
 
@@ -2223,10 +2137,6 @@ of using a formatter
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:56.796 --> 00:26:01.326 A:middle
-So here's an easy example
-of using a formatter
 
 00:26:01.326 --> 00:26:04.076 A:middle
 to print some HTML text.
@@ -2385,10 +2295,6 @@ with a formatter look like?
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:27:58.516 --> 00:28:01.276 A:middle
-Now what does a renderer
-with a formatter look like?
 
 00:28:02.316 --> 00:28:03.516 A:middle
 Well here we have
@@ -2567,10 +2473,6 @@ the actual web page printed out.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.076 --> 00:30:01.126 A:middle
-they're probably going to want
-the actual web page printed out.
-
 00:30:01.656 --> 00:30:05.116 A:middle
 So here we're actually adding a
 renderer to our activity items
@@ -2645,10 +2547,6 @@ printInteractionController
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:30:58.686 --> 00:31:01.426 A:middle
-Your class will implement
-printInteractionController
 
 00:31:01.486 --> 00:31:02.536 A:middle
 ParentViewController.
@@ -2735,10 +2633,6 @@ user has selected the printer,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.146 --> 00:32:01.316 A:middle
-This gets called after the
-user has selected the printer,
 
 00:32:02.126 --> 00:32:03.696 A:middle
 iOS communicates with
@@ -2837,10 +2731,6 @@ passed in a UIPrintPaper.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:57.826 --> 00:33:00.746 A:middle
-but in this case you're
-passed in a UIPrintPaper.
-
 00:33:01.706 --> 00:33:04.296 A:middle
 Once the user selected a
 printer that has a roll loaded,
@@ -2932,10 +2822,6 @@ selects a roll printer,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:33:59.006 --> 00:34:01.636 A:middle
-And then when user
-selects a roll printer,
-
 00:34:01.636 --> 00:34:03.476 A:middle
 we'll be printing a
 banner so it will come
@@ -3014,10 +2900,6 @@ boiler plate things
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:58.456 --> 00:35:02.816 A:middle
-We have some pretty
-boiler plate things
-
 00:35:02.816 --> 00:35:05.826 A:middle
 that are just finding the
 font that the user selected
@@ -3093,10 +2975,6 @@ to be the users chosen color
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:35:58.256 --> 00:36:02.176 A:middle
-We set the text formatters color
-to be the users chosen color
-
 00:36:02.686 --> 00:36:04.606 A:middle
 and the font to be
 the users chosen font.
@@ -3169,10 +3047,6 @@ with the size we calculated.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.526 --> 00:37:00.536 A:middle
-that we just calculated
-with the size we calculated.
-
 00:37:02.926 --> 00:37:05.866 A:middle
 Now next we actually have
 to figure out the margins.
@@ -3233,9 +3107,6 @@ We'll enter some text in here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:54.196 --> 00:38:01.266 A:middle
-[ Silence ]
 
 00:38:01.766 --> 00:38:03.966 A:middle
 San Francisco is
@@ -3316,10 +3187,6 @@ with our simulated printer?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.496 --> 00:39:02.106 A:middle
-So how do we set a size
-with our simulated printer?
-
 00:39:03.586 --> 00:39:06.476 A:middle
 Well we have this load
 paper button here in the UI.
@@ -3385,10 +3252,6 @@ an actual real printer here.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:56.106 --> 00:40:00.876 A:middle
-Now as Howard mentioned we have
-an actual real printer here.
 
 00:40:01.646 --> 00:40:04.486 A:middle
 We'll go ahead and choose that.
@@ -3468,10 +3331,6 @@ output.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:58.796 --> 00:41:00.046 A:middle
-so you can make beautiful
-output.
 
 00:41:00.426 --> 00:41:03.526 A:middle
 And like I mentioned the printer

--- a/2013/712.srt
+++ b/2013/712.srt
@@ -67,10 +67,6 @@ they see "Oh, the battery is low
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.526 --> 00:01:02.716 A:middle
-If it's the middle of the week,
-they see "Oh, the battery is low
-
 00:01:02.766 --> 00:01:05.946 A:middle
 and I'll open up the battery
 status menu and see what's going
@@ -139,10 +135,6 @@ with some background.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:57.836 --> 00:02:02.606 A:middle
-But first, let's start
-with some background.
-
 00:02:03.206 --> 00:02:07.626 A:middle
 What are the things that your
 app can do to use energy?
@@ -202,10 +194,6 @@ size of the battery.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.706 --> 00:03:00.266 A:middle
-and that's by the
-size of the battery.
 
 00:03:01.156 --> 00:03:05.446 A:middle
 And this is important
@@ -333,10 +321,6 @@ adds up to a lot of energy.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:59.816 --> 00:05:02.986 A:middle
-but over the long term it
-adds up to a lot of energy.
-
 00:05:03.586 --> 00:05:11.586 A:middle
 And then when the user
 requests action, you want to be
@@ -396,9 +380,6 @@ just look at the energy tab
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:05:59.586 --> 00:06:01.286 A:middle
-just look at the energy tab
 
 00:06:01.936 --> 00:06:03.616 A:middle
 in the Activity Monitor
@@ -462,10 +443,6 @@ run the top command of course,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.586 --> 00:07:02.436 A:middle
-with the Unix shell, you can
-run the top command of course,
 
 00:07:02.666 --> 00:07:05.136 A:middle
 look at the percent CPU column.
@@ -537,10 +514,6 @@ problems.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.856 --> 00:08:00.766 A:middle
-to diagnose performance
-problems.
 
 00:08:01.046 --> 00:08:03.316 A:middle
 If you haven't used
@@ -756,10 +729,6 @@ know, open/closed system calls,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.266 --> 00:11:02.966 A:middle
-So these are things like, you
-know, open/closed system calls,
-
 00:11:03.666 --> 00:11:08.216 A:middle
 read/writes from the network,
 disk I/Os, things like that.
@@ -822,10 +791,6 @@ go back, give that a watch
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:59.366 --> 00:12:01.976 A:middle
-So I highly recommend you
-go back, give that a watch
 
 00:12:02.076 --> 00:12:02.996 A:middle
 when you get a chance.
@@ -898,9 +863,6 @@ because it's using the CPU.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.036 --> 00:13:00.426 A:middle
-because it's using the CPU.
-
 00:13:01.136 --> 00:13:04.956 A:middle
 And in a lot of cases, this
 drawing could be invisible
@@ -964,10 +926,6 @@ periodic events or future events
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.006 --> 00:14:02.466 A:middle
-Timers are used to schedule
-periodic events or future events
-
 00:14:02.466 --> 00:14:06.306 A:middle
 and drive animations,
 you use timers.
@@ -1024,10 +982,6 @@ your app out of idle,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:55.986 --> 00:15:00.626 A:middle
-out of idle, bringing
-your app out of idle,
 
 00:15:00.626 --> 00:15:03.186 A:middle
 getting your app
@@ -1110,10 +1064,6 @@ APIs in Grand Central Dispatch,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:54.916 --> 00:16:01.426 A:middle
-Of course we have explicit timer
-APIs in Grand Central Dispatch,
-
 00:16:01.646 --> 00:16:03.706 A:middle
 Core Foundation -- foundation.
 
@@ -1183,10 +1133,6 @@ easier to see the timer usage
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:55.616 --> 00:17:01.206 A:middle
-In Mavericks, it's a lot
-easier to see the timer usage
 
 00:17:01.206 --> 00:17:03.906 A:middle
 of your app if you go back
@@ -1261,10 +1207,6 @@ of wakes over the last second
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:56.546 --> 00:18:00.226 A:middle
-This will give you the number
-of wakes over the last second
 
 00:18:00.876 --> 00:18:06.246 A:middle
 and a readout of your
@@ -1393,10 +1335,6 @@ just run the completion block."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:58.066 --> 00:20:01.326 A:middle
-"And then once it's done, I'll
-just run the completion block."
-
 00:20:01.876 --> 00:20:04.776 A:middle
 Well, first of all, this doesn't
 work for several reasons.
@@ -1489,10 +1427,6 @@ will just automatically run
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:20:58.676 --> 00:21:01.566 A:middle
-And then the completion block
-will just automatically run
-
 00:21:01.896 --> 00:21:04.546 A:middle
 when the work is done, no
 need to wake up and check.
@@ -1565,9 +1499,6 @@ like DISPATCH SOURCE TYPE VNODE
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:59.566 --> 00:22:01.256 A:middle
-like DISPATCH SOURCE TYPE VNODE
 
 00:22:02.306 --> 00:22:05.276 A:middle
 for a small scale
@@ -1651,10 +1582,6 @@ notification, so you don't have
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:22:59.626 --> 00:23:02.586 A:middle
-and network reachability
-notification, so you don't have
-
 00:23:02.646 --> 00:23:04.406 A:middle
 to wake up and say,
 "Can I reach the server?
@@ -1723,10 +1650,6 @@ doing anything special
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:23:58.116 --> 00:24:00.906 A:middle
-but I'm not really
-doing anything special
 
 00:24:01.206 --> 00:24:03.316 A:middle
 if dispatch semaphore
@@ -1802,10 +1725,6 @@ to do some work.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:58.346 --> 00:25:00.896 A:middle
-up a recurring timer
-to do some work.
-
 00:25:01.946 --> 00:25:03.686 A:middle
 And it's doing some
 valuable work for me,
@@ -1877,10 +1796,6 @@ idle in its low power state.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:25:58.216 --> 00:26:02.546 A:middle
-and the more the system is
-idle in its low power state.
-
 00:26:03.086 --> 00:26:08.426 A:middle
 So it's really easy to specify
 a tolerance for all your timers
@@ -1937,10 +1852,6 @@ I'm interested in.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:59.666 --> 00:27:01.776 A:middle
-of all the stocks
-I'm interested in.
 
 00:27:02.736 --> 00:27:04.966 A:middle
 And look, it's even
@@ -2006,10 +1917,6 @@ then it will show me those
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:57.486 --> 00:28:01.836 A:middle
-where it's executing, and
-then it will show me those
-
 00:28:01.836 --> 00:28:02.816 A:middle
 in the call to review.
 
@@ -2066,9 +1973,6 @@ If I run this again, I'll turn
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:51.716 --> 00:29:01.086 A:middle
-If I run this again, I'll turn
 
 00:29:01.086 --> 00:29:04.366 A:middle
 on show view drawing
@@ -2143,10 +2047,6 @@ from the network,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:29:58.926 --> 00:30:00.636 A:middle
-It's not getting data
-from the network,
 
 00:30:00.636 --> 00:30:03.546 A:middle
 it's getting data
@@ -2325,10 +2225,6 @@ things to debug, it looks like.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:59.126 --> 00:33:01.576 A:middle
-I still have a few other
-things to debug, it looks like.
-
 00:33:02.186 --> 00:33:05.816 A:middle
 So-- but let me show
 you one more thing.
@@ -2391,9 +2287,6 @@ So let me go back in Xcode.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:57.146 --> 00:34:05.546 A:middle
-So let me go back in Xcode.
 
 00:34:05.706 --> 00:34:10.966 A:middle
 OK, so this is the timer that
@@ -2463,10 +2356,6 @@ when it's not in use.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.736 --> 00:35:01.546 A:middle
-My app is absolutely idle
-when it's not in use.
-
 00:35:02.936 --> 00:35:07.866 A:middle
 OK, let's go back to the slides.
 
@@ -2527,10 +2416,6 @@ to do every so often.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:57.796 --> 00:36:00.156 A:middle
-that you know you have
-to do every so often.
 
 00:36:00.916 --> 00:36:02.426 A:middle
 And I want to show
@@ -2748,10 +2633,6 @@ say, "OK, is the image stale?
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:38:59.526 --> 00:39:02.996 A:middle
-And then in that routine I
-say, "OK, is the image stale?
-
 00:39:03.206 --> 00:39:04.366 A:middle
 If so, remove it.
 
@@ -2824,9 +2705,6 @@ Prune all the stale ones.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:56.516 --> 00:40:00.026 A:middle
-[ Pause ]
 
 00:40:00.526 --> 00:40:05.266 A:middle
 And you may have some periodic
@@ -2901,10 +2779,6 @@ an hour, 3,600 seconds,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:40:56.246 --> 00:41:00.656 A:middle
-I want this to happen in
-an hour, 3,600 seconds,
-
 00:41:00.706 --> 00:41:04.916 A:middle
 but I'm OK if it doesn't start
 for another 6 hours after that,
@@ -2975,10 +2849,6 @@ week, Efficient Design with XPC.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:57.196 --> 00:42:00.686 A:middle
-there's a session earlier this
-week, Efficient Design with XPC.
-
 00:42:00.766 --> 00:42:04.116 A:middle
 If you're interested, go ahead
 and give that a watch online.
@@ -3036,10 +2906,6 @@ S Technologies Evangelist,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:59.126 --> 00:43:01.936 A:middle
-you can contact our Core
-S Technologies Evangelist,
 
 00:43:01.936 --> 00:43:02.976 A:middle
 that's Paul Denbaum.
@@ -3112,10 +2978,6 @@ the XPC session,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:43:57.226 --> 00:44:01.216 A:middle
-Of course there was
-the XPC session,
 
 00:44:01.216 --> 00:44:05.966 A:middle
 and I highly recommend the

--- a/2013/713.srt
+++ b/2013/713.srt
@@ -77,10 +77,6 @@ a collection of functions
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:58.496 --> 00:01:01.116 A:middle
-The Accelerate Framework is
-a collection of functions
-
 00:01:01.116 --> 00:01:04.286 A:middle
 of commonly used computationally
 intensive operations.
@@ -168,10 +164,6 @@ so that you don't have to.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:01:58.606 --> 00:02:03.276 A:middle
-We spent a lot of time testing
-so that you don't have to.
-
 00:02:04.196 --> 00:02:06.886 A:middle
 The big one is fast
 with low energy usage.
@@ -244,10 +236,6 @@ and vForce and vMathLive,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:57.976 --> 00:03:01.556 A:middle
-transcendental math functions
-and vForce and vMathLive,
 
 00:03:03.106 --> 00:03:06.876 A:middle
 and finally, linear
@@ -330,10 +318,6 @@ Accelerate Framework is fast is
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:03:58.296 --> 00:04:03.366 A:middle
-One of the big reasons the
-Accelerate Framework is fast is
-
 00:04:03.366 --> 00:04:05.166 A:middle
 we utilize SIMD instructions.
 
@@ -407,10 +391,6 @@ it requires a certain amount
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:04:57.516 --> 00:05:00.256 A:middle
-So I bring these up because
-it requires a certain amount
 
 00:05:00.256 --> 00:05:01.666 A:middle
 of data before optimizations
@@ -507,10 +487,6 @@ Framework we always strive
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:58.786 --> 00:06:01.916 A:middle
-With the Accelerate
-Framework we always strive
-
 00:06:01.916 --> 00:06:03.396 A:middle
 to deliver the greatest
 performance,
@@ -601,10 +577,6 @@ be as small as 8 elements.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:06:59.286 --> 00:07:02.826 A:middle
-Matrix Multiply, it could
-be as small as 8 elements.
-
 00:07:04.086 --> 00:07:06.196 A:middle
 The best thing you can
 do here is to experiment.
@@ -683,10 +655,6 @@ to the Accelerate Framework,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:07:58.376 --> 00:08:00.786 A:middle
-For those of you brand new
-to the Accelerate Framework,
-
 00:08:01.046 --> 00:08:03.896 A:middle
 including it is just like
 including any other framework.
@@ -761,10 +729,6 @@ details of what's available
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:08:57.396 --> 00:09:03.256 A:middle
-So now I want to dive into the
-details of what's available
 
 00:09:03.256 --> 00:09:04.316 A:middle
 in the Accelerate Framework.
@@ -899,10 +863,6 @@ performance.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:58.636 --> 00:11:00.556 A:middle
-to deliver the maximum
-performance.
-
 00:11:03.696 --> 00:11:07.046 A:middle
 We also introduced
 resampling of 16-bit images,
@@ -974,10 +934,6 @@ to look at how to go
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:11:59.746 --> 00:12:03.646 A:middle
-So here we're going
-to look at how to go
-
 00:12:03.646 --> 00:12:06.646 A:middle
 from a CGImage ref
 to a vImage buffer.
@@ -1041,10 +997,6 @@ describing an ARGB 8-bit image.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:12:56.796 --> 00:13:00.576 A:middle
-This descriptor is
-describing an ARGB 8-bit image.
 
 00:13:01.876 --> 00:13:03.816 A:middle
 We see that the first entry
@@ -1123,10 +1075,6 @@ about background color.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.636 --> 00:14:01.706 A:middle
-This is information
-about background color.
-
 00:14:02.706 --> 00:14:05.916 A:middle
 In certain conversions when
 alpha channels are involved,
@@ -1198,10 +1146,6 @@ that we created before.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.506 --> 00:15:01.676 A:middle
-to use our same format specifier
-that we created before.
 
 00:15:02.386 --> 00:15:05.536 A:middle
 To create the CGImage
@@ -1276,10 +1220,6 @@ allocated CGImage ref containing
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:15:58.536 --> 00:16:03.336 A:middle
-This is going to be a freshly
-allocated CGImage ref containing
-
 00:16:03.486 --> 00:16:07.246 A:middle
 the image information,
 and we are free
@@ -1346,10 +1286,6 @@ you an example of hits
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:16:59.336 --> 00:17:01.216 A:middle
-and I want to show
-you an example of hits
 
 00:17:01.216 --> 00:17:02.576 A:middle
 with a real world application.
@@ -1426,9 +1362,6 @@ We see a few things here.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:17:57.536 --> 00:18:01.786 A:middle
-We see a few things here.
-
 00:18:02.266 --> 00:18:03.976 A:middle
 First we see a lot
 of variability.
@@ -1494,10 +1427,6 @@ format to the other format,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:18:58.416 --> 00:19:01.116 A:middle
-converting from the input image
-format to the other format,
 
 00:19:01.706 --> 00:19:04.266 A:middle
 to a very small percent
@@ -1570,10 +1499,6 @@ to perform the scale.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:59.566 --> 00:20:02.656 A:middle
-In step two, we're going
-to perform the scale.
-
 00:20:03.926 --> 00:20:05.706 A:middle
 And then in step
 three we're going
@@ -1639,10 +1564,6 @@ some performance of vImage
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:53.996 --> 00:21:00.986 A:middle
-Now I want to talk about
-some performance of vImage
 
 00:21:00.986 --> 00:21:04.736 A:middle
 as compared to some of the
@@ -1715,10 +1636,6 @@ below 1 it means OpenCV is going
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:21:56.296 --> 00:22:00.256 A:middle
-than OpenCV, and for numbers
-below 1 it means OpenCV is going
-
 00:22:00.256 --> 00:22:00.846 A:middle
 to be faster.
 
@@ -1786,10 +1703,6 @@ I've got our instantaneous
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:57.616 --> 00:23:01.186 A:middle
-In the beginning, on the y-axis
-I've got our instantaneous
 
 00:23:01.186 --> 00:23:01.896 A:middle
 power measurement.
@@ -1869,9 +1782,6 @@ for the energy numbers.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:58.876 --> 00:24:00.416 A:middle
-for the energy numbers.
-
 00:24:01.856 --> 00:24:05.216 A:middle
 So I've got the vImage energy
 savings over OpenCV here.
@@ -1938,10 +1848,6 @@ signal processing.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.596 --> 00:25:02.346 A:middle
-and that is digital
-signal processing.
-
 00:25:02.906 --> 00:25:06.606 A:middle
 You'll find digital
 signal processing in vDSP.
@@ -2002,10 +1908,6 @@ calls into an IIR filter.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:56.246 --> 00:26:00.296 A:middle
-that with individual
-calls into an IIR filter.
 
 00:26:00.456 --> 00:26:02.136 A:middle
 Now with this new
@@ -2075,10 +1977,6 @@ that you use the DFT.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:26:56.006 --> 00:27:00.666 A:middle
-to compute, we recommend
-that you use the DFT.
 
 00:27:00.876 --> 00:27:03.306 A:middle
 So this brings up another
@@ -2156,9 +2054,6 @@ that with vDSP zop create setup.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:58.526 --> 00:28:00.616 A:middle
-that with vDSP zop create setup.
-
 00:28:01.896 --> 00:28:03.076 A:middle
 Takes a few arguments.
 
@@ -2228,10 +2123,6 @@ comparison now vDSP versus FFTW.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:28:56.046 --> 00:29:02.596 A:middle
-So I want to do another
-comparison now vDSP versus FFTW.
-
 00:29:04.126 --> 00:29:07.886 A:middle
 FFTW is called Fastest
 Fourier Transform in the West.
@@ -2299,10 +2190,6 @@ We see that vDSP is between
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:29:58.536 --> 00:30:06.836 A:middle
-We see that vDSP is between
-1.8 and about 2.5 times faster
-
 00:30:06.886 --> 00:30:09.606 A:middle
 than FFTW for all of these
 number of points that we looked
@@ -2365,10 +2252,6 @@ linking against FFTW.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:59.196 --> 00:31:02.816 A:middle
-This is when we're
-linking against FFTW.
-
 00:31:02.816 --> 00:31:07.156 A:middle
 The only thing we change
 is we link against vDSP
@@ -2429,9 +2312,6 @@ Highly recommended.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:31:59.226 --> 00:32:00.296 A:middle
-Highly recommended.
 
 00:32:01.516 --> 00:32:02.006 A:middle
 Thank you.
@@ -2498,10 +2378,6 @@ library, it has a collection
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:32:54.936 --> 00:33:00.766 A:middle
-It's a standard C math
-library, it has a collection
-
 00:33:00.766 --> 00:33:05.426 A:middle
 of [inaudible] like
 exponents, logarithm,
@@ -2558,10 +2434,6 @@ constant 10 as base.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:59.026 --> 00:34:03.166 A:middle
-one, to use Pow and use
-constant 10 as base.
 
 00:34:04.046 --> 00:34:08.295 A:middle
 However, this is inefficient,
@@ -2621,10 +2493,6 @@ function in terms of pi.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:57.266 --> 00:35:00.486 A:middle
-Next is trigonometry
-function in terms of pi.
-
 00:35:01.836 --> 00:35:04.926 A:middle
 Basically it's the same
 regular trigonometry function
@@ -2680,10 +2548,6 @@ sine/cosine pairs.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:56.556 --> 00:36:01.936 A:middle
-There's no error
-sine/cosine pairs.
 
 00:36:03.276 --> 00:36:05.096 A:middle
 A lot of times when
@@ -2743,9 +2607,6 @@ Without this, you're more likely
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:36:58.916 --> 00:37:01.176 A:middle
-Without this, you're more likely
 
 00:37:01.176 --> 00:37:05.716 A:middle
 to do the real part
@@ -2808,10 +2669,6 @@ with a single V, so we have VX,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:37:58.516 --> 00:38:04.436 A:middle
-We prefix the function then
-with a single V, so we have VX,
-
 00:38:04.436 --> 00:38:06.986 A:middle
 Vlog, Vsine, et cetera.
 
@@ -2870,10 +2727,6 @@ function call to VsineF.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:38:58.546 --> 00:39:02.326 A:middle
-for loop you make one
-function call to VsineF.
 
 00:39:02.716 --> 00:39:04.156 A:middle
 You will take your SIMD vector
@@ -2941,9 +2794,6 @@ Here's how.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:39:59.536 --> 00:40:00.036 A:middle
-Here's how.
 
 00:40:02.296 --> 00:40:04.036 A:middle
 Instead of using a for loop,
@@ -3084,10 +2934,6 @@ number that's 4 bytes aligned,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:58.226 --> 00:42:01.646 A:middle
-for a single precision floating
-number that's 4 bytes aligned,
-
 00:42:02.106 --> 00:42:04.656 A:middle
 double precision floating point
 number is 8 bytes aligned.
@@ -3155,9 +3001,6 @@ of the presentation.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:57.516 --> 00:43:00.816 A:middle
-[Applause]
 
 00:43:01.316 --> 00:43:01.826 A:middle
 &gt;&gt; Jeff: Thanks, Luke.
@@ -3235,10 +3078,6 @@ look at here is using a matrix
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:58.736 --> 00:44:01.436 A:middle
-The one that we're going to
-look at here is using a matrix
-
 00:44:01.436 --> 00:44:03.466 A:middle
 of 1,000 x 1,000 elements.
 
@@ -3307,10 +3146,6 @@ running on the iPhone 4S.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:44:59.686 --> 00:45:04.376 A:middle
-This is the performance
-running on the iPhone 4S.
-
 00:45:04.376 --> 00:45:07.216 A:middle
 Let's look at the performance
 
@@ -3375,10 +3210,6 @@ bake-offs with the Power Mac G5,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.856 --> 00:46:01.726 A:middle
-you might remember some of the
-bake-offs with the Power Mac G5,
-
 00:46:02.326 --> 00:46:04.916 A:middle
 so we're having a
 triumphant return.
@@ -3442,10 +3273,6 @@ Accelerate Framework header,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:58.236 --> 00:47:00.466 A:middle
-by including the
-Accelerate Framework header,
 
 00:47:00.466 --> 00:47:03.886 A:middle
 and then we're going to
@@ -3532,10 +3359,6 @@ vector that we created,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:47:59.946 --> 00:48:03.046 A:middle
-and then the pivot
-vector that we created,
-
 00:48:03.956 --> 00:48:05.446 A:middle
 and that right-hand sides B.
 
@@ -3606,10 +3429,6 @@ and prepare our data,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:48:59.876 --> 00:49:02.296 A:middle
-As always we'll create
-and prepare our data,
 
 00:49:02.336 --> 00:49:04.766 A:middle
 so we'll align these
@@ -3748,10 +3567,6 @@ in vDSP,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:50:57.796 --> 00:51:01.526 A:middle
-digital signal processing
-in vDSP,
-
 00:51:01.526 --> 00:51:04.876 A:middle
 transcendental math functions
 in vForce and vMathLib
@@ -3833,9 +3648,6 @@ Understand the problem size.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:51:59.706 --> 00:52:01.246 A:middle
-Understand the problem size.
 
 00:52:01.846 --> 00:52:04.436 A:middle
 For small problem sets,
@@ -3922,10 +3734,6 @@ contact Paul or George.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:52:58.146 --> 00:53:00.736 A:middle
-in touch with us,
-contact Paul or George.
 
 00:53:01.116 --> 00:53:04.446 A:middle
 There's some documentation

--- a/2013/714.srt
+++ b/2013/714.srt
@@ -61,10 +61,6 @@ through an example on how
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:00:57.166 --> 00:01:00.056 A:middle
-in the room, walk
-through an example on how
-
 00:01:00.056 --> 00:01:02.026 A:middle
 to take advantage
 of data isolation.
@@ -131,9 +127,6 @@ We talked about the UDID,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:01:58.746 --> 00:02:00.186 A:middle
-We talked about the UDID,
 
 00:02:00.186 --> 00:02:03.436 A:middle
 and then we introduced
@@ -207,10 +200,6 @@ Vendor Identifier
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:02:59.496 --> 00:03:01.756 A:middle
-The second is the
-Vendor Identifier
 
 00:03:01.846 --> 00:03:04.116 A:middle
 and it scoped per developer.
@@ -346,10 +335,6 @@ you test, you can find out
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:04:57.496 --> 00:05:01.076 A:middle
-If you required changes, once
-you test, you can find out
-
 00:05:01.196 --> 00:05:05.036 A:middle
 and then update your app
 before iOS 7 hits wide release.
@@ -418,10 +403,6 @@ team ID is on iTunes Connect.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:05:59.946 --> 00:06:03.756 A:middle
-and you can find what your
-team ID is on iTunes Connect.
-
 00:06:04.416 --> 00:06:08.086 A:middle
 This mapping is stored
 and managed by iOS.
@@ -486,10 +467,6 @@ have two apps, app one
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:06:59.896 --> 00:07:02.126 A:middle
-So, in this case we
-have two apps, app one
 
 00:07:02.126 --> 00:07:03.636 A:middle
 and app two for developer foo.
@@ -556,9 +533,6 @@ you must check the value
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:07:58.096 --> 00:08:00.166 A:middle
-you must check the value
 
 00:08:01.226 --> 00:08:04.446 A:middle
 of limit ad tracking
@@ -631,10 +605,6 @@ what are the differences
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:08:58.986 --> 00:09:00.836 A:middle
-If you're trying to understand
-what are the differences
-
 00:09:00.836 --> 00:09:04.236 A:middle
 between the identifiers, maybe
 compare scope or lifetime.
@@ -698,10 +668,6 @@ now scoped per application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:09:56.556 --> 00:10:01.196 A:middle
-In iOS 7, push tokens are
-now scoped per application.
 
 00:10:01.716 --> 00:10:06.306 A:middle
 The Push token was never
@@ -775,10 +741,6 @@ data isolation.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:10:59.496 --> 00:11:01.346 A:middle
-to talk more about
-data isolation.
-
 00:11:01.776 --> 00:11:02.596 A:middle
 David? [Applause]
 
@@ -836,10 +798,6 @@ we see that Camera would
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:11:57.156 --> 00:12:00.646 A:middle
-In this particular example,
-we see that Camera would
 
 00:12:00.646 --> 00:12:02.056 A:middle
 like to access your location
@@ -920,9 +878,6 @@ on behalf of the user.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:12:59.436 --> 00:13:00.636 A:middle
-on behalf of the user.
-
 00:13:02.416 --> 00:13:05.246 A:middle
 While this intervention
 happens completely outside
@@ -992,10 +947,6 @@ Calendars and Reminders.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:13:59.536 --> 00:14:03.116 A:middle
-and in Mavericks we're adding
-Calendars and Reminders.
-
 00:14:03.796 --> 00:14:09.856 A:middle
 On the social side of things
 for OS X, we're adding support
@@ -1048,9 +999,6 @@ that's great, congratulations.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:14:58.946 --> 00:15:01.196 A:middle
-that's great, congratulations.
 
 00:15:01.886 --> 00:15:04.686 A:middle
 You're already taking
@@ -1122,9 +1070,6 @@ that have been provided to you.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:15:59.676 --> 00:16:01.286 A:middle
-that have been provided to you.
 
 00:16:02.046 --> 00:16:05.906 A:middle
 Now, as I said before you should
@@ -1204,10 +1149,6 @@ or an empty object.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:16:59.726 --> 00:17:03.036 A:middle
-to get a nil value back
-or an empty object.
-
 00:17:05.076 --> 00:17:08.756 A:middle
 And for applications that
 access systems services
@@ -1268,10 +1209,6 @@ is initially outside the Sandbox
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:17:55.126 --> 00:18:00.006 A:middle
-For example, if the address book
-is initially outside the Sandbox
 
 00:18:00.046 --> 00:18:04.276 A:middle
 for your process then you
@@ -1349,10 +1286,6 @@ data or accessing data
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:18:57.466 --> 00:19:00.196 A:middle
-You shouldn't be collecting
-data or accessing data
-
 00:19:00.196 --> 00:19:02.886 A:middle
 that you don't truly need.
 
@@ -1419,10 +1352,6 @@ on iOS from OS X.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:19:56.326 --> 00:20:00.716 A:middle
-and a few differences
-on iOS from OS X.
-
 00:20:01.086 --> 00:20:05.306 A:middle
 On iOS, applications are built
 on top of the App Sandbox.
@@ -1486,10 +1415,6 @@ change appropriately.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:20:57.796 --> 00:21:00.876 A:middle
-and you can handle the
-change appropriately.
 
 00:21:01.346 --> 00:21:03.546 A:middle
 And honestly, this
@@ -1555,10 +1480,6 @@ the difference
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:21:58.046 --> 00:22:00.346 A:middle
-because they represent
-the difference
 
 00:22:00.436 --> 00:22:02.856 A:middle
 between iOS 6 and iOS 7.
@@ -1627,9 +1548,6 @@ or essentially silence.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:22:58.106 --> 00:23:02.196 A:middle
-or essentially silence.
 
 00:23:02.706 --> 00:23:06.486 A:middle
 Another way to trigger the
@@ -1707,10 +1625,6 @@ all of the different routes
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:23:59.056 --> 00:24:03.836 A:middle
-with external hardware, then
-all of the different routes
-
 00:24:03.836 --> 00:24:06.956 A:middle
 that you can interface with
 such as the headphones,
@@ -1775,10 +1689,6 @@ before you request access.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:24:59.136 --> 00:25:02.606 A:middle
-and display UI to the user
-before you request access.
-
 00:25:06.536 --> 00:25:07.976 A:middle
 So how do we test all this?
 
@@ -1842,10 +1752,6 @@ System Preferences,
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:25:56.746 --> 00:26:01.386 A:middle
-Privacy on iOS and
-System Preferences,
 
 00:26:01.386 --> 00:26:02.556 A:middle
 Security and Privacy.
@@ -1998,9 +1904,6 @@ and whatever you'd like to test.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:27:55.936 --> 00:28:01.816 A:middle
-and whatever you'd like to test.
-
 00:28:01.856 --> 00:28:05.166 A:middle
 So now that we've talked about
 what data isolation, what it is?
@@ -2070,10 +1973,6 @@ the application.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:28:58.786 --> 00:29:00.336 A:middle
-when you start up
-the application.
 
 00:29:01.106 --> 00:29:05.316 A:middle
 So consider your user interface
@@ -2208,10 +2107,6 @@ string in localizable.strings.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:30:58.306 --> 00:31:01.466 A:middle
-by simply putting the purpose
-string in localizable.strings.
-
 00:31:02.666 --> 00:31:05.146 A:middle
 And to add this purpose
 strings, it couldn't be easier.
@@ -2294,10 +2189,6 @@ attention to that.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:31:59.516 --> 00:32:00.996 A:middle
-So, make sure you pay
-attention to that.
-
 00:32:01.926 --> 00:32:04.856 A:middle
 You can always find this
 information again in the slides
@@ -2361,9 +2252,6 @@ Start today.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:32:59.886 --> 00:33:01.516 A:middle
-Start today.
 
 00:33:01.966 --> 00:33:06.236 A:middle
 After this talk, spend one
@@ -2440,10 +2328,6 @@ understand all the implications
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:33:55.996 --> 00:34:00.476 A:middle
-And then lastly, make sure you
-understand all the implications
 
 00:34:00.476 --> 00:34:03.216 A:middle
 of data isolation
@@ -2525,10 +2409,6 @@ examine what the data is.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:34:59.686 --> 00:35:02.256 A:middle
-Allow them a way to
-examine what the data is.
-
 00:35:02.656 --> 00:35:07.206 A:middle
 Your privacy policy is another
 great way to be transparent
@@ -2593,10 +2473,6 @@ quickly highlight.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:35:58.916 --> 00:36:00.296 A:middle
-that I just want to
-quickly highlight.
 
 00:36:00.926 --> 00:36:05.036 A:middle
 When you're asking for
@@ -2671,10 +2547,6 @@ collection is bad.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:36:58.786 --> 00:37:00.556 A:middle
-that I think all data
-collection is bad.
-
 00:37:02.296 --> 00:37:06.476 A:middle
 But you should weigh the
 positives and the risks
@@ -2745,10 +2617,6 @@ something is happening
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:37:59.046 --> 00:38:00.516 A:middle
-And we know that
-something is happening
 
 00:38:00.516 --> 00:38:02.976 A:middle
 for Project Zanzibar probably
@@ -2880,10 +2748,6 @@ same amount of data,
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:39:59.296 --> 00:40:00.776 A:middle
-You still have the
-same amount of data,
-
 00:40:01.216 --> 00:40:02.696 A:middle
 you'll still have
 your distribution
@@ -2942,9 +2806,6 @@ and bucket at the size.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:40:59.766 --> 00:41:03.446 A:middle
-and bucket at the size.
 
 00:41:03.446 --> 00:41:05.196 A:middle
 But you can do this
@@ -3027,10 +2888,6 @@ mean on the day seven
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:41:59.976 --> 00:42:02.966 A:middle
-on day one does not
-mean on the day seven
-
 00:42:02.966 --> 00:42:04.366 A:middle
 that you have the same need.
 
@@ -3102,10 +2959,6 @@ six different techniques
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:42:52.243 --> 00:43:01.196 A:middle
-Now, I've walk through
-six different techniques
 
 00:43:01.196 --> 00:43:04.886 A:middle
 that you can apply and you can
@@ -3183,10 +3036,6 @@ libraries are in his phone.
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:43:59.596 --> 00:44:03.706 A:middle
-Things like timestamps or what
-libraries are in his phone.
-
 00:44:03.706 --> 00:44:07.596 A:middle
 But the key thing here is,
 
@@ -3248,9 +3097,6 @@ across devices.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:44:59.556 --> 00:45:00.376 A:middle
-across devices.
 
 00:45:00.746 --> 00:45:03.676 A:middle
 Do you really need to?
@@ -3330,10 +3176,6 @@ or grandparent test."
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
-00:45:58.586 --> 00:46:01.966 A:middle
-I call it "the parent
-or grandparent test."
-
 00:46:01.966 --> 00:46:06.326 A:middle
 If I explain in clear language
 to my grandmother, what's going
@@ -3405,10 +3247,6 @@ sample code, go check it out.
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:46:56.466 --> 00:47:01.796 A:middle
-Also, David created some great
-sample code, go check it out.
 
 00:47:02.036 --> 00:47:04.206 A:middle
 Use it. Learn from it.
@@ -3484,10 +3322,6 @@ your relationship
 
 WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
-
-00:47:59.816 --> 00:48:03.116 A:middle
-And lastly, maintain
-your relationship
 
 00:48:03.116 --> 00:48:06.606 A:middle
 and strengthen your relationship


### PR DESCRIPTION
For some reason the srt files have duplicate lines that seem to only appear after the WEBVTT marker lines:

WEBVTT
X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000

The duplication also shows up on asciiwwdc.com (though in one case I didn't see it even though it was in the srt file, not sure why).

Cleanup script for reference:
https://gist.github.com/jawwad/244731e6cf0e831ffa77
