### PR TITLE
Fix?: Replaced `[inaudible]`→`triangle counts`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -2790,7 +2790,7 @@ with nodes of any shapes.
 
 00:37:01.076 --> 00:37:03.356 A:middle
 Just beware of your
-[inaudible], though.
+triangle counts, though.
 
 00:37:07.206 --> 00:37:11.446 A:middle
 Particles can be


### PR DESCRIPTION
I'm about 90% sure of this one.  The accent is heavy and these aren't specific tech terms, so there's not a ton of contextual info to go off of.

Up to whether you want to take this one or leave it as-is.