### PR TITLE
Fix: Replaced `[inaudible]`→`tessellation`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -2571,7 +2571,7 @@ and new this year but
 only on OS X, geometry
 
 00:33:53.316 --> 00:33:56.736 A:middle
-and [inaudible] shaders
+and tessellation shaders
 are supported too.
 
 00:33:57.066 --> 00:33:59.826 A:middle


### PR DESCRIPTION
Corresponds to OS X SceneKit's `SCNProgram`'s tessellation shader support, evident from the `tessellationControlShader` & `tessellationEvaluationShader` properties.