### PR TITLE
 Fixed `[inaudible]` & surrounding words to read `or equal in every directions with the ambient light`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -319,11 +319,11 @@ We support 4 types of lights:
 to illuminate from a point,
 
 00:04:11.356 --> 00:04:14.536 A:middle
-in a direction, as a spot
-[inaudible] directions,
+in a direction, as a spot,
+or equal in every directions
 
 00:04:15.146 --> 00:04:16.805 A:middle
-and with the ambient light.
+with the ambient light.
 
 00:04:17.476 --> 00:04:20.286 A:middle
 Then, next attribute, SCNCamera.


### PR DESCRIPTION
As before, the speaker's French accent makes this hard to understand, as well as the speaker speaking a word here & there incorrectly.

* The `[inaudible]` was spoken as `, or equal in every`.
* The following `directions` left as-is, since that's how it was spoken, despite being an incorrect pluralization.
* The word `and` removed from `and with the ambient light`— this was a transcription error because of a breath taken between `directions` & `with`.