### PR TITLE
Fixes for transcription typos in `2016/410.vtt`

### DIFF
--- a/2016/410.vtt
+++ b/2016/410.vtt
@@ -144,7 +144,7 @@ and static analysis
 issues are well-supported
 
 00:02:15.606 --> 00:02:18.086 A:middle
-by Xcode's user interface
+by Xcode's user interface,
 similarly
 
 00:02:18.246 --> 00:02:20.286 A:middle
@@ -1169,7 +1169,7 @@ If we select previousPartView
 -- we'll start with that one --
 
 00:13:50.596 --> 00:13:53.356 A:middle
-I'll use Command-A to
+I'll use Command-E to
 select it for search
 
 00:13:53.646 --> 00:13:55.286 A:middle
@@ -1224,7 +1224,7 @@ view available,
 
 00:14:21.206 --> 00:14:23.676 A:middle
 which will be assigned
-to above you.
+to aboveView.
 
 00:14:23.676 --> 00:14:27.036 A:middle
 And we'll set up the constraint
@@ -1340,7 +1340,7 @@ Xcode's view debugger
 supports debugging UIs
 
 00:15:43.146 --> 00:15:45.486 A:middle
-on Mac OS, iOS, and tvOS.
+on macOS, iOS, and tvOS.
 
 00:15:46.186 --> 00:15:47.816 A:middle
 Give it a try with your
@@ -1439,7 +1439,7 @@ of GameplayKit last year.
 
 00:16:46.246 --> 00:16:49.066 A:middle
 And it's available on
-Mac OS, iOS, and tvOS.
+macOS, iOS, and tvOS.
 
 00:16:50.376 --> 00:16:53.276 A:middle
 State machines allow you to more
@@ -3058,7 +3058,7 @@ But it's still a very
 powerful technique
 
 00:35:00.996 --> 00:35:03.506 A:middle
-for an app analyzing
+for analyzing
 after the fact.
 
 00:35:04.736 --> 00:35:06.466 A:middle
@@ -3159,7 +3159,7 @@ diagnostic in this scheme.
 
 00:36:17.406 --> 00:36:20.456 A:middle
 And this will mean that
-when allocation are free,
+on allocation or free,
 
 00:36:20.816 --> 00:36:23.716 A:middle
 it will write over the


### PR DESCRIPTION
* Added a comma where a verbal pause happened and where the text is confusing without it.
* Changed an instance of _“Command-A”_ to _“Command-E”_ to reflect what the presenter actually did.  I think what was spoken sounded like _“Command-A”_ but that may have been because of the presenter's accent.
* Changed an instance of _“above you”_ to the variable name being talked about, _`aboveView`_.
* Changed a couple of instances of _“Mac OS”_ to _“macOS”_ to reflect Apple's branding change.  Also, both of these were visible on the current slide as _“macOS”_.
* Removed a stutter incorrectly transcribed as _“an app”_.
* Changed _“when allocation are free”_ to what was spoken: _“on allocation or free”_.