### PR TITLE
Fix: `altering tool`→`authoring tool`

### DIFF
--- a/2014/609.vtt
+++ b/2014/609.vtt
@@ -2918,7 +2918,7 @@ The first way is to
 directly bake your shadow map
 
 00:39:03.436 --> 00:39:05.016 A:middle
-into your altering tool.
+into your authoring tool.
 
 00:39:05.866 --> 00:39:08.866 A:middle
 Then, you will use them


### PR DESCRIPTION
I'm about 70% sure of this one.  It sounds like “altering” but because of the French accent it could've been “authoring”.  So I believe the speaker meant “in your authoring tool”, but instead said “into your authoring tool”.