### PR TITLE
Fix: Replaced `[inaudible]` with `instances`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -2400,7 +2400,7 @@ on a separate object.
 
 00:31:02.456 --> 00:31:04.256 A:middle
 All these properties
-uses [inaudible]
+uses instance
 
 00:31:04.396 --> 00:31:07.186 A:middle
 of SCNMaterialsProperty class.

--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -2400,7 +2400,7 @@ on a separate object.
 
 00:31:02.456 --> 00:31:04.256 A:middle
 All these properties
-uses instance
+uses instances
 
 00:31:04.396 --> 00:31:07.186 A:middle
 of SCNMaterialsProperty class.


### PR DESCRIPTION
He said “instances of”, plural.  That makes contextual sense— `SCNMaterial` takes individual `SCNMaterialProperty` instances for each visual property type (diffuse, ambient, specular, etc.)