### PR TITLE
Removed unnecessary `[phonetic]` from `convex hull [phonetic]`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -1575,7 +1575,7 @@ build a shape for these teapots
 
 00:20:30.286 --> 00:20:31.966 A:middle
 by building the convex
-hull [phonetic] for you.
+hull for you.
 
 00:20:33.096 --> 00:20:37.146 A:middle
 That said, you can still


### PR DESCRIPTION
The words “convex hull” are accurate to what was spoken, and correlates to SceneKit's `SCNPhysicsShape` using `options:` of `@{ SCNPhysicsShapeTypeKey: SCNPhysicsShapeTypeConvexHull }` (implicitly, in the presenter's example).