### PR TITLE
Fix: Typo of `SCNMaterialsProperty` when the class name is `SCNMaterialProperty`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -2403,7 +2403,7 @@ All these properties
 uses [inaudible]
 
 00:31:04.396 --> 00:31:07.186 A:middle
-of SCNMaterialsProperty class.
+of SCNMaterialProperty class.
 
 00:31:08.236 --> 00:31:12.816 A:middle
 Let's see how we can


### PR DESCRIPTION
Obvious transcription typo.  It's much better (more searchable) for this to match the API class name.