### PR TITLE
Fix transcription typo: `This shape I represented`→`These shapes are represented`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -2838,7 +2838,7 @@ or from the surface
 of any shape.
 
 00:37:59.246 --> 00:38:01.976 A:middle
-This shape I represented
+These shapes are represented
 using standard geometries.
 
 
@@ -2846,7 +2846,7 @@ WEBVTT
 X-TIMESTAMP-MAP=MPEGTS:181083,LOCAL:00:00:00.000
 
 00:37:59.246 --> 00:38:01.976 A:middle
-This shape I represented
+These shapes are represented
 using standard geometries.
 
 00:38:02.896 --> 00:38:04.766 A:middle


### PR DESCRIPTION
It's subtle, but it sounds plural to me—  Contextually, could go either way.  Grammatically, the `I` sounds a lot more like “are” than “is”.