### PR TITLE
Replace `[inaudible]` with the words spoken: `the top-level`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -203,7 +203,7 @@ that's the equivalent
 of SKScene.
 
 00:02:51.756 --> 00:02:54.506 A:middle
-So that's [inaudible] object,
+So that's the top-level object,
 and the scene has a root node
 
 00:02:54.726 --> 00:02:58.866 A:middle


### PR DESCRIPTION
Due to the presenter's heavy French accent, this utterance was plainly difficult to understand for American-English speakers.  However, I have some background with speaking French, and was able to discern what the presenter said, which makes perfect sense in the context of the presentation.