### PR TITLE
Fix typo (plist/stringsdict)

### DIFF
--- a/2013/219.vtt
+++ b/2013/219.vtt
@@ -1387,8 +1387,8 @@ There is a new feature
 in OS X Mavericks
 
 00:16:37.396 --> 00:16:41.846 A:middle
-and iOS 7 called strings
-dict, which a localized P list
+and iOS 7 called stringsdict,
+which a localized plist
 
 00:16:41.846 --> 00:16:44.406 A:middle
 that essentially
@@ -1402,7 +1402,7 @@ You as a developer do not
 need to call any new API's,
 
 00:16:49.256 --> 00:16:51.476 A:middle
-since strings dict will
+since stringsdict will
 be called automatically,
 
 00:16:51.476 --> 00:16:54.406 A:middle
@@ -1410,7 +1410,7 @@ if it's available, and your
 localizers then just have
 
 00:16:54.406 --> 00:16:55.396 A:middle
-to fill out this P list,
+to fill out this plist,
 
 00:16:55.396 --> 00:16:57.506 A:middle
 and will handle all
@@ -1441,7 +1441,7 @@ was held two days ago.
 
 00:17:12.516 --> 00:17:14.906 A:middle
 So, here's an example
-of strings dict
+of stringsdict
 
 00:17:14.906 --> 00:17:16.665 A:middle
 on two separate localizations;
@@ -2108,7 +2108,7 @@ and then in German L.proj, we
 have just the strings file,
 
 00:25:57.846 --> 00:26:00.926 A:middle
-the strings dict, and that
+the stringsdict, and that
 credits file that X code wants
 
 WEBVTT


### PR DESCRIPTION
- `P list` ➡️ `plist`
- `strings dict` ➡️ `stringsdict`