### PR TITLE
Mute text → mutex

### DIFF
--- a/2016/406.vtt
+++ b/2016/406.vtt
@@ -3341,12 +3341,12 @@ threads in your initializers,
 basically for the same reason.
 
 00:37:18.506 --> 00:37:20.006 A:middle
-You can set up a mute
-text if you have to
+You can set up a mutex
+if you have to
 
 00:37:20.006 --> 00:37:22.696 A:middle
-and mute text even have like,
-preferred mute texts even have,
+and mutex even have like,
+preferred mutexes even have,
 
 00:37:23.116 --> 00:37:25.056 A:middle
 predefined static values


### PR DESCRIPTION
A small typo in the 2016 406 transcript.